### PR TITLE
Phase 3: Zavedení produkční research data platformy (Alembic, PostgreSQL‑compatible registry, leaderboard)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+APP_ENV=development
+LOG_LEVEL=INFO
+DATABASE_URL=postgresql+psycopg://quantlab@localhost:5432/quantlab
 TRADING_MODE=paper
 LIVE_TRADING_ENABLED=false
-DATABASE_URL=sqlite:///./quantlab.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    defaults: {run: {working-directory: backend}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      # Repository zatím nemá lockfile; --locked proto ukončoval každý CI job kódem 2.
+      - run: uv sync --all-groups
+      - run: uv run ruff format --check .
+      - run: uv run ruff check .
+      - run: uv run mypy src/quantlab
+  unit-research:
+    runs-on: ubuntu-latest
+    defaults: {run: {working-directory: backend}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --all-groups
+      - run: uv run pytest -q tests/test_research.py tests/test_research_engine.py
+  api:
+    runs-on: ubuntu-latest
+    defaults: {run: {working-directory: backend}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --all-groups
+      - run: uv run pytest -q tests/test_vertical_slice.py
+  integration-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env: {POSTGRES_DB: quantlab, POSTGRES_USER: quantlab, POSTGRES_HOST_AUTH_METHOD: trust}
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U quantlab -d quantlab"
+          --health-interval 5s --health-timeout 3s --health-retries 12
+    env:
+      DATABASE_URL: postgresql+psycopg://quantlab@localhost:5432/quantlab
+      RUN_POSTGRES_TESTS: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --all-groups
+        working-directory: backend
+      - run: uv run alembic -c ../alembic.ini upgrade head
+        working-directory: backend
+      - run: uv run pytest -q tests/test_phase3_platform.py
+        working-directory: backend

--- a/README.md
+++ b/README.md
@@ -61,3 +61,21 @@ jejich train/validation ParameterRunů i typovaných eligibility kontrol. Každ�
 status, pozorovanou hodnotu, práh a případný důvod; chybějící stabilitní sousedství se netváří jako
 běžné selhání, ale jako `not_evaluated`. Konzistenční test porovnává celý persisted snapshot s JSON
 reprezentací in-memory experimentu a ověřuje idempotenci i transakční rollback celé projekce.
+
+## Phase 3: production research data platform
+
+`DATABASE_URL` volí SQLite development adapter nebo PostgreSQL production adapter. Produkční
+bootstrap probíhá výhradně přes Alembic; `create_all` je izolován v testovacím helperu.
+
+```bash
+docker compose up -d postgres
+cd backend
+uv sync --all-groups
+uv run alembic -c ../alembic.ini upgrade head
+uv run pytest
+```
+
+Registry uchovává neměnnou identitu datasetu, verzi strategie, experiment, foldy, parameter runy,
+eligibility a leaderboard metriky. API nabízí stránkované/filtrované experimenty, leaderboard a
+comparison. Ranking je lexikografický: eligibility, kladné OOS, cost stress, stabilita, drawdown,
+Sharpe a deterministické ID; není predikcí budoucí ziskovosti.

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,31 @@
+[alembic]
+script_location = %(here)s/alembic
+prepend_sys_path = %(here)s/backend/src
+sqlalchemy.url = sqlite:///./quantlab.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+[handlers]
+keys = console
+[formatters]
+keys = generic
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,41 @@
+import logging
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from quantlab.persistence import Base
+
+config = context.config
+if config.config_file_name:
+    fileConfig(config.config_file_name)
+url = os.getenv("DATABASE_URL")
+if url:
+    config.set_main_option("sqlalchemy.url", url.replace("%", "%%"))
+target_metadata = Base.metadata
+logger = logging.getLogger(__name__)
+
+
+def run_migrations_offline() -> None:
+    context.configure(url=config.get_main_option("sqlalchemy.url"), target_metadata=target_metadata,
+                      literal_binds=True, dialect_opts={"paramstyle": "named"})
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    try:
+        connectable = engine_from_config(config.get_section(config.config_ini_section, {}), prefix="sqlalchemy.", poolclass=pool.NullPool)
+        with connectable.connect() as connection:
+            logger.info("migration_startup")
+            context.configure(connection=connection, target_metadata=target_metadata)
+            with context.begin_transaction():
+                context.run_migrations()
+    except Exception:
+        logger.exception("database_connectivity_failure")
+        raise
+
+
+if context.is_offline_mode(): run_migrations_offline()
+else: run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,20 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/20260810_01_production_registry.py
+++ b/alembic/versions/20260810_01_production_registry.py
@@ -1,0 +1,25 @@
+"""Zavedení produkční research registry.
+
+Revision ID: 20260810_01
+Revises:
+"""
+from alembic import op
+
+from quantlab.persistence import Base
+
+revision = "20260810_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for table in Base.metadata.sorted_tables:
+        table.create(bind, checkfirst=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for table in reversed(Base.metadata.sorted_tables):
+        table.drop(bind, checkfirst=False)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 description = "Auditovatelná quantitative research a paper-trading platforma"
 requires-python = ">=3.12"
 dependencies = [
+  "alembic>=1.16,<2",
   "fastapi>=0.116,<1",
   "pydantic-settings>=2.10,<3",
   "pyarrow>=20,<24",
+  "psycopg[binary]>=3.2,<4",
   "sqlalchemy>=2.0,<3",
   "uvicorn>=0.35,<1",
 ]

--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -1,16 +1,21 @@
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Annotated
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse
 
 from quantlab.backtest import serialize_result
+from quantlab.config import get_settings
 from quantlab.demo import run_demo
 from quantlab.persistence import RunRepository
 from quantlab.research_service import ResearchService
 
 app = FastAPI(title="Autonomous Quant Lab", version="0.1.0")
-repository = RunRepository()
+settings = get_settings()
+repository = RunRepository(
+    settings.database_url, bootstrap_test_schema=settings.database_url.startswith("sqlite")
+)
 fixture = Path(__file__).parents[2] / "tests" / "fixtures" / "sample_market_data.csv"
 research_service = ResearchService(repository)
 
@@ -40,8 +45,39 @@ def create_research_experiment() -> dict[str, object]:
 
 @app.get("/api/research/experiments")
 @app.get("/research/experiments")
-def research_experiments() -> list[dict[str, object]]:
-    return research_service.list()
+def research_experiments(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    strategy: str | None = None,
+    strategy_version: str | None = None,
+    dataset_id: str | None = None,
+    eligibility_status: str | None = None,
+) -> list[dict[str, object]]:
+    return repository.list_experiments(
+        limit=limit,
+        offset=offset,
+        strategy=strategy,
+        strategy_version=strategy_version,
+        dataset_id=dataset_id,
+        eligibility_status=eligibility_status,
+    )
+
+
+@app.get("/research/leaderboard")
+@app.get("/api/research/leaderboard")
+def research_leaderboard(
+    limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return repository.leaderboard(limit=limit, offset=offset)
+
+
+@app.get("/research/compare")
+@app.get("/api/research/compare")
+def research_compare(ids: Annotated[list[str], Query()]) -> list[dict[str, object]]:
+    try:
+        return repository.compare(ids)
+    except (ValueError, KeyError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.get("/research/experiments/{experiment_id}")

--- a/backend/src/quantlab/config.py
+++ b/backend/src/quantlab/config.py
@@ -1,0 +1,16 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    database_url: str = "sqlite:///./quantlab.db"
+    app_env: str = "development"
+    log_level: str = "INFO"
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/src/quantlab/persistence.py
+++ b/backend/src/quantlab/persistence.py
@@ -1,21 +1,31 @@
 import builtins
 import hashlib
 import json
+import logging
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
+from enum import StrEnum
+from typing import Any, cast
 
 from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
     ForeignKeyConstraint,
+    Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
     create_engine,
+    event,
+    select,
 )
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+logger = logging.getLogger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -25,34 +35,86 @@ class Base(DeclarativeBase):
 class RunRecord(Base):
     __tablename__ = "backtest_runs"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
-    strategy: Mapped[str] = mapped_column(String(100))
-    result_json: Mapped[str] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    strategy: Mapped[str] = mapped_column(String(100), nullable=False)
+    result_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class DatasetRecord(Base):
+    __tablename__ = "datasets"
+    dataset_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    universe: Mapped[str] = mapped_column(String(200), nullable=False)
+    source: Mapped[str] = mapped_column(String(100), nullable=False)
+    timeframe: Mapped[str] = mapped_column(String(30), nullable=False)
+    start_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    end_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    row_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    timezone: Mapped[str] = mapped_column(String(50), nullable=False, default="UTC")
+    schema_version: Mapped[str] = mapped_column(String(30), nullable=False)
+    storage_uri: Mapped[str | None] = mapped_column(String(500))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class StrategyRecord(Base):
+    __tablename__ = "strategies"
+    strategy_identity: Mapped[str] = mapped_column(String(64), primary_key=True)
+    strategy_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    strategy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    metadata_json: Mapped[str] = mapped_column(Text, nullable=False)
+    __table_args__ = (UniqueConstraint("strategy_name", "strategy_version"),)
 
 
 class ExperimentRecord(Base):
     __tablename__ = "research_experiments"
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
-    dataset_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="COMPLETED")
+    failure_kind: Mapped[str | None] = mapped_column(String(40))
+    failure_reason: Mapped[str | None] = mapped_column(Text)
+    dataset_id: Mapped[str | None] = mapped_column(
+        ForeignKey("datasets.dataset_id", ondelete="RESTRICT"), index=True
+    )
+    strategy_identity: Mapped[str | None] = mapped_column(
+        ForeignKey("strategies.strategy_identity", ondelete="RESTRICT"), index=True
+    )
     strategy_name: Mapped[str | None] = mapped_column(String(100), index=True)
-    strategy_version: Mapped[str | None] = mapped_column(String(50))
-    parameter_space_id: Mapped[str | None] = mapped_column(String(64))
+    strategy_version: Mapped[str | None] = mapped_column(String(50), index=True)
+    parameter_space_id: Mapped[str | None] = mapped_column(String(64), index=True)
     decision: Mapped[str | None] = mapped_column(String(30), index=True)
-    config_json: Mapped[str] = mapped_column(Text)
-    result_json: Mapped[str] = mapped_column(Text)
+    total_return: Mapped[float | None] = mapped_column(Float)
+    cagr: Mapped[float | None] = mapped_column(Float)
+    sharpe: Mapped[float | None] = mapped_column(Float)
+    sortino: Mapped[float | None] = mapped_column(Float)
+    max_drawdown: Mapped[float | None] = mapped_column(Float)
+    calmar: Mapped[float | None] = mapped_column(Float)
+    closed_trade_count: Mapped[int | None] = mapped_column(Integer)
+    profit_factor: Mapped[float | None] = mapped_column(Float)
+    expectancy: Mapped[float | None] = mapped_column(Float)
+    turnover: Mapped[float | None] = mapped_column(Float)
+    total_commissions: Mapped[float | None] = mapped_column(Float)
+    total_slippage: Mapped[float | None] = mapped_column(Float)
+    config_json: Mapped[str] = mapped_column(Text, nullable=False)
+    result_json: Mapped[str] = mapped_column(Text, nullable=False)
 
 
 class ExperimentFoldRecord(Base):
     __tablename__ = "research_experiment_folds"
     __table_args__ = (UniqueConstraint("experiment_id", "fold_id"),)
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    experiment_id: Mapped[str] = mapped_column(ForeignKey("research_experiments.id"), index=True)
+    experiment_id: Mapped[str] = mapped_column(
+        ForeignKey("research_experiments.id", ondelete="RESTRICT"), index=True
+    )
     fold_id: Mapped[str] = mapped_column(String(64))
-    status: Mapped[str] = mapped_column(String(30))
-    oos_start: Mapped[datetime] = mapped_column(DateTime(timezone=True))
-    oos_end: Mapped[datetime] = mapped_column(DateTime(timezone=True))
-    oos_evaluations: Mapped[int] = mapped_column(Integer)
+    status: Mapped[str] = mapped_column(String(30), nullable=False)
+    oos_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    oos_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    oos_evaluations: Mapped[int] = mapped_column(Integer, nullable=False)
     selected_config_json: Mapped[str | None] = mapped_column(Text)
 
 
@@ -60,9 +122,11 @@ class EligibilityCheckRecord(Base):
     __tablename__ = "research_eligibility_checks"
     __table_args__ = (UniqueConstraint("experiment_id", "name"),)
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    experiment_id: Mapped[str] = mapped_column(ForeignKey("research_experiments.id"), index=True)
-    name: Mapped[str] = mapped_column(String(80))
-    status: Mapped[str] = mapped_column(String(30), index=True)
+    experiment_id: Mapped[str] = mapped_column(
+        ForeignKey("research_experiments.id", ondelete="RESTRICT"), index=True
+    )
+    name: Mapped[str] = mapped_column(String(80), nullable=False)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
     observed_value: Mapped[float | None] = mapped_column(Float)
     threshold: Mapped[float | None] = mapped_column(Float)
     reason: Mapped[str | None] = mapped_column(String(200))
@@ -74,45 +138,174 @@ class ParameterRunRecord(Base):
         ForeignKeyConstraint(
             ("experiment_id", "fold_id"),
             ("research_experiment_folds.experiment_id", "research_experiment_folds.fold_id"),
+            ondelete="RESTRICT",
         ),
         UniqueConstraint("experiment_id", "fold_id", "stage", "run_id"),
+        Index("ix_parameter_run_fold", "experiment_id", "fold_id"),
     )
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     run_id: Mapped[str] = mapped_column(String(64), index=True)
-    experiment_id: Mapped[str] = mapped_column(ForeignKey("research_experiments.id"), index=True)
+    experiment_id: Mapped[str] = mapped_column(
+        ForeignKey("research_experiments.id", ondelete="RESTRICT"), index=True
+    )
     fold_id: Mapped[str] = mapped_column(String(64), index=True)
     stage: Mapped[str] = mapped_column(String(20), index=True)
     parameter_config_id: Mapped[str] = mapped_column(String(64), index=True)
-    parameter_config_json: Mapped[str] = mapped_column(Text)
+    parameter_config_json: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(30), index=True)
     objective_score: Mapped[float | None] = mapped_column(Float)
     metrics_json: Mapped[str | None] = mapped_column(Text)
-    closed_trade_count: Mapped[int] = mapped_column(Integer)
+    closed_trade_count: Mapped[int] = mapped_column(Integer, nullable=False)
     failure_reason: Mapped[str | None] = mapped_column(Text)
 
 
 def _json_default(value: object) -> str:
-    if isinstance(value, (Decimal, datetime)):
+    if isinstance(value, (Decimal, datetime, StrEnum)):
         return str(value)
     raise TypeError(f"Nelze serializovat {type(value)}")
 
 
-def _parameter_config_id(config: object) -> str:
-    canonical = json.dumps(config, default=_json_default, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode()).hexdigest()
+def _canonical(value: object) -> str:
+    return json.dumps(value, default=_json_default, sort_keys=True, separators=(",", ":"))
+
+
+def _utc(value: datetime) -> datetime:
+    return value.astimezone(UTC) if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def _sqlite_fk(dbapi_connection: Any, _: Any) -> None:
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+def create_test_schema(engine: Engine) -> None:
+    """Izolovaný helper; runtime PostgreSQL bootstrap vždy používá Alembic."""
+    Base.metadata.create_all(engine)
+
+
+@dataclass(frozen=True)
+class LeaderboardPolicy:
+    name: str = "eligibility-consistency-v1"
+    eligibility_order: tuple[str, ...] = ("PAPER_CANDIDATE", "RESEARCH_ONLY", "REJECTED")
+
+
+class DatasetRepository:
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+
+    def register(self, record: dict[str, object]) -> str:
+        dataset_id = str(record["dataset_id"])
+        candidate = dict(record)
+        candidate.pop("created_at", None)
+        candidate["start_at"] = _utc(cast(datetime, candidate["start_at"]))
+        candidate["end_at"] = _utc(cast(datetime, candidate["end_at"]))
+        candidate.setdefault("timezone", "UTC")
+        candidate.setdefault("storage_uri", None)
+        candidate.setdefault("metadata", {})
+        with Session(self.engine) as session:
+            existing = session.get(DatasetRecord, dataset_id)
+            if existing:
+                persisted = _canonical(self._as_dict(existing, include_created=False))
+                if persisted != _canonical(candidate):
+                    raise ValueError("Dataset identity koliduje s odlišným neměnným obsahem")
+                return dataset_id
+            metadata = record.get("metadata", {})
+            row = DatasetRecord(
+                dataset_id=dataset_id,
+                content_hash=str(record["content_hash"]),
+                universe=str(record["universe"]),
+                source=str(record["source"]),
+                timeframe=str(record["timeframe"]),
+                start_at=_utc(cast(datetime, record["start_at"])),
+                end_at=_utc(cast(datetime, record["end_at"])),
+                row_count=int(str(record["row_count"])),
+                timezone=str(record.get("timezone", "UTC")),
+                schema_version=str(record["schema_version"]),
+                storage_uri=str(record["storage_uri"]) if record.get("storage_uri") else None,
+                created_at=_utc(cast(datetime, record.get("created_at", datetime.now(UTC)))),
+                metadata_json=_canonical(metadata),
+            )
+            session.add(row)
+            session.commit()
+            logger.info("dataset_registered", extra={"dataset_id": dataset_id})
+            return dataset_id
+
+    @staticmethod
+    def _as_dict(row: DatasetRecord, include_created: bool = True) -> dict[str, object]:
+        result = {
+            "dataset_id": row.dataset_id,
+            "content_hash": row.content_hash,
+            "universe": row.universe,
+            "source": row.source,
+            "timeframe": row.timeframe,
+            "start_at": _utc(row.start_at),
+            "end_at": _utc(row.end_at),
+            "row_count": row.row_count,
+            "timezone": row.timezone,
+            "schema_version": row.schema_version,
+            "storage_uri": row.storage_uri,
+            "metadata": json.loads(row.metadata_json),
+        }
+        if include_created:
+            result["created_at"] = _utc(row.created_at)
+        return result
+
+    def get(self, dataset_id: str) -> dict[str, object] | None:
+        with Session(self.engine) as session:
+            row = session.get(DatasetRecord, dataset_id)
+            return self._as_dict(row) if row else None
+
+
+class StrategyRepository:
+    def __init__(self, engine: Engine) -> None:
+        self.engine = engine
+
+    def register(self, name: str, version: str, metadata: dict[str, object] | None = None) -> str:
+        identity = hashlib.sha256(
+            _canonical({"name": name, "version": version}).encode()
+        ).hexdigest()
+        payload = _canonical(metadata or {})
+        with Session(self.engine) as session:
+            existing = session.get(StrategyRecord, identity)
+            if existing and existing.metadata_json != payload:
+                raise ValueError("Strategy identity koliduje")
+            if not existing:
+                session.add(
+                    StrategyRecord(
+                        strategy_identity=identity,
+                        strategy_name=name,
+                        strategy_version=version,
+                        created_at=datetime.now(UTC),
+                        metadata_json=payload,
+                    )
+                )
+                session.commit()
+        return identity
 
 
 class RunRepository:
-    def __init__(self, url: str = "sqlite:///:memory:") -> None:
+    def __init__(
+        self, url: str = "sqlite:///:memory:", *, bootstrap_test_schema: bool | None = None
+    ) -> None:
         self.engine = create_engine(url)
-        Base.metadata.create_all(self.engine)
+        if self.engine.dialect.name == "sqlite":
+            event.listen(self.engine, "connect", _sqlite_fk)
+        if bootstrap_test_schema is None:
+            bootstrap_test_schema = url.startswith("sqlite")
+        if bootstrap_test_schema:
+            create_test_schema(self.engine)
+        self.datasets, self.strategies = (
+            DatasetRepository(self.engine),
+            StrategyRepository(self.engine),
+        )
 
     def save(self, strategy: str, result: dict[str, object], created_at: datetime) -> int:
         with Session(self.engine) as session:
             row = RunRecord(
                 strategy=strategy,
                 result_json=json.dumps(result, default=_json_default),
-                created_at=created_at,
+                created_at=_utc(created_at),
             )
             session.add(row)
             session.commit()
@@ -121,21 +314,15 @@ class RunRepository:
 
     def list(self) -> list[dict[str, object]]:
         with Session(self.engine) as session:
-            records: builtins.list[dict[str, object]] = []
-            for row in session.query(RunRecord).all():
-                created_at = row.created_at
-                # SQLite časovou zónu neuchová; repository obnoví explicitní UTC.
-                if created_at.tzinfo is None:
-                    created_at = created_at.replace(tzinfo=UTC)
-                records.append(
-                    {
-                        "id": row.id,
-                        "strategy": row.strategy,
-                        "created_at": created_at,
-                        "result": json.loads(row.result_json),
-                    }
-                )
-            return records
+            return [
+                {
+                    "id": row.id,
+                    "strategy": row.strategy,
+                    "created_at": _utc(row.created_at),
+                    "result": json.loads(row.result_json),
+                }
+                for row in session.scalars(select(RunRecord))
+            ]
 
     def save_experiment(
         self,
@@ -144,133 +331,337 @@ class RunRepository:
         result: dict[str, object],
         created_at: datetime,
     ) -> str:
-        config_json = json.dumps(config, default=_json_default, sort_keys=True)
-        result_json = json.dumps(result, default=_json_default, sort_keys=True)
+        config_json, result_json = _canonical(config), _canonical(result)
+        dataset_id = str(result.get("dataset_id", "")) or None
+        name, version = (
+            str(result.get("strategy_name", "")) or None,
+            str(result.get("strategy_version", "")) or None,
+        )
+        if dataset_id and not self.datasets.get(dataset_id):
+            folds = result.get("folds", ())
+            if not isinstance(folds, (list, tuple)):
+                raise TypeError("Fold snapshot musí být sekvence")
+            starts = [
+                datetime.fromisoformat(str(f["train_start"])) for f in folds if isinstance(f, dict)
+            ]
+            ends = [datetime.fromisoformat(str(f["oos_end"])) for f in folds if isinstance(f, dict)]
+            self.datasets.register(
+                {
+                    "dataset_id": dataset_id,
+                    "content_hash": dataset_id,
+                    "universe": "unknown",
+                    "source": "research-input",
+                    "timeframe": "unknown",
+                    "start_at": min(starts),
+                    "end_at": max(ends),
+                    "row_count": 0,
+                    "timezone": "UTC",
+                    "schema_version": "phase2-bars-v1",
+                    "storage_uri": None,
+                    "metadata": {"registration": "legacy-experiment-materialization"},
+                }
+            )
+        strategy_identity = self.strategies.register(name, version) if name and version else None
+        eligibility = result.get("eligibility", {})
+        if not isinstance(eligibility, dict):
+            raise TypeError("Eligibility snapshot musí být mapování")
+        metrics = result.get("aggregate_oos_metrics", {})
+        if not isinstance(metrics, dict):
+            raise TypeError("Aggregate metrics musí být mapování")
         with Session(self.engine) as session:
             existing = session.get(ExperimentRecord, experiment_id)
-            if existing is None:
-                eligibility = result.get("eligibility", {})
-                if not isinstance(eligibility, dict):
-                    raise TypeError("Eligibility snapshot musí být mapování")
-                session.add(
-                    ExperimentRecord(
-                        id=experiment_id,
-                        dataset_id=str(result.get("dataset_id", "")) or None,
-                        strategy_name=str(result.get("strategy_name", "")) or None,
-                        strategy_version=str(result.get("strategy_version", "")) or None,
-                        parameter_space_id=str(result.get("parameter_space_id", "")) or None,
-                        decision=str(eligibility.get("decision", "")) or None,
-                        config_json=config_json,
-                        result_json=result_json,
-                        created_at=created_at,
-                    )
-                )
-                folds = result.get("folds", ())
-                if not isinstance(folds, (list, tuple)):
-                    raise TypeError("Fold snapshot musí být sekvence")
-                for fold in folds:
-                    if not isinstance(fold, dict):
-                        raise TypeError("Fold snapshot musí být mapování")
-                    session.add(
-                        ExperimentFoldRecord(
+            if existing:
+                if existing.config_json != config_json or existing.result_json != result_json:
+                    raise ValueError("Experiment identity koliduje s odlišným neměnným snapshotem")
+                return experiment_id
+            row = ExperimentRecord(
+                id=experiment_id,
+                created_at=_utc(created_at),
+                completed_at=_utc(created_at),
+                status="COMPLETED",
+                dataset_id=dataset_id,
+                strategy_identity=strategy_identity,
+                strategy_name=name,
+                strategy_version=version,
+                parameter_space_id=str(result.get("parameter_space_id", "")) or None,
+                decision=str(eligibility.get("decision", "")) or None,
+                total_return=metrics.get("total_return"),
+                cagr=metrics.get("cagr"),
+                sharpe=metrics.get("sharpe_ratio"),
+                sortino=metrics.get("sortino_ratio"),
+                max_drawdown=metrics.get("maximum_drawdown"),
+                calmar=metrics.get("calmar_ratio"),
+                closed_trade_count=metrics.get("number_of_trades"),
+                profit_factor=metrics.get("profit_factor"),
+                expectancy=metrics.get("expectancy"),
+                turnover=metrics.get("turnover"),
+                total_commissions=metrics.get("total_commissions"),
+                total_slippage=metrics.get("total_slippage_cost"),
+                config_json=config_json,
+                result_json=result_json,
+            )
+            session.add(row)
+            session.flush()
+            for fold in self._folds(experiment_id, result):
+                session.add(fold)
+            session.flush()
+            for run in self._runs(experiment_id, result):
+                session.add(run)
+            for check in self._checks(experiment_id, eligibility):
+                session.add(check)
+            session.commit()
+            logger.info("experiment_persisted", extra={"experiment_id": experiment_id})
+        return experiment_id
+
+    def _folds(
+        self, experiment_id: str, result: dict[str, object]
+    ) -> builtins.list[ExperimentFoldRecord]:
+        folds = result.get("folds", ())
+        if not isinstance(folds, (list, tuple)):
+            raise TypeError("Fold snapshot musí být sekvence")
+        return [
+            ExperimentFoldRecord(
+                experiment_id=experiment_id,
+                fold_id=str(f["fold_id"]),
+                status=str(f["status"]),
+                oos_start=_utc(datetime.fromisoformat(str(f["oos_start"]))),
+                oos_end=_utc(datetime.fromisoformat(str(f["oos_end"]))),
+                oos_evaluations=int(f["oos_evaluations"]),
+                selected_config_json=_canonical(f.get("selected_config")),
+            )
+            for f in folds
+            if isinstance(f, dict)
+        ]
+
+    def _runs(
+        self, experiment_id: str, result: dict[str, object]
+    ) -> builtins.list[ParameterRunRecord]:
+        rows: builtins.list[ParameterRunRecord] = []
+        folds = result.get("folds", ())
+        if not isinstance(folds, (list, tuple)):
+            raise TypeError("Fold snapshot musí být sekvence")
+        for fold in folds:
+            if not isinstance(fold, dict):
+                raise TypeError("Fold snapshot musí být mapování")
+            for stage, key in (("TRAIN", "train_runs"), ("VALIDATION", "validation_runs")):
+                for run in fold.get(key, ()):
+                    pc = run["parameter_config"]
+                    score = run.get("objective_score")
+                    rows.append(
+                        ParameterRunRecord(
+                            run_id=str(run["run_id"]),
                             experiment_id=experiment_id,
                             fold_id=str(fold["fold_id"]),
-                            status=str(fold["status"]),
-                            oos_start=datetime.fromisoformat(str(fold["oos_start"])),
-                            oos_end=datetime.fromisoformat(str(fold["oos_end"])),
-                            oos_evaluations=int(fold["oos_evaluations"]),
-                            selected_config_json=json.dumps(
-                                fold.get("selected_config"), default=_json_default, sort_keys=True
-                            ),
-                        )
-                    )
-                    for stage, key in (("TRAIN", "train_runs"), ("VALIDATION", "validation_runs")):
-                        runs = fold.get(key, ())
-                        if not isinstance(runs, (list, tuple)):
-                            raise TypeError("Parameter runs musí být sekvence")
-                        for run in runs:
-                            if not isinstance(run, dict):
-                                raise TypeError("Parameter run snapshot musí být mapování")
-                            parameter_config = run["parameter_config"]
-                            score = run.get("objective_score")
-                            session.add(
-                                ParameterRunRecord(
-                                    run_id=str(run["run_id"]),
-                                    experiment_id=experiment_id,
-                                    fold_id=str(fold["fold_id"]),
-                                    stage=stage,
-                                    parameter_config_id=_parameter_config_id(parameter_config),
-                                    parameter_config_json=json.dumps(
-                                        parameter_config, default=_json_default, sort_keys=True
-                                    ),
-                                    status=str(run["status"]),
-                                    objective_score=float(score) if score is not None else None,
-                                    metrics_json=json.dumps(
-                                        run["metrics"], default=_json_default, sort_keys=True
-                                    )
-                                    if run.get("metrics") is not None
-                                    else None,
-                                    closed_trade_count=int(run["closed_trades"]),
-                                    failure_reason=str(run["failure_reason"])
-                                    if run.get("failure_reason") is not None
-                                    else None,
-                                )
-                            )
-                checks = eligibility.get("checks", ())
-                if not isinstance(checks, (list, tuple)):
-                    raise TypeError("Eligibility checks musí být sekvence")
-                for check in checks:
-                    if not isinstance(check, dict):
-                        raise TypeError("Eligibility check musí být mapování")
-                    observed = check.get("observed_value")
-                    threshold = check.get("threshold")
-                    session.add(
-                        EligibilityCheckRecord(
-                            experiment_id=experiment_id,
-                            name=str(check["name"]),
-                            status=str(check["status"]),
-                            observed_value=float(observed) if observed is not None else None,
-                            threshold=float(threshold) if threshold is not None else None,
-                            reason=str(check["reason"])
-                            if check.get("reason") is not None
+                            stage=stage,
+                            parameter_config_id=hashlib.sha256(_canonical(pc).encode()).hexdigest(),
+                            parameter_config_json=_canonical(pc),
+                            status=str(run["status"]),
+                            objective_score=float(score) if score is not None else None,
+                            metrics_json=_canonical(run["metrics"])
+                            if run.get("metrics") is not None
+                            else None,
+                            closed_trade_count=int(run["closed_trades"]),
+                            failure_reason=str(run["failure_reason"])
+                            if run.get("failure_reason") is not None
                             else None,
                         )
                     )
-                session.commit()
-            elif existing.config_json != config_json or existing.result_json != result_json:
-                raise ValueError("Experiment identity koliduje s odlišným neměnným snapshotem")
-            return experiment_id
+        return rows
+
+    def _checks(
+        self, experiment_id: str, eligibility: dict[str, object]
+    ) -> builtins.list[EligibilityCheckRecord]:
+        checks = eligibility.get("checks", ())
+        if not isinstance(checks, (list, tuple)):
+            raise TypeError("Eligibility checks musí být sekvence")
+        if any(not isinstance(check, dict) for check in checks):
+            raise TypeError("Eligibility check musí být mapování")
+        return [
+            EligibilityCheckRecord(
+                experiment_id=experiment_id,
+                name=str(c["name"]),
+                status=str(c["status"]),
+                observed_value=float(c["observed_value"])
+                if c.get("observed_value") is not None
+                else None,
+                threshold=float(c["threshold"]) if c.get("threshold") is not None else None,
+                reason=str(c["reason"]) if c.get("reason") is not None else None,
+            )
+            for c in checks
+        ]
 
     def get_experiment(self, experiment_id: str) -> dict[str, object] | None:
         with Session(self.engine) as session:
             row = session.get(ExperimentRecord, experiment_id)
-            if row is None:
-                return None
-            return {
-                "id": row.id,
-                "config": json.loads(row.config_json),
-                "result": json.loads(row.result_json),
-            }
+            return (
+                {
+                    "id": row.id,
+                    "config": json.loads(row.config_json),
+                    "result": json.loads(row.result_json),
+                }
+                if row
+                else None
+            )
+
+    def list_experiments(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        strategy: str | None = None,
+        strategy_version: str | None = None,
+        dataset_id: str | None = None,
+        eligibility_status: str | None = None,
+    ) -> builtins.list[dict[str, object]]:
+        if limit < 1 or limit > 200 or offset < 0:
+            raise ValueError("Neplatná pagination")
+        statement = select(ExperimentRecord)
+        for column, value in (
+            (ExperimentRecord.strategy_name, strategy),
+            (ExperimentRecord.strategy_version, strategy_version),
+            (ExperimentRecord.dataset_id, dataset_id),
+            (ExperimentRecord.decision, eligibility_status),
+        ):
+            if value is not None:
+                statement = statement.where(column == value)
+        statement = (
+            statement.order_by(ExperimentRecord.created_at.desc(), ExperimentRecord.id)
+            .limit(limit)
+            .offset(offset)
+        )
+        with Session(self.engine) as session:
+            return [
+                {
+                    "id": r.id,
+                    "config": json.loads(r.config_json),
+                    "result": json.loads(r.result_json),
+                }
+                for r in session.scalars(statement)
+            ]
+
+    def leaderboard(
+        self, *, limit: int = 50, offset: int = 0, policy: LeaderboardPolicy | None = None
+    ) -> builtins.list[dict[str, object]]:
+        if limit < 1 or limit > 200 or offset < 0:
+            raise ValueError("Neplatná pagination")
+        policy = policy or LeaderboardPolicy()
+        with Session(self.engine) as session:
+            rows = [
+                {
+                    "id": row.id,
+                    "config": json.loads(row.config_json),
+                    "result": json.loads(row.result_json),
+                }
+                for row in session.scalars(select(ExperimentRecord).order_by(ExperimentRecord.id))
+            ]
+        rank = {value: index for index, value in enumerate(policy.eligibility_order)}
+
+        def key(item: dict[str, object]) -> tuple[object, ...]:
+            result = item["result"]
+            assert isinstance(result, dict)
+            metrics = result.get("aggregate_oos_metrics", {})
+            eligibility = result.get("eligibility", {})
+            assert isinstance(metrics, dict) and isinstance(eligibility, dict)
+            stress = result.get("cost_stress", {})
+            stability = result.get("parameter_stability", {})
+            survived = bool(
+                isinstance(stress, dict) and stress and all(float(v) > 0 for v in stress.values())
+            )
+            profitable_fraction = (
+                stability.get("profitable_fraction") if isinstance(stability, dict) else None
+            )
+            consistency = float(profitable_fraction) if profitable_fraction is not None else -1.0
+            total_return = metrics.get("total_return")
+            maximum_drawdown = metrics.get("maximum_drawdown")
+            sharpe_ratio = metrics.get("sharpe_ratio")
+            return (
+                rank.get(str(eligibility.get("decision")), len(rank)),
+                -(float(total_return) > 0 if total_return is not None else False),
+                -survived,
+                -consistency,
+                abs(float(maximum_drawdown)) if maximum_drawdown is not None else float("inf"),
+                -float(sharpe_ratio) if sharpe_ratio is not None else float("inf"),
+                item["id"],
+            )
+
+        selected = sorted(rows, key=key)[offset : offset + limit]
+        return [
+            {"rank": offset + i + 1, "policy": policy.name, **item}
+            for i, item in enumerate(selected)
+        ]
+
+    def compare(self, experiment_ids: builtins.list[str]) -> builtins.list[dict[str, object]]:
+        if len(experiment_ids) < 2:
+            raise ValueError("Porovnání vyžaduje alespoň dva experimenty")
+        output = []
+        for experiment_id in experiment_ids:
+            item = self.get_experiment(experiment_id)
+            if item is None:
+                raise KeyError(experiment_id)
+            result = item["result"]
+            assert isinstance(result, dict)
+            output.append(
+                {
+                    "id": experiment_id,
+                    "strategy_name": result.get("strategy_name"),
+                    "strategy_version": result.get("strategy_version"),
+                    "dataset_id": result.get("dataset_id"),
+                    "fold_count": len(result.get("folds", [])),
+                    "metrics": result.get("aggregate_oos_metrics"),
+                    "cost_stress": result.get("cost_stress"),
+                    "monte_carlo": result.get("monte_carlo"),
+                    "parameter_stability": result.get("parameter_stability"),
+                    "eligibility": result.get("eligibility"),
+                }
+            )
+        return output
+
+    def lineage(self, experiment_id: str) -> dict[str, object] | None:
+        item = self.get_experiment(experiment_id)
+        if not item:
+            return None
+        result, config = item["result"], item["config"]
+        assert isinstance(result, dict) and isinstance(config, dict)
+        research_config = config.get("research_config", {})
+        dataset_id = str(result.get("dataset_id"))
+        return {
+            "experiment_id": experiment_id,
+            "dataset": self.datasets.get(dataset_id),
+            "strategy_name": result.get("strategy_name"),
+            "strategy_version": result.get("strategy_version"),
+            "parameter_space_id": result.get("parameter_space_id"),
+            "research_config": research_config,
+            "engine_version": research_config.get("engine_version")
+            if isinstance(research_config, dict)
+            else None,
+            "transaction_costs": research_config.get("costs")
+            if isinstance(research_config, dict)
+            else None,
+            "random_seed": research_config.get("random_seed")
+            if isinstance(research_config, dict)
+            else None,
+        }
 
     def get_experiment_structure(self, experiment_id: str) -> dict[str, object] | None:
-        """Vrátí queryable strukturu vedle úplného neměnného reprodukčního snapshotu."""
         with Session(self.engine) as session:
             row = session.get(ExperimentRecord, experiment_id)
-            if row is None:
+            if not row:
                 return None
-            folds = session.query(ExperimentFoldRecord).filter_by(experiment_id=experiment_id).all()
-            checks = (
-                session.query(EligibilityCheckRecord)
-                .filter_by(experiment_id=experiment_id)
+            folds = session.scalars(
+                select(ExperimentFoldRecord).where(
+                    ExperimentFoldRecord.experiment_id == experiment_id
+                )
+            ).all()
+            checks = session.scalars(
+                select(EligibilityCheckRecord)
+                .where(EligibilityCheckRecord.experiment_id == experiment_id)
                 .order_by(EligibilityCheckRecord.id)
-                .all()
-            )
-            parameter_runs = (
-                session.query(ParameterRunRecord)
-                .filter_by(experiment_id=experiment_id)
+            ).all()
+            runs = session.scalars(
+                select(ParameterRunRecord)
+                .where(ParameterRunRecord.experiment_id == experiment_id)
                 .order_by(ParameterRunRecord.id)
-                .all()
-            )
+            ).all()
             return {
                 "experiment": {
                     "id": row.id,
@@ -282,44 +673,42 @@ class RunRepository:
                 },
                 "folds": [
                     {
-                        "fold_id": fold.fold_id,
-                        "status": fold.status,
-                        "oos_start": fold.oos_start.replace(tzinfo=fold.oos_start.tzinfo or UTC),
-                        "oos_end": fold.oos_end.replace(tzinfo=fold.oos_end.tzinfo or UTC),
-                        "oos_evaluations": fold.oos_evaluations,
-                        "selected_config": json.loads(fold.selected_config_json)
-                        if fold.selected_config_json is not None
+                        "fold_id": f.fold_id,
+                        "status": f.status,
+                        "oos_start": _utc(f.oos_start),
+                        "oos_end": _utc(f.oos_end),
+                        "oos_evaluations": f.oos_evaluations,
+                        "selected_config": json.loads(f.selected_config_json)
+                        if f.selected_config_json
                         else None,
                     }
-                    for fold in folds
+                    for f in folds
                 ],
                 "eligibility_checks": [
                     {
-                        "name": check.name,
-                        "status": check.status,
-                        "observed_value": check.observed_value,
-                        "threshold": check.threshold,
-                        "reason": check.reason,
+                        "name": c.name,
+                        "status": c.status,
+                        "observed_value": c.observed_value,
+                        "threshold": c.threshold,
+                        "reason": c.reason,
                     }
-                    for check in checks
+                    for c in checks
                 ],
                 "parameter_runs": [
                     {
-                        "run_id": run.run_id,
-                        "experiment_id": run.experiment_id,
-                        "fold_id": run.fold_id,
-                        "stage": run.stage,
-                        "parameter_config_id": run.parameter_config_id,
-                        "parameter_config": json.loads(run.parameter_config_json),
-                        "status": run.status,
-                        "objective_score": run.objective_score,
-                        "metrics": json.loads(run.metrics_json)
-                        if run.metrics_json is not None
-                        else None,
-                        "closed_trade_count": run.closed_trade_count,
-                        "failure_reason": run.failure_reason,
+                        "run_id": r.run_id,
+                        "experiment_id": r.experiment_id,
+                        "fold_id": r.fold_id,
+                        "stage": r.stage,
+                        "parameter_config_id": r.parameter_config_id,
+                        "parameter_config": json.loads(r.parameter_config_json),
+                        "status": r.status,
+                        "objective_score": r.objective_score,
+                        "metrics": json.loads(r.metrics_json) if r.metrics_json else None,
+                        "closed_trade_count": r.closed_trade_count,
+                        "failure_reason": r.failure_reason,
                     }
-                    for run in parameter_runs
+                    for r in runs
                 ],
             }
 
@@ -331,14 +720,3 @@ class RunRepository:
                 "parameter_runs": session.query(ParameterRunRecord).count(),
                 "eligibility_checks": session.query(EligibilityCheckRecord).count(),
             }
-
-    def list_experiments(self) -> builtins.list[dict[str, object]]:
-        with Session(self.engine) as session:
-            return [
-                {
-                    "id": row.id,
-                    "config": json.loads(row.config_json),
-                    "result": json.loads(row.result_json),
-                }
-                for row in session.query(ExperimentRecord).order_by(ExperimentRecord.id)
-            ]

--- a/backend/src/quantlab/reproducibility.py
+++ b/backend/src/quantlab/reproducibility.py
@@ -1,0 +1,51 @@
+import hashlib
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import asdict
+from enum import StrEnum
+
+from quantlab.persistence import RunRepository
+from quantlab.research_engine import ResearchExperimentResult
+
+logger = logging.getLogger(__name__)
+
+
+class ReproductionStatus(StrEnum):
+    MATCH = "MATCH"
+    MISMATCH = "MISMATCH"
+    NOT_REPRODUCIBLE = "NOT_REPRODUCIBLE"
+
+
+def deterministic_result_identity(result: dict[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(result, default=str, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def verify_reproduction(
+    repository: RunRepository,
+    experiment_id: str,
+    reproduce: Callable[[dict[str, object]], ResearchExperimentResult] | None,
+) -> tuple[ReproductionStatus, str]:
+    persisted = repository.get_experiment(experiment_id)
+    lineage = repository.lineage(experiment_id)
+    if persisted is None or lineage is None:
+        return ReproductionStatus.NOT_REPRODUCIBLE, "missing_experiment"
+    dataset = lineage.get("dataset")
+    if not dataset:
+        return ReproductionStatus.NOT_REPRODUCIBLE, "missing_dataset"
+    if reproduce is None:
+        return ReproductionStatus.NOT_REPRODUCIBLE, "missing_strategy_version"
+    config = persisted["config"]
+    expected = persisted["result"]
+    if not isinstance(config, dict) or not isinstance(expected, dict):
+        return ReproductionStatus.NOT_REPRODUCIBLE, "invalid_snapshot"
+    produced = asdict(reproduce(config))
+    status = (
+        ReproductionStatus.MATCH
+        if deterministic_result_identity(produced) == deterministic_result_identity(expected)
+        else ReproductionStatus.MISMATCH
+    )
+    logger.info("experiment_reproduction", extra={"experiment_id": experiment_id, "status": status})
+    return status, "deterministic_identity_compared"

--- a/backend/tests/test_phase3_platform.py
+++ b/backend/tests/test_phase3_platform.py
@@ -1,0 +1,122 @@
+import json
+import os
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.orm import Session
+
+from quantlab.persistence import Base, ExperimentRecord, RunRepository, create_test_schema
+
+
+def dataset(dataset_id: str = "a" * 64) -> dict[str, object]:
+    return {
+        "dataset_id": dataset_id,
+        "content_hash": dataset_id,
+        "universe": "SPY",
+        "source": "fixture",
+        "timeframe": "1d",
+        "start_at": datetime(2024, 1, 1, tzinfo=UTC),
+        "end_at": datetime(2024, 1, 2, tzinfo=UTC),
+        "row_count": 2,
+        "timezone": "UTC",
+        "schema_version": "bars-v1",
+        "storage_uri": "fixtures/sample_market_data.csv",
+        "metadata": {"adjustment": "fixture"},
+    }
+
+
+def test_empty_database_bootstrap_contains_expected_schema(tmp_path: object) -> None:
+    repository = RunRepository("sqlite:///:memory:", bootstrap_test_schema=False)
+    assert inspect(repository.engine).get_table_names() == []
+    create_test_schema(repository.engine)
+    assert set(inspect(repository.engine).get_table_names()) == set(Base.metadata.tables)
+
+
+def test_dataset_registry_is_idempotent_and_fails_closed_on_conflict() -> None:
+    repository = RunRepository()
+    value = dataset()
+    assert repository.datasets.register(value) == value["dataset_id"]
+    assert repository.datasets.register(value) == value["dataset_id"]
+    conflict = {**value, "row_count": 3}
+    with pytest.raises(ValueError, match="koliduje"):
+        repository.datasets.register(conflict)
+
+
+def test_strategy_registry_is_versioned_and_immutable() -> None:
+    repository = RunRepository()
+    identity = repository.strategies.register("moving_average", "1.0.0", {"owner": "core"})
+    assert repository.strategies.register("moving_average", "1.0.0", {"owner": "core"}) == identity
+    with pytest.raises(ValueError, match="koliduje"):
+        repository.strategies.register("moving_average", "1.0.0", {"owner": "other"})
+
+
+def test_pagination_limits_fail_closed() -> None:
+    repository = RunRepository()
+    with pytest.raises(ValueError, match="pagination"):
+        repository.list_experiments(limit=201)
+
+
+@pytest.mark.skipif(
+    os.getenv("RUN_POSTGRES_TESTS") != "1", reason="Vyžaduje PostgreSQL integrační službu"
+)
+def test_postgres_migrated_schema_and_registry() -> None:
+    database_url = os.environ["DATABASE_URL"]
+    repository = RunRepository(database_url, bootstrap_test_schema=False)
+    tables = set(inspect(repository.engine).get_table_names())
+    assert set(Base.metadata.tables).issubset(tables)
+    assert "alembic_version" in tables
+    value = dataset("b" * 64)
+    assert repository.datasets.register(value) == value["dataset_id"]
+    assert repository.datasets.get(str(value["dataset_id"])) is not None
+
+
+def test_dataset_timestamps_are_normalized_to_utc() -> None:
+    repository = RunRepository()
+    value = dataset("c" * 64)
+    non_utc = timezone(timedelta(hours=2))
+    value["start_at"] = datetime(2024, 1, 1, 2, tzinfo=non_utc)
+    repository.datasets.register(value)
+    persisted = repository.datasets.get(str(value["dataset_id"]))
+    assert persisted is not None
+    assert persisted["start_at"] == datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def test_malformed_eligibility_check_fails_closed() -> None:
+    repository = RunRepository()
+    with pytest.raises(TypeError, match="mapování"):
+        repository._checks("experiment", {"checks": [{"name": "valid"}, "invalid"]})
+
+
+def test_leaderboard_ranks_all_experiments_and_preserves_zero_metrics() -> None:
+    repository = RunRepository()
+    created_at = datetime(2024, 1, 1, tzinfo=UTC)
+    with Session(repository.engine) as session:
+        for index in range(205):
+            experiment_id = f"{index:064d}"
+            is_old_winner = index == 0
+            is_competitor = index == 1
+            result = {
+                "aggregate_oos_metrics": {
+                    "total_return": 0.1 if is_old_winner or is_competitor else -0.1,
+                    "maximum_drawdown": 0.0 if is_old_winner else -0.2,
+                    "sharpe_ratio": 0.0 if is_old_winner else -0.5,
+                },
+                "eligibility": {
+                    "decision": "PAPER_CANDIDATE" if is_old_winner or is_competitor else "REJECTED"
+                },
+                "cost_stress": {"base": 0.01},
+                "parameter_stability": {"profitable_fraction": 1.0 if is_old_winner else 0.0},
+            }
+            session.add(
+                ExperimentRecord(
+                    id=experiment_id,
+                    created_at=created_at + timedelta(days=index),
+                    status="COMPLETED",
+                    config_json="{}",
+                    result_json=json.dumps(result),
+                )
+            )
+        session.commit()
+    leaderboard = repository.leaderboard(limit=1)
+    assert leaderboard[0]["id"] == f"{0:064d}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: quantlab
+      POSTGRES_USER: quantlab
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - quantlab-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U quantlab -d quantlab"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+volumes:
+  quantlab-postgres:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,3 +79,12 @@ Eligibility check je doménový typ se stavem `passed`, `failed` nebo `not_evalu
 hodnotou, prahem a důvodem. Odvozená boolean mapa zůstává pouze kompatibilním read-only pohledem.
 Experiment, foldy, ParameterRuny a kontroly se materializují v jedné SQLAlchemy session a jednom
 commitu; výjimka před commitem ukončí session s rollbackem celé projekce.
+
+## Phase 3 registry a lineage
+
+`DatasetRecord ← ResearchExperiment → StrategyRecord` tvoří kořen lineage. PostgreSQL je produkční
+cíl, SQLite testovací adapter a Alembic jediná produkční bootstrap cesta. Experiment chrání
+restrict FK; fold, ParameterRun a eligibility check mají explicitní FK a unikátní constraints.
+Aggregate OOS metriky jsou explicitní sloupce, úplný snapshot zůstává autoritativní. Registry
+neukládá market bary, pouze identitu, rozsah, metadata a storage referenci. Redis a worker nejsou
+součástí Phase 3.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,23 @@
+# Databáze a migrace
+
+SQLite slouží pro rychlé unit testy. PostgreSQL 17 je produkční cíl. Business vrstva používá
+portable SQLAlchemy typy a timezone-aware timestamps. Produkční schema vzniká příkazem:
+
+Lokální Compose používá důvěryhodné připojení bez hesla pouze na loopback rozhraní. Jde výhradně
+o development konfiguraci; produkční PostgreSQL musí vyžadovat credentials mimo repository.
+
+```bash
+docker compose up -d postgres
+cd backend
+uv sync --all-groups
+uv run alembic -c ../alembic.ini upgrade head
+```
+
+Initial revision `20260810_01` vytvoří Phase 2 schema i Phase 3 registry. Migrace jsou
+forward-first; downgrade initial revision nesmí být použit na databázi s auditní historií.
+Aplikační runtime nevolá `create_all`; dostupný je pouze pojmenovaný test helper. CI čeká na
+`pg_isready`, provede upgrade a spustí PostgreSQL testy. SQLite není důkaz PostgreSQL kompatibility.
+
+Repository zatím neobsahuje `uv.lock`. CI proto nesmí používat `uv sync --locked`, který bez
+lockfile končí ještě před instalací a nespustí žádný test. Po vygenerování a commitnutí lockfile
+v prostředí s dostupným package indexem se CI vrátí k `uv sync --all-groups --locked`.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -43,3 +43,9 @@ akce jsou idempotentní a každý equity bod dokládá `equity = cash + market_v
 zůstává konfigurovatelnou ranking heuristikou, nikoli tvrzením o statistické optimalitě; všechny
 eligibility hranice jsou inkluzivní. Demo guardraily se v reportu označují `NOT_EVALUATED`
 s důvodem místo prázdného výsledku.
+
+## Phase 3 data platform
+
+Implementována je PostgreSQL-kompatibilní registry, Alembic initial migration, dataset/strategy
+identity, query API, leaderboard, comparison, lineage, reprodukční verifikace, CI a PostgreSQL
+Docker Compose. Trading worker a scheduler zůstávají mimo scope.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,5 @@
+# Reprodukovatelnost
+
+`verify_reproduction` načte immutable config a lineage, ověří dataset registry a vyžaduje přesný
+callback strategie/verze. Bez vstupu vrací `NOT_REPRODUCIBLE` a nikdy nepoužije novější variantu.
+Deterministická shoda snapshotu je `MATCH`; rozdíl je `MISMATCH` a závažný auditní signál.

--- a/docs/research-registry.md
+++ b/docs/research-registry.md
@@ -1,0 +1,13 @@
+# Research registry
+
+Dataset je identifikován content hashem. Shodná registrace je idempotentní a konflikt stejného ID
+selže uzavřeně. `universe` připravuje registry na budoucnost, engine však zůstává single-symbol.
+DB ukládá lineage a storage URI, nikoli samotné bary.
+
+Experiment lze filtrovat podle strategie, verze, datasetu a eligibility; limit je nejvýše 200.
+Policy `eligibility-consistency-v1` řadí lexikograficky: eligibility class, kladný OOS, přežití
+cost stressu, profitable-neighbor ratio, absolutní drawdown, Sharpe a experiment ID. Nevzniká
+magické profit score a pořadí není důkaz budoucí profitability.
+
+Comparison čte persisted snapshoty. Lineage vrací dataset/hash, strategii/verzi, parameter space,
+ResearchConfig, engine version, náklady a seed.


### PR DESCRIPTION
### Motivation

- Připravit přechod Phase 2 persistence na verzované migrace a PostgreSQL‑kompatibilní registry bez ztráty auditních invariantů.  
- Zajistit queryable registry pro datasety, strategie a experimenty a umožnit auditovatelnou reprodukovatelnost výsledků.  
- Doplňovat backendové služby (leaderboard, comparison, lineage) jako tenkou vrstvu nad persistence vrstvou, přičemž doménová logika zůstává nezměněná.

### Description

- Přidány PostgreSQL‑kompatibilní SQLAlchemy modely a repository: `DatasetRecord`, `StrategyRecord`, `ExperimentRecord`, `ExperimentFoldRecord`, `ParameterRunRecord`, `EligibilityCheckRecord` a vylepšený `RunRepository` se `DatasetRepository` a `StrategyRepository` a `create_test_schema` helper pro izolované SQLite testy; FK používají `RESTRICT` (audit-first).  
- Zavedení transakčního a FK‑bezpečného ukládání experimentu v `RunRepository.save_experiment` (flush parent/fold před child řádky), fail‑closed behavior při konfliktních immutable snapshotech a idempotentní dataset registry; doplněna legacy auto‑registrace datasetu pro existující snapshoty.  
- Přidán Alembic scaffold a initial migration `alembic/versions/20260810_01_production_registry.py`, Docker Compose pro PostgreSQL, centralizovaná konfigurace přes `DATABASE_URL` (`backend/src/quantlab/config.py`) a nová třída pro reprodukovatelnost `backend/src/quantlab/reproducibility.py`.  
- API rozšířeno o stránkované/filtrované `GET /research/experiments`, `GET /research/leaderboard` a `GET /research/compare`; implementována backendová leaderboard politika `eligibility-consistency-v1` (lexikografické řazení eligibility → OOS → cost stress → stability → drawdown → Sharpe → ID).  
- CI a infrastruktura: přidán GitHub Actions workflow s joby `quality`, `unit-research`, `api` a `integration-postgres`, `.env.example` bezpečné hodnoty, `docker-compose.yml` s PostgreSQL healthcheck, a nové integrační jednotkové testy `backend/tests/test_phase3_platform.py` pokrývající registry idempotenci a pagination constraints.  

### Testing

- Spuštěno `ruff format` / `ruff check` a `mypy` nad `backend/src` — prošlo bez chyb v upraveném kódu.  
- Spuštěny pytest s vybranými testy: `backend/tests/test_research.py`, `backend/tests/test_research_engine.py` a novými `backend/tests/test_phase3_platform.py`; všechny automatické testy v tomto běhu prošly: **28 passed**.  
- Zdokumentováno a v repo přidáno: Alembic scaffold a `alembic.ini` + initial revision; ale migrace nebyla lokálně prověřena spuštěním `alembic upgrade head` v produkčním režimu kvůli omezením prostředí.  
- Environmentální omezení během rolloutu: nebylo možné vytvořit závazný `uv.lock` ani stáhnout nové dependency (`psycopg`, `alembic`) kvůli síťovým omezením, a `docker` nebyl dostupný pro lokální PostgreSQL integraci; z toho důvodu nebyla v tomto prostředí plně ověřena Alembic bootstrap/CI `integration-postgres` job.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a32741d5483329b7ca6560d2460e5)