### PR TITLE
Rekonstrukce research foundation (Phase 2.7): ResearchExperimentRunner, ParameterSpace, Walk‑forward a FIFO ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,14 @@ pro audit.
 
 Vývojová skupina obsahuje `httpx2`, který Starlette 1.6 používá pro `TestClient`; nejde o import
 aplikace ani o náhradu HTTP klienta. Synchronizace vyžaduje dostupný Python package index.
+
+## Phase 2.7: kompletní research use-case
+
+`ResearchExperimentRunner` je jediný aplikační tok od validace a dataset hash přes obecný
+`StrategyFactory`, neměnný `ParameterSpace`, train sweep, validation výběr a právě jednu OOS
+evaluaci až po agregované OOS metriky, OOS benchmark, robustness, eligibility, SQLite snapshot
+a report. Raw invalidní kombinace se neztrácejí. OOS foldy se nesmějí překrývat.
+
+Research trade metriky a Monte Carlo používají autoritativní FIFO closed-trade ledger. Cost
+stress znovu přehrává každý vybraný OOS fold s jeho zamčenou konfigurací; nejde o aritmetický
+odhad nákladů.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -38,3 +38,7 @@ select = ["E", "F", "I", "B", "UP"]
 python_version = "3.12"
 strict = true
 packages = ["quantlab"]
+
+[[tool.mypy.overrides]]
+module = ["pyarrow", "pyarrow.*"]
+ignore_missing_imports = true

--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -39,6 +39,7 @@ def create_research_experiment() -> dict[str, object]:
 
 
 @app.get("/api/research/experiments")
+@app.get("/research/experiments")
 def research_experiments() -> list[dict[str, object]]:
     return research_service.list()
 

--- a/backend/src/quantlab/metrics.py
+++ b/backend/src/quantlab/metrics.py
@@ -7,6 +7,22 @@ from quantlab.domain import Bar, Fill, Side
 
 
 @dataclass(frozen=True)
+class ClosedTrade:
+    symbol: str
+    quantity: Decimal
+    opened_at: datetime
+    closed_at: datetime
+    entry_price: Decimal
+    exit_price: Decimal
+    net_pnl: Decimal
+
+    @property
+    def net_return(self) -> float:
+        basis = self.entry_price * self.quantity
+        return float(self.net_pnl / basis) if basis else 0.0
+
+
+@dataclass(frozen=True)
 class PerformanceMetrics:
     total_return: float
     cagr: float | None
@@ -29,18 +45,43 @@ class PerformanceMetrics:
     total_slippage_cost: float
 
 
-def _trade_pnls(fills: list[Fill]) -> tuple[list[float], list[float]]:
-    entries: dict[str, tuple[Decimal, datetime]] = {}
-    pnls: list[float] = []
-    holding: list[float] = []
+def fifo_closed_trades(fills: list[Fill]) -> list[ClosedTrade]:
+    """Autoritativní FIFO ledger uzavřených částí lotů včetně alokovaných komisí."""
+    entries: dict[str, list[tuple[Decimal, Decimal, datetime, Decimal]]] = {}
+    trades: list[ClosedTrade] = []
     for fill in fills:
         if fill.side is Side.BUY:
-            entries[fill.symbol] = (fill.price, fill.timestamp)
-        elif fill.symbol in entries:
-            price, entered = entries.pop(fill.symbol)
-            pnls.append(float((fill.price - price) * fill.quantity - fill.commission))
-            holding.append((fill.timestamp - entered).total_seconds() / 86400)
-    return pnls, holding
+            entries.setdefault(fill.symbol, []).append(
+                (fill.quantity, fill.price, fill.timestamp, fill.commission)
+            )
+            continue
+        remaining = fill.quantity
+        lots = entries.get(fill.symbol, [])
+        if remaining > sum((lot[0] for lot in lots), Decimal("0")):
+            raise ValueError("FIFO ledger zjistil prodej bez dostatečného otevřeného lotu")
+        while remaining:
+            quantity, price, opened_at, entry_commission = lots[0]
+            allocated = min(remaining, quantity)
+            entry_fee = entry_commission * allocated / quantity
+            exit_fee = fill.commission * allocated / fill.quantity
+            trades.append(
+                ClosedTrade(
+                    fill.symbol,
+                    allocated,
+                    opened_at,
+                    fill.timestamp,
+                    price,
+                    fill.price,
+                    allocated * (fill.price - price) - entry_fee - exit_fee,
+                )
+            )
+            remaining -= allocated
+            quantity -= allocated
+            if quantity:
+                lots[0] = (quantity, price, opened_at, entry_commission - entry_fee)
+            else:
+                lots.pop(0)
+    return trades
 
 
 def calculate_metrics(
@@ -94,7 +135,11 @@ def calculate_metrics(
     for fill in fills:
         position += fill.quantity if fill.side is Side.BUY else -fill.quantity
         exposed += int(position != 0)
-    pnls, holding = _trade_pnls(fills)
+    closed_trades = fifo_closed_trades(fills)
+    pnls = [float(trade.net_pnl) for trade in closed_trades]
+    holding = [
+        (trade.closed_at - trade.opened_at).total_seconds() / 86400 for trade in closed_trades
+    ]
     wins = [pnl for pnl in pnls if pnl > 0]
     losses = [pnl for pnl in pnls if pnl < 0]
     gross_profit, gross_loss = sum(wins), -sum(losses)

--- a/backend/src/quantlab/research_engine.py
+++ b/backend/src/quantlab/research_engine.py
@@ -1,0 +1,618 @@
+import hashlib
+import itertools
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+
+from quantlab.backtest import BacktestResult, run_backtest
+from quantlab.data import dataset_identity, validate_bars
+from quantlab.domain import Bar, Fill
+from quantlab.metrics import (
+    PerformanceMetrics,
+    benchmark_metrics,
+    calculate_metrics,
+    fifo_closed_trades,
+)
+from quantlab.research import (
+    DEFAULT_COST_SCENARIOS,
+    AnalysisResult,
+    CostScenario,
+    EligibilityConfig,
+    ObjectiveConfig,
+    ParameterStability,
+    StrategyEligibilityResult,
+    WalkForwardConfig,
+    evaluate_eligibility,
+    guarded_monte_carlo,
+    objective_score,
+    parameter_stability,
+    run_cost_stress_backtests,
+)
+from quantlab.strategy import StrategyFactory
+from quantlab.trading import (
+    CostModel,
+    ExecutionEngine,
+    FixedBpsSlippage,
+    PaperBroker,
+    Portfolio,
+    PortfolioConstructor,
+    RiskConfig,
+    RiskEngine,
+)
+
+type ParameterValue = int | float | str | bool
+type ParameterConfig = Mapping[str, ParameterValue]
+
+
+def _canonical(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _identity(value: object) -> str:
+    return hashlib.sha256(_canonical(value).encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class ParameterCombination:
+    config: tuple[tuple[str, ParameterValue], ...]
+    valid: bool
+    reason: str | None
+
+    @property
+    def as_dict(self) -> dict[str, ParameterValue]:
+        return dict(self.config)
+
+    @property
+    def config_id(self) -> str:
+        return _identity(self.as_dict)
+
+
+class ParameterSpace:
+    """Neměnný, kanonicky seřazený prostor; neplatné kombinace zůstávají auditovatelné."""
+
+    def __init__(
+        self,
+        dimensions: Mapping[str, Sequence[ParameterValue]],
+        validator: Callable[[ParameterConfig], bool | tuple[bool, str | None]],
+    ) -> None:
+        if not dimensions or any(not values for values in dimensions.values()):
+            raise ValueError("Parameter space musí mít neprázdné dimenze")
+        names = sorted(dimensions)
+        combinations: list[ParameterCombination] = []
+        for values in itertools.product(*(dimensions[name] for name in names)):
+            config = dict(zip(names, values, strict=True))
+            try:
+                verdict = validator(config)
+                valid, reason = verdict if isinstance(verdict, tuple) else (verdict, None)
+                reason = reason if valid or reason else "validator_rejected"
+            except (KeyError, TypeError, ValueError) as exc:
+                valid, reason = False, f"{type(exc).__name__}: {exc}"
+            combinations.append(
+                ParameterCombination(tuple(sorted(config.items())), bool(valid), reason)
+            )
+        self._combinations = tuple(combinations)
+
+    @property
+    def combinations(self) -> tuple[ParameterCombination, ...]:
+        return self._combinations
+
+    @property
+    def raw_count(self) -> int:
+        return len(self._combinations)
+
+    @property
+    def valid_count(self) -> int:
+        return sum(item.valid for item in self._combinations)
+
+    @property
+    def invalid_count(self) -> int:
+        return self.raw_count - self.valid_count
+
+    @property
+    def parameter_space_id(self) -> str:
+        return _identity(self.to_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        return {"combinations": [asdict(item) for item in self._combinations]}
+
+
+class ParameterRunStatus(StrEnum):
+    COMPLETED = "COMPLETED"
+    INVALID_CONFIG = "INVALID_CONFIG"
+    BACKTEST_FAILED = "BACKTEST_FAILED"
+    INSUFFICIENT_TRADES = "INSUFFICIENT_TRADES"
+
+
+@dataclass(frozen=True)
+class ParameterRun:
+    run_id: str
+    strategy_name: str
+    strategy_version: str
+    parameter_config: tuple[tuple[str, ParameterValue], ...]
+    dataset_slice_id: str
+    start: datetime
+    end: datetime
+    status: ParameterRunStatus
+    metrics: PerformanceMetrics | None
+    objective_score: float | None
+    failure_reason: str | None
+    closed_trades: int
+    backtest: BacktestResult | None
+
+
+class FoldStatus(StrEnum):
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class WalkForwardFoldResult:
+    fold_id: str
+    train_start: datetime
+    train_end: datetime
+    validation_start: datetime
+    validation_end: datetime
+    oos_start: datetime
+    oos_end: datetime
+    train_runs: tuple[ParameterRun, ...]
+    validation_runs: tuple[ParameterRun, ...]
+    selected_config: tuple[tuple[str, ParameterValue], ...] | None
+    selection_score: float | None
+    selection_reason: str
+    oos_backtest: BacktestResult | None
+    oos_metrics: PerformanceMetrics | None
+    oos_equity_id: str | None
+    oos_evaluations: int
+    status: FoldStatus
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ResearchConfig:
+    walk_forward: WalkForwardConfig
+    objective: ObjectiveConfig = ObjectiveConfig()
+    validation_candidate_count: int = 3
+    initial_cash: Decimal = Decimal("100000")
+    costs: CostModel = CostModel()
+    slippage: FixedBpsSlippage = FixedBpsSlippage()
+    cost_scenarios: tuple[CostScenario, ...] = DEFAULT_COST_SCENARIOS
+    monte_carlo_min_trades: int = 20
+    monte_carlo_simulations: int = 1000
+    random_seed: int = 42
+    eligibility: EligibilityConfig = EligibilityConfig()
+    engine_version: str = "2.7.0"
+
+    def __post_init__(self) -> None:
+        if self.validation_candidate_count <= 0 or self.initial_cash <= 0:
+            raise ValueError("Research config obsahuje neplatný limit nebo kapitál")
+
+
+@dataclass(frozen=True)
+class ResearchExperimentResult:
+    experiment_id: str
+    dataset_id: str
+    strategy_name: str
+    strategy_version: str
+    parameter_space_id: str
+    parameter_space_raw_count: int
+    parameter_space_valid_count: int
+    folds: tuple[WalkForwardFoldResult, ...]
+    aggregate_oos_equity_curve: tuple[tuple[datetime, Decimal], ...]
+    aggregate_oos_metrics: PerformanceMetrics
+    aggregate_oos_fills: tuple[Fill, ...]
+    benchmark: Mapping[str, float | None]
+    cost_stress: Mapping[str, float]
+    monte_carlo: AnalysisResult[object]
+    parameter_stability: ParameterStability
+    eligibility: StrategyEligibilityResult
+    report: str
+
+
+class WalkForwardRunner:
+    def _backtest(
+        self,
+        bars: list[Bar],
+        factory: StrategyFactory,
+        config: ParameterConfig,
+        settings: ResearchConfig,
+    ) -> BacktestResult:
+        execution = ExecutionEngine(
+            RiskEngine(
+                RiskConfig(
+                    max_position_weight=Decimal("1"),
+                    max_order_notional=settings.initial_cash * Decimal("2"),
+                    allowed_symbols=frozenset({bars[0].symbol}),
+                )
+            ),
+            PaperBroker(settings.costs, settings.slippage),
+        )
+        return run_backtest(
+            bars,
+            factory.create(config),
+            Portfolio(settings.initial_cash),
+            PortfolioConstructor(),
+            execution,
+        )
+
+    def _run_parameter(
+        self,
+        bars: list[Bar],
+        factory: StrategyFactory,
+        combination: ParameterCombination,
+        settings: ResearchConfig,
+        scope: str,
+    ) -> ParameterRun:
+        slice_id = dataset_identity(bars)
+        run_id = _identity(
+            {
+                "slice": slice_id,
+                "config": combination.as_dict,
+                "scope": scope,
+                "strategy": factory.strategy_name,
+                "version": factory.strategy_version,
+                "objective": asdict(settings.objective),
+                "costs": asdict(settings.costs),
+                "slippage": asdict(settings.slippage),
+            }
+        )
+        if not combination.valid:
+            return ParameterRun(
+                run_id,
+                factory.strategy_name,
+                factory.strategy_version,
+                combination.config,
+                slice_id,
+                bars[0].timestamp,
+                bars[-1].timestamp,
+                ParameterRunStatus.INVALID_CONFIG,
+                None,
+                None,
+                combination.reason,
+                0,
+                None,
+            )
+        try:
+            result = self._backtest(bars, factory, combination.as_dict, settings)
+            values = [
+                (point["timestamp"], point["portfolio_value"]) for point in result.equity_curve
+            ]
+            metrics = calculate_metrics(result.initial_cash, values, result.fills)  # type: ignore[arg-type]
+            score = objective_score(
+                metrics.total_return,
+                metrics.sharpe_ratio,
+                metrics.maximum_drawdown,
+                metrics.number_of_trades,
+                settings.objective,
+            )
+            status = (
+                ParameterRunStatus.COMPLETED
+                if score is not None
+                else ParameterRunStatus.INSUFFICIENT_TRADES
+            )
+            return ParameterRun(
+                run_id,
+                factory.strategy_name,
+                factory.strategy_version,
+                combination.config,
+                slice_id,
+                bars[0].timestamp,
+                bars[-1].timestamp,
+                status,
+                metrics,
+                score,
+                None if score is not None else "insufficient_closed_trades",
+                metrics.number_of_trades,
+                result,
+            )
+        except (KeyError, TypeError, ValueError, ArithmeticError) as exc:
+            return ParameterRun(
+                run_id,
+                factory.strategy_name,
+                factory.strategy_version,
+                combination.config,
+                slice_id,
+                bars[0].timestamp,
+                bars[-1].timestamp,
+                ParameterRunStatus.BACKTEST_FAILED,
+                None,
+                None,
+                f"{type(exc).__name__}: {exc}",
+                0,
+                None,
+            )
+
+    def run(
+        self,
+        bars: list[Bar],
+        factory: StrategyFactory,
+        space: ParameterSpace,
+        settings: ResearchConfig,
+    ) -> tuple[WalkForwardFoldResult, ...]:
+        window = settings.walk_forward
+        size = window.training_window + window.validation_window + window.test_window
+        starts = list(range(0, len(bars) - size + 1, window.step_size))
+        if not starts:
+            raise ValueError("Dataset neobsahuje ani jeden celý walk-forward fold")
+        intervals = [
+            (start + window.training_window + window.validation_window, start + size)
+            for start in starts
+        ]
+        if any(
+            current[0] < previous[1]
+            for previous, current in zip(intervals, intervals[1:], strict=False)
+        ):
+            raise ValueError("OOS intervaly walk-forward se překrývají")
+        folds: list[WalkForwardFoldResult] = []
+        for index, start in enumerate(starts):
+            train_end = start + window.training_window
+            validation_end = train_end + window.validation_window
+            test_end = validation_end + window.test_window
+            train, validation, oos = (
+                bars[start:train_end],
+                bars[train_end:validation_end],
+                bars[validation_end:test_end],
+            )
+            fold_id = _identity(
+                {
+                    "index": index,
+                    "train": dataset_identity(train),
+                    "validation": dataset_identity(validation),
+                    "oos_bounds": [oos[0].timestamp, oos[-1].timestamp],
+                }
+            )
+            train_runs = tuple(
+                self._run_parameter(train, factory, item, settings, "train")
+                for item in space.combinations
+            )
+            ranked = sorted(
+                (run for run in train_runs if run.objective_score is not None),
+                key=lambda run: (-(run.objective_score or 0.0), _canonical(run.parameter_config)),
+            )
+            candidates = ranked[: settings.validation_candidate_count]
+            validation_runs = tuple(
+                self._run_parameter(
+                    validation,
+                    factory,
+                    ParameterCombination(candidate.parameter_config, True, None),
+                    settings,
+                    "validation",
+                )
+                for candidate in candidates
+            )
+            selected = sorted(
+                (run for run in validation_runs if run.objective_score is not None),
+                key=lambda run: (-(run.objective_score or 0.0), _canonical(run.parameter_config)),
+            )
+            if not selected:
+                folds.append(
+                    WalkForwardFoldResult(
+                        fold_id,
+                        train[0].timestamp,
+                        train[-1].timestamp,
+                        validation[0].timestamp,
+                        validation[-1].timestamp,
+                        oos[0].timestamp,
+                        oos[-1].timestamp,
+                        train_runs,
+                        validation_runs,
+                        None,
+                        None,
+                        "no_eligible_validation_candidate",
+                        None,
+                        None,
+                        None,
+                        0,
+                        FoldStatus.FAILED,
+                        "selection_failed",
+                    )
+                )
+                continue
+            winner = selected[0]
+            # Parametry jsou zde zamčené; následuje jediná OOS evaluace.
+            oos_result = self._backtest(oos, factory, dict(winner.parameter_config), settings)
+            values = [
+                (point["timestamp"], point["portfolio_value"]) for point in oos_result.equity_curve
+            ]
+            oos_metrics = calculate_metrics(oos_result.initial_cash, values, oos_result.fills)  # type: ignore[arg-type]
+            equity_id = _identity(values)
+            folds.append(
+                WalkForwardFoldResult(
+                    fold_id,
+                    train[0].timestamp,
+                    train[-1].timestamp,
+                    validation[0].timestamp,
+                    validation[-1].timestamp,
+                    oos[0].timestamp,
+                    oos[-1].timestamp,
+                    train_runs,
+                    validation_runs,
+                    winner.parameter_config,
+                    winner.objective_score,
+                    "best_validation_objective_after_train_top_k",
+                    oos_result,
+                    oos_metrics,
+                    equity_id,
+                    1,
+                    FoldStatus.COMPLETED,
+                )
+            )
+        return tuple(folds)
+
+
+class ResearchExperimentRunner:
+    def __init__(self, walk_forward_runner: WalkForwardRunner | None = None) -> None:
+        self.walk_forward_runner = walk_forward_runner or WalkForwardRunner()
+
+    def run(
+        self,
+        dataset: list[Bar],
+        strategy_factory: StrategyFactory,
+        parameter_space: ParameterSpace,
+        config: ResearchConfig,
+    ) -> ResearchExperimentResult:
+        validate_bars(dataset)
+        dataset_id = dataset_identity(dataset)
+        identity_payload = {
+            "dataset": dataset_id,
+            "strategy": strategy_factory.strategy_name,
+            "version": strategy_factory.strategy_version,
+            "parameter_space": parameter_space.parameter_space_id,
+            "config": asdict(config),
+        }
+        experiment_id = _identity(identity_payload)
+        folds = self.walk_forward_runner.run(dataset, strategy_factory, parameter_space, config)
+        completed = [fold for fold in folds if fold.status is FoldStatus.COMPLETED]
+        if not completed:
+            raise ValueError("Žádný walk-forward fold nebyl dokončen")
+        curve: list[tuple[datetime, Decimal]] = []
+        fills: list[Fill] = []
+        capital = config.initial_cash
+        for fold in completed:
+            assert fold.oos_backtest is not None
+            for point in fold.oos_backtest.equity_curve:
+                relative = point["portfolio_value"] / fold.oos_backtest.initial_cash  # type: ignore[operator]
+                curve.append((point["timestamp"], capital * relative))  # type: ignore[arg-type]
+            capital = curve[-1][1] if curve else capital
+            fills.extend(fold.oos_backtest.fills)
+        aggregate_metrics = calculate_metrics(config.initial_cash, curve, fills)
+        oos_bars = [
+            bar
+            for fold in completed
+            for bar in dataset
+            if fold.oos_start <= bar.timestamp <= fold.oos_end
+        ]
+        benchmark = benchmark_metrics(oos_bars)
+        stress_values: dict[str, float] = {}
+        for scenario in config.cost_scenarios:
+            stressed_capital = config.initial_cash
+            for fold in completed:
+                selected = dict(fold.selected_config or ())
+                section = [
+                    bar for bar in dataset if fold.oos_start <= bar.timestamp <= fold.oos_end
+                ]
+                result = run_cost_stress_backtests(
+                    section,
+                    strategy_factory.create(selected),
+                    config.initial_cash,
+                    config.costs,
+                    config.slippage,
+                    (scenario,),
+                )[scenario.name]
+                stressed_capital *= result.final_value / result.initial_cash
+            stress_values[scenario.name] = float(stressed_capital / config.initial_cash - 1)
+        closed = fifo_closed_trades(fills)
+        monte_carlo = guarded_monte_carlo(
+            [trade.net_return for trade in closed],
+            float(config.initial_cash),
+            config.monte_carlo_min_trades,
+            config.monte_carlo_simulations,
+            config.random_seed,
+        )
+        # Stabilita je lokální k jednomu validation slice; runy různých dataset slices nemícháme.
+        selected_runs = [
+            run
+            for run in completed[0].validation_runs
+            if run.metrics is not None and run.objective_score is not None
+        ]
+        chosen = completed[0].selected_config or ()
+        keys = sorted(name for name, value in chosen if isinstance(value, int))
+        stability_input = {
+            tuple(int(dict(run.parameter_config)[key]) for key in keys): (
+                run.objective_score or 0.0
+            )
+            for run in selected_runs
+            if all(key in dict(run.parameter_config) for key in keys)
+        }
+        stability = (
+            parameter_stability(stability_input, tuple(int(dict(chosen)[key]) for key in keys))
+            if keys
+            else ParameterStability(0, None, None, None)
+        )
+        profitable_folds = sum(
+            bool(fold.oos_metrics and fold.oos_metrics.total_return > 0) for fold in completed
+        ) / len(completed)
+        eligibility = evaluate_eligibility(
+            aggregate_metrics.number_of_trades,
+            aggregate_metrics.total_return,
+            aggregate_metrics.maximum_drawdown,
+            stress_values,
+            profitable_folds,
+            stability,
+            config.eligibility,
+        )
+        report_payload = {
+            "experiment": experiment_id,
+            "engine_config": identity_payload["config"],
+            "dataset": {
+                "identity": dataset_id,
+                "source": dataset[0].source,
+                "timeframe": dataset[0].timeframe,
+                "start": dataset[0].timestamp,
+                "end": dataset[-1].timestamp,
+            },
+            "strategy": {
+                "name": strategy_factory.strategy_name,
+                "version": strategy_factory.strategy_version,
+            },
+            "version": strategy_factory.strategy_version,
+            "parameter_space": {
+                "identity": parameter_space.parameter_space_id,
+                "raw": parameter_space.raw_count,
+                "valid": parameter_space.valid_count,
+                "invalid": parameter_space.invalid_count,
+            },
+            "walk_forward": [
+                {
+                    "fold_id": fold.fold_id,
+                    "train_runs": len(fold.train_runs),
+                    "validation_runs": len(fold.validation_runs),
+                    "selected": fold.selected_config,
+                    "oos_metrics": asdict(fold.oos_metrics) if fold.oos_metrics else None,
+                }
+                for fold in folds
+            ],
+            "aggregate_oos": asdict(aggregate_metrics),
+            "metrics": asdict(aggregate_metrics),
+            "selected_parameters": [fold.selected_config for fold in completed],
+            "benchmark": benchmark,
+            "accounting": {
+                "closed_fifo_trades": len(closed),
+                "commissions": aggregate_metrics.total_commissions,
+                "slippage": aggregate_metrics.total_slippage_cost,
+            },
+            "cost_stress": stress_values,
+            "monte_carlo": asdict(monte_carlo),
+            "parameter_stability": asdict(stability),
+            "eligibility": asdict(eligibility),
+            "known_limitations": [
+                "single-symbol long-only",
+                "empirical bootstrap nezachovává režimy",
+            ],
+        }
+        report = (
+            "# Research report\n\n```json\n"
+            + json.dumps(report_payload, default=str, sort_keys=True, indent=2)
+            + "\n```"
+        )
+        return ResearchExperimentResult(
+            experiment_id,
+            dataset_id,
+            strategy_factory.strategy_name,
+            strategy_factory.strategy_version,
+            parameter_space.parameter_space_id,
+            parameter_space.raw_count,
+            parameter_space.valid_count,
+            folds,
+            tuple(curve),
+            aggregate_metrics,
+            tuple(fills),
+            benchmark,
+            stress_values,
+            monte_carlo,
+            stability,
+            eligibility,
+            report,
+        )

--- a/backend/src/quantlab/research_service.py
+++ b/backend/src/quantlab/research_service.py
@@ -2,94 +2,44 @@ from dataclasses import asdict
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import cast
 
-from quantlab.data import CSVMarketDataProvider, dataset_identity
-from quantlab.demo import run_demo
-from quantlab.metrics import benchmark_metrics, calculate_metrics
+from quantlab.data import CSVMarketDataProvider
 from quantlab.persistence import RunRepository
-from quantlab.research import (
-    AnalysisStatus,
-    EligibilityDecision,
-    ExperimentIdentity,
-    ParameterStability,
-    StrategyEligibilityResult,
-    cost_stress,
-    markdown_report,
-)
+from quantlab.research import EligibilityConfig, ObjectiveConfig, WalkForwardConfig
+from quantlab.research_engine import ParameterSpace, ResearchConfig, ResearchExperimentRunner
+from quantlab.strategy import MovingAverageStrategyFactory
 
 
 class ResearchService:
+    """Aplikační adaptér; veškerou research business logiku deleguje runneru."""
+
     def __init__(self, repository: RunRepository) -> None:
         self.repository = repository
 
     def create_demo_experiment(self, fixture: Path) -> dict[str, object]:
         bars = CSVMarketDataProvider(fixture).load("SPY")
-        backtest = run_demo(fixture)
-        identity = ExperimentIdentity(
-            "moving_average",
-            "1.0.0",
-            {"fast_window": 3, "slow_window": 5},
-            dataset_identity(bars),
-            bars[0].timestamp.isoformat(),
-            bars[-1].timestamp.isoformat(),
-            {"fixed": "1", "rate": "0.001", "minimum": "1"},
-            {"basis_points": "5"},
-            42,
+        space = ParameterSpace(
+            {"fast_window": (2, 3), "slow_window": (3, 5)},
+            lambda item: int(item["fast_window"]) < int(item["slow_window"]),
         )
-        values = [
-            (cast(datetime, item["timestamp"]), cast(Decimal, item["portfolio_value"]))
-            for item in backtest.equity_curve
-        ]
-        metrics = calculate_metrics(backtest.initial_cash, values, backtest.fills)
-        gross_return = metrics.total_return + (
-            metrics.total_commissions + metrics.total_slippage_cost
-        ) / float(backtest.initial_cash)
-        stress = cost_stress(
-            gross_return,
-            metrics.total_commissions,
-            metrics.total_slippage_cost,
-            float(backtest.initial_cash),
+        config = ResearchConfig(
+            WalkForwardConfig(4, 3, 3, 3),
+            ObjectiveConfig(minimum_trades=0),
+            validation_candidate_count=2,
+            initial_cash=Decimal("100000"),
+            monte_carlo_min_trades=20,
+            monte_carlo_simulations=100,
+            eligibility=EligibilityConfig(minimum_trades=20),
         )
-        stability = ParameterStability(0, None, None, None)
-        walk_forward_status: dict[str, object] = {
-            "status": AnalysisStatus.NOT_EVALUATED,
-            "reason": "insufficient_fixture_bars",
-            "folds": [],
-        }
-        result: dict[str, object] = {
-            "metrics": asdict(metrics),
-            "benchmark": benchmark_metrics(bars),
-            "excess_return": metrics.total_return - (benchmark_metrics(bars)["total_return"] or 0),
-            "cost_stress": stress,
-            "walk_forward": walk_forward_status,
-            "monte_carlo": {
-                "status": AnalysisStatus.NOT_EVALUATED,
-                "reason": "insufficient_closed_trades",
-                "result": None,
-            },
-            "parameter_stability": asdict(stability),
-            "eligibility": {"decision": "RESEARCH_ONLY", "reasons": ["insufficient_fixture"]},
-        }
-        result["report"] = markdown_report(
-            identity,
-            asdict(metrics),
-            benchmark_metrics(bars),
-            stress,
-            None,
-            stability,
-            # Demo fixture je záměrně příliš malá pro způsobilost.
-            StrategyEligibilityResult(
-                EligibilityDecision.RESEARCH_ONLY,
-                {},
-                ("insufficient_fixture",),
-            ),
-            walk_forward_status,
-        )
+        result = ResearchExperimentRunner().run(bars, MovingAverageStrategyFactory(), space, config)
+        snapshot = asdict(result)
         self.repository.save_experiment(
-            identity.experiment_id, asdict(identity), result, datetime.now(UTC)
+            result.experiment_id,
+            {"research_config": asdict(config), "parameter_space": space.to_dict()},
+            snapshot,
+            datetime.now(UTC),
         )
-        return {"id": identity.experiment_id, "config": asdict(identity), "result": result}
+        return {"id": result.experiment_id, "config": asdict(config), "result": snapshot}
 
     def get(self, experiment_id: str) -> dict[str, object] | None:
         return self.repository.get_experiment(experiment_id)

--- a/backend/src/quantlab/strategy.py
+++ b/backend/src/quantlab/strategy.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Protocol
@@ -16,6 +17,40 @@ class Strategy(Protocol):
     def required_lookback(self) -> int: ...
 
     def generate_target(self, available_bars: list[Bar]) -> TargetPosition: ...
+
+
+class StrategyFactory(Protocol):
+    @property
+    def strategy_name(self) -> str: ...
+
+    @property
+    def strategy_version(self) -> str: ...
+
+    def create(self, config: Mapping[str, object]) -> Strategy: ...
+
+
+@dataclass(frozen=True)
+class MovingAverageStrategyFactory:
+    strategy_name: str = "moving_average"
+    strategy_version: str = "1.0.0"
+
+    def create(self, config: Mapping[str, object]) -> Strategy:
+        fast, slow = config["fast_window"], config["slow_window"]
+        if not isinstance(fast, int) or not isinstance(slow, int):
+            raise TypeError("MA okna musí být celá čísla")
+        return MovingAverageStrategy(fast, slow)
+
+
+@dataclass(frozen=True)
+class DonchianBreakoutStrategyFactory:
+    strategy_name: str = "donchian_breakout"
+    strategy_version: str = "1.0.0"
+
+    def create(self, config: Mapping[str, object]) -> Strategy:
+        entry, exit_ = config["entry_lookback"], config["exit_lookback"]
+        if not isinstance(entry, int) or not isinstance(exit_, int):
+            raise TypeError("Donchian okna musí být celá čísla")
+        return DonchianBreakoutStrategy(entry, exit_)
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_research.py
+++ b/backend/tests/test_research.py
@@ -419,5 +419,5 @@ def test_research_report_is_complete_and_experiment_is_deterministic() -> None:
     } <= payload.keys()
     assert payload["monte_carlo"]["status"] == "NOT_EVALUATED"
     assert payload["monte_carlo"]["reason"] == "insufficient_closed_trades"
-    assert payload["walk_forward"]["status"] == "NOT_EVALUATED"
-    assert payload["walk_forward"]["reason"] == "insufficient_fixture_bars"
+    assert len(payload["walk_forward"]) == 1
+    assert payload["walk_forward"][0]["validation_runs"] == 2

--- a/backend/tests/test_research_engine.py
+++ b/backend/tests/test_research_engine.py
@@ -1,0 +1,150 @@
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from quantlab.domain import Bar, Fill, Side
+from quantlab.metrics import fifo_closed_trades
+from quantlab.research import ObjectiveConfig, WalkForwardConfig
+from quantlab.research_engine import (
+    ParameterRunStatus,
+    ParameterSpace,
+    ResearchConfig,
+    ResearchExperimentRunner,
+)
+from quantlab.strategy import MovingAverageStrategyFactory
+
+
+def market_bars(count: int = 44) -> list[Bar]:
+    start = datetime(2024, 1, 1, 21, tzinfo=UTC)
+    closes = [Decimal(100 + (index % 7) * 3 - (index % 3) * 2) for index in range(count)]
+    return [
+        Bar(
+            "SPY",
+            start + timedelta(days=index),
+            close,
+            close + 2,
+            close - 2,
+            close,
+            Decimal("10000"),
+            close,
+            "deterministic-test",
+        )
+        for index, close in enumerate(closes)
+    ]
+
+
+def setup() -> tuple[ParameterSpace, ResearchConfig]:
+    space = ParameterSpace(
+        {"slow_window": (4, 5), "fast_window": (2, 4)},
+        lambda config: (
+            int(config["fast_window"]) < int(config["slow_window"]),
+            "fast_must_be_less_than_slow",
+        ),
+    )
+    config = ResearchConfig(
+        WalkForwardConfig(12, 8, 8, 8),
+        ObjectiveConfig(minimum_trades=0),
+        validation_candidate_count=2,
+        monte_carlo_min_trades=2,
+        monte_carlo_simulations=40,
+        random_seed=17,
+    )
+    return space, config
+
+
+def test_parameter_space_is_deterministic_and_preserves_invalid_configs() -> None:
+    first, _ = setup()
+    second, _ = setup()
+    assert first.parameter_space_id == second.parameter_space_id
+    assert first.raw_count == 4 and first.valid_count == 3 and first.invalid_count == 1
+    assert [item.config_id for item in first.combinations] == [
+        item.config_id for item in second.combinations
+    ]
+
+
+def test_walk_forward_search_validation_exactly_once_oos_and_determinism() -> None:
+    space, config = setup()
+    runner = ResearchExperimentRunner()
+    first = runner.run(market_bars(), MovingAverageStrategyFactory(), space, config)
+    second = runner.run(market_bars(), MovingAverageStrategyFactory(), space, config)
+    assert first == second
+    assert len(first.folds) == 3
+    for fold in first.folds:
+        assert len(fold.train_runs) == 4
+        assert sum(run.status is ParameterRunStatus.INVALID_CONFIG for run in fold.train_runs) == 1
+        assert len(fold.validation_runs) == 2
+        assert fold.selected_config is not None
+        assert fold.oos_evaluations == 1
+    timestamps = [timestamp for timestamp, _ in first.aggregate_oos_equity_curve]
+    assert timestamps == sorted(set(timestamps))
+    assert first.parameter_space_id == space.parameter_space_id
+
+
+def test_oos_mutation_cannot_change_selection_or_prior_fold() -> None:
+    space, config = setup()
+    runner = ResearchExperimentRunner()
+    source = market_bars()
+    baseline = runner.run(source, MovingAverageStrategyFactory(), space, config)
+    changed = list(source)
+    # Druhý OOS fold jsou indexy 28..35; změna je za celým prvním foldem.
+    for index in range(28, 36):
+        bar = changed[index]
+        price = bar.close + Decimal("70")
+        changed[index] = replace(
+            bar, open=price, high=price + 2, low=price - 2, close=price, adjusted_close=price
+        )
+    mutated = runner.run(changed, MovingAverageStrategyFactory(), space, config)
+    before, after = baseline.folds[0], mutated.folds[0]
+    assert before.train_runs == after.train_runs
+    assert before.validation_runs == after.validation_runs
+    assert before.selected_config == after.selected_config
+    assert before.oos_backtest == after.oos_backtest
+    assert before.oos_metrics == after.oos_metrics
+    second_before, second_after = baseline.folds[1], mutated.folds[1]
+    assert second_before.train_runs == second_after.train_runs
+    assert second_before.validation_runs == second_after.validation_runs
+    assert second_before.selected_config == second_after.selected_config
+    assert second_before.oos_metrics != second_after.oos_metrics
+
+
+def test_overlapping_oos_fails_fast() -> None:
+    space, config = setup()
+    overlapping = replace(config, walk_forward=WalkForwardConfig(12, 8, 8, 4))
+    with pytest.raises(ValueError, match="překrývají"):
+        ResearchExperimentRunner().run(
+            market_bars(), MovingAverageStrategyFactory(), space, overlapping
+        )
+
+
+def test_fifo_ledger_handles_scale_in_and_partial_scale_out() -> None:
+    start = datetime(2025, 1, 1, tzinfo=UTC)
+    fills = [
+        Fill("b1", "SPY", Side.BUY, Decimal("2"), Decimal("10"), Decimal("2"), start),
+        Fill(
+            "b2",
+            "SPY",
+            Side.BUY,
+            Decimal("2"),
+            Decimal("12"),
+            Decimal("2"),
+            start + timedelta(days=1),
+        ),
+        Fill(
+            "s1",
+            "SPY",
+            Side.SELL,
+            Decimal("3"),
+            Decimal("15"),
+            Decimal("3"),
+            start + timedelta(days=2),
+        ),
+    ]
+    trades = fifo_closed_trades(fills)
+    assert [(trade.quantity, trade.entry_price) for trade in trades] == [
+        (Decimal("2"), Decimal("10")),
+        (Decimal("1"), Decimal("12")),
+    ]
+    # Hrubý P&L 13 minus tři alokované vstupní a tři výstupní poplatky.
+    assert sum((trade.net_pnl for trade in trades), Decimal("0")) == Decimal("7")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,3 +57,12 @@ Adjusted signalová řada se znovu účetně nepřipisuje. Corporate actions mus
 Fixture nedokládá point-in-time universe ani absenci survivorship bias. Kalendář potřebuje pro
 produkční historii úplný seznam mimořádných uzavírek. Bootstrap s malým počtem obchodů je
 nestabilní. SQLite je vývojový adapter a research záznamy jsou jednoduché JSON snapshots.
+
+## Phase 2.7 research orchestrace
+
+Autoritativní tok je `provider → quality validation → dataset identity → StrategyFactory →
+ParameterSpace → train sweep → validation selection → locked config → exactly-once OOS →
+aggregate OOS → FIFO metrics/OOS benchmark → fold-level cost re-backtests → Monte Carlo a
+stabilita → eligibility → immutable persistence snapshot/report`. Business tok vlastní
+`ResearchExperimentRunner`; FastAPI pouze deleguje aplikační službě. Překryv OOS oken selže.
+Train ani validation equity se do agregované research equity nikdy nevkládá.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -7,8 +7,8 @@
 | 2 Market data | probíhá | CSV/Parquet provider, hash, quality events, kalendář | úplný US kalendář a DB quality persistence |
 | 3 Strategy | probíhá | MA, buy-and-hold a Donchian s lookbackem | multi-asset strategie |
 | 4 Backtest | dokončeno pro Phase 2 | next-open, deterministická ID, FIFO lot accounting, scale-in/out, idempotentní corporate actions, účetní invarianty, metriky/benchmark | multi-symbol engine je mimo Phase 2 |
-| 5 Validation | probíhá | leakage, chronologický split, walk-forward hranice | výběr uvnitř foldů a embargo |
-| 6 Research automation | probíhá | grid, identity, path-dependent stress re-backtest, Monte Carlo guardrail, stabilita, eligibility a report se stavem NOT_EVALUATED | obecný konfigurovatelný service use-case nad demo experimentem |
+| 5 Validation | dokončeno pro Phase 2 | chronologické neoverlapující foldy, train sweep, validation selection, zamčený one-shot OOS a mutation izolace | embargo mimo scope |
+| 6 Research automation | dokončeno pro Phase 2 | StrategyFactory, typed ParameterSpace/ParameterRun, ResearchExperimentRunner, OOS agregace, FIFO metriky, skutečný stress, Monte Carlo, stabilita, eligibility, snapshot a report | distribuované běhy patří do Phase 3 |
 | 7 Portfolio & risk | probíhá | long-only konstrukce, allowlist/notional/kill switch | exposure/loss/drawdown limity |
 | 8 Paper broker | probíhá | market fills a účetní aktualizace | limit/cancel/partial fills, P&L |
 | 9 Trading cycle | čeká | audit přes uložený run | idempotence, reconciliation, locks |

--- a/docs/research-methodology.md
+++ b/docs/research-methodology.md
@@ -37,3 +37,14 @@ Monte Carlo se pod konfigurovaným minimem uzavřených FIFO obchodů vrací jak
 Metriky používají 252 období pro anualizaci denních returns a 365,25 dne pro CAGR. Sharpe má
 risk-free předpoklad nula, Sortino downside deviation vůči nule. Nulový jmenovatel, chybějící
 uzavřené obchody nebo nedostatečný vzorek vrací `None`.
+
+## Walk-forward selection v Phase 2.7
+
+V train se auditovatelně vyhodnotí všechny raw kombinace, včetně explicitního `INVALID_CONFIG`.
+Konfigurované top-k se znovu vyhodnotí ve validation. Vítěz validation se zamkne a OOS se spustí
+právě jednou. OOS intervaly se nesmějí překrývat a benchmark používá tutéž množinu OOS barů.
+Cost stress je nový backtest každého OOS foldu s jeho selected configem.
+
+Experiment identity zahrnuje dataset content hash, strategy name/version, celý parameter space,
+walk-forward/objective/top-k konfiguraci, cost a stress modely, seed, Monte Carlo, eligibility
+a engine version. Identické vstupy reprodukují foldy, runy, fills, agregaci i robustness výstupy.


### PR DESCRIPTION
### Motivation
- Repo postrádal skutečný end‑to‑end research orchestrator a typed research model (ResearchExperimentRunner, StrategyFactory, ParameterSpace, ParameterRun, walk‑forward runner), přitom bylo nutné zachovat correctness opravy z Phase 2.6 (FIFO accounting, split/dividend idempotence, cost‑stress princip apod.).
- Cílem změny je znovu vytvořit auditovatelný research tok: chronologické train/validation/OOS, train sweep → validation selection → exactly‑once OOS, fold‑level cost re‑backtests, agregovaná OOS equity a použití autoritativního FIFO closed‑trade ledgeru pro metriky a Monte Carlo.

### Description
- Přidán nový aplikační orchestrátor `ResearchExperimentRunner` a pomocné typy ve `backend/src/quantlab/research_engine.py` včetně `ParameterSpace`, `ParameterCombination`, `ParameterRun`, `WalkForwardRunner`, `WalkForwardFoldResult` a `ResearchExperimentResult`; identita a serializace jsou deterministické (SHA‑256). 
- Implementována obecná `StrategyFactory` abstrakce a konkrétní továrny pro `MovingAverage` a `DonchianBreakout` v `backend/src/quantlab/strategy.py`, aby orchestrace nerůstala přes hardcoded větvení podle jména strategie.
- Metriky sjednoceny na autoritativní FIFO ledger: přidána funkcionalita `fifo_closed_trades` a `ClosedTrade` v `backend/src/quantlab/metrics.py`, která alokuje vstupní a výstupní poplatky poměrným způsobem a poskytuje net returns pro Monte Carlo; původní jednoduché párování bylo nahrazeno tímto ledgerem.
- `ResearchService` přepsán, aby delegoval skutečný runner (vykonávání experimentu, persistování immutable snapshotu výsledku) a API doplněno o canonical `/research/experiments` cestu; dokumentace (`README.md`, `docs/*`) aktualizována.
- Přidány nové typované testy `backend/tests/test_research_engine.py` pokrývající determinismus experimentu, walk‑forward foldy, exactly‑once OOS, OOS‑isolation mutation test a FIFO ledger regression; menší úpravy testů existujících očekávání pro nový report shape.
- Konfigurační a CI‑pomůcky: drobný mypy override pro `pyarrow` (optional dependency) a úpravy formátování/lint pravidel.

### Testing
- `ruff format --check src tests` — passed. 
- `ruff check src tests` — passed. 
- `PYTHONPATH=src mypy src/quantlab` — strict typecheck passed (with targeted `pyarrow` ignore override). 
- `pytest -q tests/test_research.py tests/test_research_engine.py` — all relevant research tests passed: `22 passed, 0 failed, 0 errors`.
- Environment blockers: import/collection of API integration tests using `starlette.testclient` fails without `httpx2` (package not available in this environment), and `uv sync --all-groups` failed to fetch from PyPI; these prevented running the full vertical‑slice HTTP client tests in this environment (collection error for `tests/test_vertical_slice.py`).

Commit: `cf0c6e4759c417f31c7a7d76044fadf1eea89c4a`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a2978fbf0833293009a8b268bf0c6)