### PR TITLE
Phase 2.8: structured experiment persistence and typed eligibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ a report. Raw invalidní kombinace se neztrácejí. OOS foldy se nesmějí přek
 Research trade metriky a Monte Carlo používají autoritativní FIFO closed-trade ledger. Cost
 stress znovu přehrává každý vybraný OOS fold s jeho zamčenou konfigurací; nejde o aritmetický
 odhad nákladů.
+
+## Phase 2.8: closure
+
+**Phase 2 je COMPLETE v definovaném research-foundation scope.** Experiment má vedle úplného
+neměnného reprodukčního snapshotu strukturované, dotazovatelné záznamy identity, OOS foldů a
+jejich train/validation ParameterRunů i typovaných eligibility kontrol. Každá kontrola ukládá
+status, pozorovanou hodnotu, práh a případný důvod; chybějící stabilitní sousedství se netváří jako
+běžné selhání, ale jako `not_evaluated`. Konzistenční test porovnává celý persisted snapshot s JSON
+reprezentací in-memory experimentu a ověřuje idempotenci i transakční rollback celé projekce.

--- a/backend/src/quantlab/persistence.py
+++ b/backend/src/quantlab/persistence.py
@@ -1,9 +1,20 @@
 import builtins
+import hashlib
 import json
 from datetime import UTC, datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, Integer, String, Text, create_engine
+from sqlalchemy import (
+    DateTime,
+    Float,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
 
 
@@ -23,14 +34,72 @@ class ExperimentRecord(Base):
     __tablename__ = "research_experiments"
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    dataset_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    strategy_name: Mapped[str | None] = mapped_column(String(100), index=True)
+    strategy_version: Mapped[str | None] = mapped_column(String(50))
+    parameter_space_id: Mapped[str | None] = mapped_column(String(64))
+    decision: Mapped[str | None] = mapped_column(String(30), index=True)
     config_json: Mapped[str] = mapped_column(Text)
     result_json: Mapped[str] = mapped_column(Text)
+
+
+class ExperimentFoldRecord(Base):
+    __tablename__ = "research_experiment_folds"
+    __table_args__ = (UniqueConstraint("experiment_id", "fold_id"),)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    experiment_id: Mapped[str] = mapped_column(ForeignKey("research_experiments.id"), index=True)
+    fold_id: Mapped[str] = mapped_column(String(64))
+    status: Mapped[str] = mapped_column(String(30))
+    oos_start: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    oos_end: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    oos_evaluations: Mapped[int] = mapped_column(Integer)
+    selected_config_json: Mapped[str | None] = mapped_column(Text)
+
+
+class EligibilityCheckRecord(Base):
+    __tablename__ = "research_eligibility_checks"
+    __table_args__ = (UniqueConstraint("experiment_id", "name"),)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    experiment_id: Mapped[str] = mapped_column(ForeignKey("research_experiments.id"), index=True)
+    name: Mapped[str] = mapped_column(String(80))
+    status: Mapped[str] = mapped_column(String(30), index=True)
+    observed_value: Mapped[float | None] = mapped_column(Float)
+    threshold: Mapped[float | None] = mapped_column(Float)
+    reason: Mapped[str | None] = mapped_column(String(200))
+
+
+class ParameterRunRecord(Base):
+    __tablename__ = "research_parameter_runs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ("experiment_id", "fold_id"),
+            ("research_experiment_folds.experiment_id", "research_experiment_folds.fold_id"),
+        ),
+        UniqueConstraint("experiment_id", "fold_id", "stage", "run_id"),
+    )
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[str] = mapped_column(String(64), index=True)
+    experiment_id: Mapped[str] = mapped_column(ForeignKey("research_experiments.id"), index=True)
+    fold_id: Mapped[str] = mapped_column(String(64), index=True)
+    stage: Mapped[str] = mapped_column(String(20), index=True)
+    parameter_config_id: Mapped[str] = mapped_column(String(64), index=True)
+    parameter_config_json: Mapped[str] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String(30), index=True)
+    objective_score: Mapped[float | None] = mapped_column(Float)
+    metrics_json: Mapped[str | None] = mapped_column(Text)
+    closed_trade_count: Mapped[int] = mapped_column(Integer)
+    failure_reason: Mapped[str | None] = mapped_column(Text)
 
 
 def _json_default(value: object) -> str:
     if isinstance(value, (Decimal, datetime)):
         return str(value)
     raise TypeError(f"Nelze serializovat {type(value)}")
+
+
+def _parameter_config_id(config: object) -> str:
+    canonical = json.dumps(config, default=_json_default, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
 
 
 class RunRepository:
@@ -75,18 +144,101 @@ class RunRepository:
         result: dict[str, object],
         created_at: datetime,
     ) -> str:
+        config_json = json.dumps(config, default=_json_default, sort_keys=True)
+        result_json = json.dumps(result, default=_json_default, sort_keys=True)
         with Session(self.engine) as session:
             existing = session.get(ExperimentRecord, experiment_id)
             if existing is None:
+                eligibility = result.get("eligibility", {})
+                if not isinstance(eligibility, dict):
+                    raise TypeError("Eligibility snapshot musí být mapování")
                 session.add(
                     ExperimentRecord(
                         id=experiment_id,
-                        config_json=json.dumps(config, default=_json_default, sort_keys=True),
-                        result_json=json.dumps(result, default=_json_default, sort_keys=True),
+                        dataset_id=str(result.get("dataset_id", "")) or None,
+                        strategy_name=str(result.get("strategy_name", "")) or None,
+                        strategy_version=str(result.get("strategy_version", "")) or None,
+                        parameter_space_id=str(result.get("parameter_space_id", "")) or None,
+                        decision=str(eligibility.get("decision", "")) or None,
+                        config_json=config_json,
+                        result_json=result_json,
                         created_at=created_at,
                     )
                 )
+                folds = result.get("folds", ())
+                if not isinstance(folds, (list, tuple)):
+                    raise TypeError("Fold snapshot musí být sekvence")
+                for fold in folds:
+                    if not isinstance(fold, dict):
+                        raise TypeError("Fold snapshot musí být mapování")
+                    session.add(
+                        ExperimentFoldRecord(
+                            experiment_id=experiment_id,
+                            fold_id=str(fold["fold_id"]),
+                            status=str(fold["status"]),
+                            oos_start=datetime.fromisoformat(str(fold["oos_start"])),
+                            oos_end=datetime.fromisoformat(str(fold["oos_end"])),
+                            oos_evaluations=int(fold["oos_evaluations"]),
+                            selected_config_json=json.dumps(
+                                fold.get("selected_config"), default=_json_default, sort_keys=True
+                            ),
+                        )
+                    )
+                    for stage, key in (("TRAIN", "train_runs"), ("VALIDATION", "validation_runs")):
+                        runs = fold.get(key, ())
+                        if not isinstance(runs, (list, tuple)):
+                            raise TypeError("Parameter runs musí být sekvence")
+                        for run in runs:
+                            if not isinstance(run, dict):
+                                raise TypeError("Parameter run snapshot musí být mapování")
+                            parameter_config = run["parameter_config"]
+                            score = run.get("objective_score")
+                            session.add(
+                                ParameterRunRecord(
+                                    run_id=str(run["run_id"]),
+                                    experiment_id=experiment_id,
+                                    fold_id=str(fold["fold_id"]),
+                                    stage=stage,
+                                    parameter_config_id=_parameter_config_id(parameter_config),
+                                    parameter_config_json=json.dumps(
+                                        parameter_config, default=_json_default, sort_keys=True
+                                    ),
+                                    status=str(run["status"]),
+                                    objective_score=float(score) if score is not None else None,
+                                    metrics_json=json.dumps(
+                                        run["metrics"], default=_json_default, sort_keys=True
+                                    )
+                                    if run.get("metrics") is not None
+                                    else None,
+                                    closed_trade_count=int(run["closed_trades"]),
+                                    failure_reason=str(run["failure_reason"])
+                                    if run.get("failure_reason") is not None
+                                    else None,
+                                )
+                            )
+                checks = eligibility.get("checks", ())
+                if not isinstance(checks, (list, tuple)):
+                    raise TypeError("Eligibility checks musí být sekvence")
+                for check in checks:
+                    if not isinstance(check, dict):
+                        raise TypeError("Eligibility check musí být mapování")
+                    observed = check.get("observed_value")
+                    threshold = check.get("threshold")
+                    session.add(
+                        EligibilityCheckRecord(
+                            experiment_id=experiment_id,
+                            name=str(check["name"]),
+                            status=str(check["status"]),
+                            observed_value=float(observed) if observed is not None else None,
+                            threshold=float(threshold) if threshold is not None else None,
+                            reason=str(check["reason"])
+                            if check.get("reason") is not None
+                            else None,
+                        )
+                    )
                 session.commit()
+            elif existing.config_json != config_json or existing.result_json != result_json:
+                raise ValueError("Experiment identity koliduje s odlišným neměnným snapshotem")
             return experiment_id
 
     def get_experiment(self, experiment_id: str) -> dict[str, object] | None:
@@ -98,6 +250,86 @@ class RunRepository:
                 "id": row.id,
                 "config": json.loads(row.config_json),
                 "result": json.loads(row.result_json),
+            }
+
+    def get_experiment_structure(self, experiment_id: str) -> dict[str, object] | None:
+        """Vrátí queryable strukturu vedle úplného neměnného reprodukčního snapshotu."""
+        with Session(self.engine) as session:
+            row = session.get(ExperimentRecord, experiment_id)
+            if row is None:
+                return None
+            folds = session.query(ExperimentFoldRecord).filter_by(experiment_id=experiment_id).all()
+            checks = (
+                session.query(EligibilityCheckRecord)
+                .filter_by(experiment_id=experiment_id)
+                .order_by(EligibilityCheckRecord.id)
+                .all()
+            )
+            parameter_runs = (
+                session.query(ParameterRunRecord)
+                .filter_by(experiment_id=experiment_id)
+                .order_by(ParameterRunRecord.id)
+                .all()
+            )
+            return {
+                "experiment": {
+                    "id": row.id,
+                    "dataset_id": row.dataset_id,
+                    "strategy_name": row.strategy_name,
+                    "strategy_version": row.strategy_version,
+                    "parameter_space_id": row.parameter_space_id,
+                    "decision": row.decision,
+                },
+                "folds": [
+                    {
+                        "fold_id": fold.fold_id,
+                        "status": fold.status,
+                        "oos_start": fold.oos_start.replace(tzinfo=fold.oos_start.tzinfo or UTC),
+                        "oos_end": fold.oos_end.replace(tzinfo=fold.oos_end.tzinfo or UTC),
+                        "oos_evaluations": fold.oos_evaluations,
+                        "selected_config": json.loads(fold.selected_config_json)
+                        if fold.selected_config_json is not None
+                        else None,
+                    }
+                    for fold in folds
+                ],
+                "eligibility_checks": [
+                    {
+                        "name": check.name,
+                        "status": check.status,
+                        "observed_value": check.observed_value,
+                        "threshold": check.threshold,
+                        "reason": check.reason,
+                    }
+                    for check in checks
+                ],
+                "parameter_runs": [
+                    {
+                        "run_id": run.run_id,
+                        "experiment_id": run.experiment_id,
+                        "fold_id": run.fold_id,
+                        "stage": run.stage,
+                        "parameter_config_id": run.parameter_config_id,
+                        "parameter_config": json.loads(run.parameter_config_json),
+                        "status": run.status,
+                        "objective_score": run.objective_score,
+                        "metrics": json.loads(run.metrics_json)
+                        if run.metrics_json is not None
+                        else None,
+                        "closed_trade_count": run.closed_trade_count,
+                        "failure_reason": run.failure_reason,
+                    }
+                    for run in parameter_runs
+                ],
+            }
+
+    def persistence_counts(self) -> dict[str, int]:
+        with Session(self.engine) as session:
+            return {
+                "experiments": session.query(ExperimentRecord).count(),
+                "folds": session.query(ExperimentFoldRecord).count(),
+                "parameter_runs": session.query(ParameterRunRecord).count(),
+                "eligibility_checks": session.query(EligibilityCheckRecord).count(),
             }
 
     def list_experiments(self) -> builtins.list[dict[str, object]]:

--- a/backend/src/quantlab/research.py
+++ b/backend/src/quantlab/research.py
@@ -327,6 +327,21 @@ class EligibilityDecision(StrEnum):
     PAPER_CANDIDATE = "PAPER_CANDIDATE"
 
 
+class EligibilityCheckStatus(StrEnum):
+    PASSED = "passed"
+    FAILED = "failed"
+    NOT_EVALUATED = "not_evaluated"
+
+
+@dataclass(frozen=True)
+class EligibilityCheck:
+    name: str
+    status: EligibilityCheckStatus
+    observed_value: int | float | bool | None
+    threshold: int | float | bool | None
+    reason: str | None = None
+
+
 @dataclass(frozen=True)
 class EligibilityConfig:
     minimum_trades: int = 20
@@ -339,8 +354,13 @@ class EligibilityConfig:
 @dataclass(frozen=True)
 class StrategyEligibilityResult:
     decision: EligibilityDecision
-    passed: dict[str, bool]
+    checks: tuple[EligibilityCheck, ...]
     reasons: tuple[str, ...]
+
+    @property
+    def passed(self) -> dict[str, bool]:
+        """Zpětně kompatibilní odvozený pohled; autoritativní jsou typované kontroly."""
+        return {check.name: check.status is EligibilityCheckStatus.PASSED for check in self.checks}
 
 
 def evaluate_eligibility(
@@ -353,25 +373,77 @@ def evaluate_eligibility(
     config: EligibilityConfig | None = None,
 ) -> StrategyEligibilityResult:
     config = config or EligibilityConfig()
-    checks = {
-        "minimum_trades": number_of_trades >= config.minimum_trades,
-        "positive_oos": oos_return >= config.minimum_oos_return,
-        "drawdown": abs(maximum_drawdown) <= config.maximum_drawdown,
-        "cost_stress": all(value > 0 for value in stressed_returns.values()),
-        "walk_forward": profitable_folds >= config.minimum_profitable_folds,
-        "parameter_stability": stability.profitable_fraction is not None
-        and stability.profitable_fraction >= config.minimum_profitable_neighbors,
-    }
-    passed_count = sum(checks.values())
+    stability_status = (
+        EligibilityCheckStatus.NOT_EVALUATED
+        if stability.profitable_fraction is None
+        else EligibilityCheckStatus.PASSED
+        if stability.profitable_fraction >= config.minimum_profitable_neighbors
+        else EligibilityCheckStatus.FAILED
+    )
+    checks = (
+        EligibilityCheck(
+            "minimum_trades",
+            EligibilityCheckStatus.PASSED
+            if number_of_trades >= config.minimum_trades
+            else EligibilityCheckStatus.FAILED,
+            number_of_trades,
+            config.minimum_trades,
+        ),
+        EligibilityCheck(
+            "positive_oos",
+            EligibilityCheckStatus.PASSED
+            if oos_return >= config.minimum_oos_return
+            else EligibilityCheckStatus.FAILED,
+            oos_return,
+            config.minimum_oos_return,
+        ),
+        EligibilityCheck(
+            "drawdown",
+            EligibilityCheckStatus.PASSED
+            if abs(maximum_drawdown) <= config.maximum_drawdown
+            else EligibilityCheckStatus.FAILED,
+            abs(maximum_drawdown),
+            config.maximum_drawdown,
+        ),
+        EligibilityCheck(
+            "cost_stress",
+            EligibilityCheckStatus.PASSED
+            if stressed_returns and all(value > 0 for value in stressed_returns.values())
+            else EligibilityCheckStatus.FAILED,
+            min(stressed_returns.values()) if stressed_returns else None,
+            0.0,
+            None if stressed_returns else "missing_cost_stress_scenarios",
+        ),
+        EligibilityCheck(
+            "walk_forward",
+            EligibilityCheckStatus.PASSED
+            if profitable_folds >= config.minimum_profitable_folds
+            else EligibilityCheckStatus.FAILED,
+            profitable_folds,
+            config.minimum_profitable_folds,
+        ),
+        EligibilityCheck(
+            "parameter_stability",
+            stability_status,
+            stability.profitable_fraction,
+            config.minimum_profitable_neighbors,
+            "no_parameter_neighbors" if stability.profitable_fraction is None else None,
+        ),
+    )
+    check_by_name = {check.name: check for check in checks}
+    passed_count = sum(check.status is EligibilityCheckStatus.PASSED for check in checks)
     decision = (
         EligibilityDecision.PAPER_CANDIDATE
         if passed_count == len(checks)
         else EligibilityDecision.RESEARCH_ONLY
-        if checks["minimum_trades"] and checks["positive_oos"]
+        if check_by_name["minimum_trades"].status is EligibilityCheckStatus.PASSED
+        and check_by_name["positive_oos"].status is EligibilityCheckStatus.PASSED
         else EligibilityDecision.REJECTED
     )
     return StrategyEligibilityResult(
-        decision, checks, tuple(name for name, passed in checks.items() if not passed)
+        decision,
+        checks,
+        tuple(check.name for check in checks if check.status is not EligibilityCheckStatus.PASSED),
     )
 
 

--- a/backend/tests/test_research.py
+++ b/backend/tests/test_research.py
@@ -13,6 +13,7 @@ from quantlab.persistence import RunRepository
 from quantlab.research import (
     AnalysisStatus,
     CostScenario,
+    EligibilityCheckStatus,
     EligibilityDecision,
     ExperimentIdentity,
     ParameterStability,
@@ -113,6 +114,7 @@ def test_monte_carlo_cost_stress_and_eligibility_are_deterministic() -> None:
         25, 0.1, -0.1, stressed, 0.8, ParameterStability(2, 0.1, 0.01, 1.0)
     )
     assert result.decision is EligibilityDecision.PAPER_CANDIDATE
+    assert all(check.status is EligibilityCheckStatus.PASSED for check in result.checks)
 
 
 def test_metrics_edge_cases_and_benchmark_alignment() -> None:
@@ -396,7 +398,8 @@ def test_baselines_and_reproducible_backtest() -> None:
 
 
 def test_research_report_is_complete_and_experiment_is_deterministic() -> None:
-    service = ResearchService(RunRepository())
+    repository = RunRepository()
+    service = ResearchService(repository)
     first = service.create_demo_experiment(FIXTURE)
     second = service.create_demo_experiment(FIXTURE)
     assert first == second
@@ -421,3 +424,18 @@ def test_research_report_is_complete_and_experiment_is_deterministic() -> None:
     assert payload["monte_carlo"]["reason"] == "insufficient_closed_trades"
     assert len(payload["walk_forward"]) == 1
     assert payload["walk_forward"][0]["validation_runs"] == 2
+
+    # Úplný uložený snapshot musí být shodný s JSON reprezentací in-memory výsledku.
+    persisted = service.get(str(first["id"]))
+    assert persisted is not None
+    expected = json.loads(json.dumps(first["result"], default=str, sort_keys=True))
+    assert persisted["result"] == expected
+
+    structure = repository.get_experiment_structure(str(first["id"]))
+    assert structure is not None
+    assert structure["experiment"]["dataset_id"] == first["result"]["dataset_id"]
+    assert len(structure["folds"]) == len(first["result"]["folds"])
+    assert structure["folds"][0]["oos_evaluations"] == 1
+    assert [check["name"] for check in structure["eligibility_checks"]] == [
+        check["name"] for check in first["result"]["eligibility"]["checks"]
+    ]

--- a/backend/tests/test_research_engine.py
+++ b/backend/tests/test_research_engine.py
@@ -1,4 +1,7 @@
-from dataclasses import replace
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import asdict, replace
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
@@ -6,6 +9,7 @@ import pytest
 
 from quantlab.domain import Bar, Fill, Side
 from quantlab.metrics import fifo_closed_trades
+from quantlab.persistence import RunRepository
 from quantlab.research import ObjectiveConfig, WalkForwardConfig
 from quantlab.research_engine import (
     ParameterRunStatus,
@@ -116,6 +120,134 @@ def test_overlapping_oos_fails_fast() -> None:
         ResearchExperimentRunner().run(
             market_bars(), MovingAverageStrategyFactory(), space, overlapping
         )
+
+
+def test_structured_persistence_is_complete_idempotent_and_immutable() -> None:
+    space, config = setup()
+    runner = ResearchExperimentRunner()
+    result = runner.run(market_bars(), MovingAverageStrategyFactory(), space, config)
+    repository = RunRepository()
+    snapshot = asdict(result)
+    persisted_config = {"research_config": asdict(config), "parameter_space": space.to_dict()}
+
+    repository.save_experiment(result.experiment_id, persisted_config, snapshot, datetime.now(UTC))
+    expected_counts = {
+        "experiments": 1,
+        "folds": 3,
+        "parameter_runs": 18,
+        "eligibility_checks": 6,
+    }
+    assert repository.persistence_counts() == expected_counts
+
+    structure = repository.get_experiment_structure(result.experiment_id)
+    assert structure is not None
+    assert structure["experiment"] == {
+        "id": result.experiment_id,
+        "dataset_id": result.dataset_id,
+        "strategy_name": result.strategy_name,
+        "strategy_version": result.strategy_version,
+        "parameter_space_id": result.parameter_space_id,
+        "decision": result.eligibility.decision,
+    }
+    assert len(structure["folds"]) == len(result.folds)
+    source_runs = {
+        (fold.fold_id, stage, run.run_id): run
+        for fold in result.folds
+        for stage, runs in (("TRAIN", fold.train_runs), ("VALIDATION", fold.validation_runs))
+        for run in runs
+    }
+    assert len(structure["parameter_runs"]) == len(source_runs)
+    for persisted_run in structure["parameter_runs"]:
+        source = source_runs[
+            (persisted_run["fold_id"], persisted_run["stage"], persisted_run["run_id"])
+        ]
+        assert persisted_run["experiment_id"] == result.experiment_id
+        assert persisted_run["parameter_config"] == json.loads(json.dumps(source.parameter_config))
+        canonical_config = json.dumps(
+            source.parameter_config, sort_keys=True, separators=(",", ":")
+        )
+        assert (
+            persisted_run["parameter_config_id"]
+            == hashlib.sha256(canonical_config.encode()).hexdigest()
+        )
+        assert persisted_run["status"] == source.status
+        assert persisted_run["objective_score"] == source.objective_score
+        assert persisted_run["metrics"] == (
+            json.loads(json.dumps(asdict(source.metrics), default=str)) if source.metrics else None
+        )
+        assert persisted_run["closed_trade_count"] == source.closed_trades
+        assert persisted_run["failure_reason"] == source.failure_reason
+    for persisted_fold, source_fold in zip(structure["folds"], result.folds, strict=True):
+        assert persisted_fold["selected_config"] == json.loads(
+            json.dumps(source_fold.selected_config)
+        )
+    assert structure["eligibility_checks"] == [
+        {
+            "name": check.name,
+            "status": check.status,
+            "observed_value": float(check.observed_value)
+            if check.observed_value is not None
+            else None,
+            "threshold": float(check.threshold) if check.threshold is not None else None,
+            "reason": check.reason,
+        }
+        for check in result.eligibility.checks
+    ]
+    assert repository.get_experiment(result.experiment_id)["result"] == json.loads(
+        json.dumps(snapshot, default=str)
+    )
+
+    repository.save_experiment(result.experiment_id, persisted_config, snapshot, datetime.now(UTC))
+    assert repository.persistence_counts() == expected_counts
+
+    conflicting = deepcopy(snapshot)
+    conflicting["dataset_id"] = "conflicting-content"
+    with pytest.raises(ValueError, match="koliduje"):
+        repository.save_experiment(
+            result.experiment_id, persisted_config, conflicting, datetime.now(UTC)
+        )
+    assert repository.persistence_counts() == expected_counts
+
+    other_config = replace(config, random_seed=config.random_seed + 1)
+    other = runner.run(market_bars(), MovingAverageStrategyFactory(), space, other_config)
+    assert other.experiment_id != result.experiment_id
+    repository.save_experiment(
+        other.experiment_id,
+        {"research_config": asdict(other_config), "parameter_space": space.to_dict()},
+        asdict(other),
+        datetime.now(UTC),
+    )
+    assert repository.persistence_counts() == {
+        "experiments": 2,
+        "folds": 6,
+        "parameter_runs": 36,
+        "eligibility_checks": 12,
+    }
+
+
+def test_structured_experiment_materialization_is_transactional() -> None:
+    space, config = setup()
+    result = ResearchExperimentRunner().run(
+        market_bars(), MovingAverageStrategyFactory(), space, config
+    )
+    malformed = asdict(result)
+    malformed["eligibility"]["checks"] = "invalid"
+    repository = RunRepository()
+
+    with pytest.raises(TypeError, match="Eligibility checks"):
+        repository.save_experiment(
+            result.experiment_id,
+            {"research_config": asdict(config), "parameter_space": space.to_dict()},
+            malformed,
+            datetime.now(UTC),
+        )
+
+    assert repository.persistence_counts() == {
+        "experiments": 0,
+        "folds": 0,
+        "parameter_runs": 0,
+        "eligibility_checks": 0,
+    }
 
 
 def test_fifo_ledger_handles_scale_in_and_partial_scale_out() -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,3 +66,16 @@ aggregate OOS → FIFO metrics/OOS benchmark → fold-level cost re-backtests �
 stabilita → eligibility → immutable persistence snapshot/report`. Business tok vlastní
 `ResearchExperimentRunner`; FastAPI pouze deleguje aplikační službě. Překryv OOS oken selže.
 Train ani validation equity se do agregované research equity nikdy nevkládá.
+
+## Phase 2.8 strukturovaná persistence
+
+SQLite ukládá úplný neměnný JSON snapshot kvůli přesné reprodukci a současně normalizované
+hlavičky experimentu, OOS foldy, jejich train/validation ParameterRuny a jednotlivé eligibility
+kontroly pro auditní dotazy. ParameterRun ukládá config i jeho hash, stage, status, objective,
+metriky, počet uzavřených obchodů a failure reason. OOS evaluace zůstává ve fold/backtest snapshotu,
+protože není během výběru parametrů ParameterRunem. Opakovaný zápis stejné identity s odlišným
+configem nebo výsledkem selže; nemůže tiše přepsat experiment.
+Eligibility check je doménový typ se stavem `passed`, `failed` nebo `not_evaluated`, observed
+hodnotou, prahem a důvodem. Odvozená boolean mapa zůstává pouze kompatibilním read-only pohledem.
+Experiment, foldy, ParameterRuny a kontroly se materializují v jedné SQLAlchemy session a jednom
+commitu; výjimka před commitem ukončí session s rollbackem celé projekce.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -20,6 +20,16 @@
 | 15 Dokumentace | probíhá | README, architektura, tento plán | doména/risk/operations |
 | 16 E2E verification | probíhá | fixture→API/dashboard integrační test | úplný master demo scénář |
 
+## Phase 2 closure
+
+**Stav: COMPLETE (Phase 2 research-foundation scope).** Phase 2.8 uzavřela strukturovanou
+persistence experiment identity/foldů/eligibility checks, nahradila autoritativní mapu eligibility
+typovaným doménovým modelem a přidala úplné persisted-versus-in-memory porovnání snapshotu.
+Finální verification doplnila chybějící strukturované train/validation ParameterRuny. Testovací
+experiment dokládá 1 experiment, 3 foldy, 18 ParameterRunů a 6 eligibility checks před i po
+idempotentním opakovaném zápisu, immutable konflikt i transakční rollback.
+Omezení uvedená v tabulce patří do pozdějších fází master plánu a nemění tento closure verdikt.
+
 Každá fáze je „dokončeno“ až po implementaci acceptance scope, unit/integration testech,
 lintu, formátu a typechecku. Aktuální ověřitelný milník je první funkční vertical slice.
 

--- a/docs/research-methodology.md
+++ b/docs/research-methodology.md
@@ -48,3 +48,8 @@ Cost stress je nový backtest každého OOS foldu s jeho selected configem.
 Experiment identity zahrnuje dataset content hash, strategy name/version, celý parameter space,
 walk-forward/objective/top-k konfiguraci, cost a stress modely, seed, Monte Carlo, eligibility
 a engine version. Identické vstupy reprodukují foldy, runy, fills, agregaci i robustness výstupy.
+
+Každá eligibility podmínka je samostatný typovaný záznam se statusem, observed hodnotou, prahem
+a volitelným důvodem. `not_evaluated` je odlišné od `failed` a nikdy se nepočítá jako průchod.
+Snapshot experimentu je neměnný; strukturované tabulky identity, foldů a kontrol jsou jeho
+dotazovatelnou projekcí, nikoli druhým zdrojem research pravdy.


### PR DESCRIPTION
### Motivation
- Zavést dotazovatelnou, normalizovanou projekci neměnného JSON snapshotu experimentu pro audit a reporting. 
- Nahradit autoritativní boolean mapu eligibility typovaným doménovým modelem s jasnými stavy a důvody. 
- Zajistit idempotentní uložení, detekci kolizí a transakční rollback při chybné materializaci.

### Description
- Přidány SQLAlchemy modely `ExperimentFoldRecord`, `EligibilityCheckRecord` a `ParameterRunRecord` a rozšířen `ExperimentRecord` o `dataset_id`, `strategy_name`, `strategy_version`, `parameter_space_id` a `decision` hlavičky. 
- Rozšířen `RunRepository` o `save_experiment` s validační logikou, canonicalizací JSON (`_json_default`) a výpočtem `parameter_config_id` přes SHA256, o dotazovací projekci `get_experiment_structure` a sumarizační `persistence_counts`, přičemž opakovaný zápis stejné identity s odlišným snapshotem nyní vyhodí `ValueError`. 
- V `quantlab.research` zaveden `EligibilityCheckStatus` a `EligibilityCheck` typy, `StrategyEligibilityResult` nyní nese sekvenci typovaných kontrol a zachovává zpětně kompatibilní `passed` pohled; `evaluate_eligibility` vrací typované kontroly a produkuje odpovídající důvody/`not_evaluated` stavy. 
- Dokumentace a README/architektura/implementační plán byly aktualizovány popisující Phase 2.8 (closure) a návrh strukturované persistence.

### Testing
- Spuštěny unit/integration testy upravené a doplněné o nové ověření persistence: `backend/tests/test_research.py::test_monte_carlo_cost_stress_and_eligibility_are_deterministic` a `backend/tests/test_research.py::test_research_report_is_complete_and_experiment_is_deterministic`, které kontrolují nové typované kontroly a konzistenci uloženého snapshotu; tyto testy prošly. 
- Přidány a spuštěny integrační testy persistence v `backend/tests/test_research_engine.py::test_structured_persistence_is_complete_idempotent_and_immutable` a `backend/tests/test_research_engine.py::test_structured_experiment_materialization_is_transactional`, které ověřují úplnost materializace, idempotenci, detekci konfliktu a rollback; tyto testy prošly. 
- Regulární vývojové backend testy byly spuštěny proti změnám a nezjistily regresi v existující sadě testů.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a2de399b883328b18711e6b72fd44)