### PR TITLE
Zpevnění uv toolchainu a CI: připnutí uv 0.12.3, locked sync a policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,36 +2,76 @@ name: CI
 on: [push, pull_request]
 permissions:
   contents: read
+
+env:
+  PYTHON_VERSION: "3.12"
+  UV_VERSION: "0.12.3"
+
 jobs:
   quality:
     runs-on: ubuntu-latest
     defaults: {run: {working-directory: backend}}
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          working-directory: backend
+          cache-dependency-glob: |
+            backend/pyproject.toml
+            backend/uv.lock
+      - run: uv --version
       - run: uv lock --check
       - run: uv sync --locked --all-groups
       - run: uv run ruff format --check .
       - run: uv run ruff check .
       - run: uv run mypy src/quantlab
+
   unit-research:
     runs-on: ubuntu-latest
     defaults: {run: {working-directory: backend}}
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          working-directory: backend
+          cache-dependency-glob: |
+            backend/pyproject.toml
+            backend/uv.lock
       - run: uv sync --locked --all-groups
       - run: uv run pytest -q tests/test_research.py tests/test_research_engine.py
+
   api:
     runs-on: ubuntu-latest
     defaults: {run: {working-directory: backend}}
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          working-directory: backend
+          cache-dependency-glob: |
+            backend/pyproject.toml
+            backend/uv.lock
       - run: uv sync --locked --all-groups
       - run: uv run pytest -q tests/test_vertical_slice.py
+
   integration-postgres:
     runs-on: ubuntu-latest
+    defaults: {run: {working-directory: backend}}
     services:
       postgres:
         image: postgres:17-alpine
@@ -45,10 +85,17 @@ jobs:
       RUN_POSTGRES_TESTS: "1"
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ env.UV_VERSION }}
+          working-directory: backend
+          cache-dependency-glob: |
+            backend/pyproject.toml
+            backend/uv.lock
       - run: uv sync --locked --all-groups
-        working-directory: backend
       - run: uv run alembic -c ../alembic.ini upgrade head
-        working-directory: backend
       - run: uv run pytest -q tests/test_phase3_platform.py
-        working-directory: backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,27 @@ run unit and relevant integration tests, and update documentation.
 - Add regression tests for defects and explicit future-data leakage tests.
 - CI and development use only `PaperBroker`.
 - Live trading requires independent mode, enablement, and confirmation gates and fails closed.
+
+## Dependency and uv.lock policy
+- `backend/uv.lock` must be committed and is the authoritative dependency lockfile.
+- Never manually edit URLs, hashes, or package entries in `backend/uv.lock`; only `uv` may
+  generate the lockfile.
+- Every dependency change in `backend/pyproject.toml` must be followed by the commands below
+  and the relevant tests:
+
+  ```bash
+  cd backend
+  uv lock
+  uv lock --check
+  uv sync --locked --all-groups
+  ```
+
+- A changed `backend/uv.lock` may be committed only after
+  `uv sync --locked --all-groups` succeeds in the same environment.
+- If package registry or PyPI access is unavailable, do not generate or commit a new lockfile
+  from partial or fallback metadata. Report dependency verification as
+  `BLOCKED BY ENVIRONMENT`.
+- A dependency task is not `COMPLETE` until both `uv lock --check` and
+  `uv sync --locked --all-groups` succeed.
+- Do not add a dependency when the existing stack can reasonably solve the problem. Every new
+  dependency requires a concrete justification.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: setup test format lint typecheck dev
-setup:
+.PHONY: install setup check test format lint typecheck dev
+install:
 	cd backend && uv sync --locked --all-groups
+setup: install
+check:
+	cd backend && uv lock --check
+	cd backend && uv run ruff format --check .
+	cd backend && uv run ruff check .
+	cd backend && uv run mypy src/quantlab
 test:
 	cd backend && uv run pytest
 format:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ uv run uvicorn quantlab.api:app --reload
 
 Otevřete <http://127.0.0.1:8000>. Testy a kontroly: `make test`.
 
+## Závislosti a lockfile
+
+Projekt vyžaduje `uv 0.12.3`; verze je vynucena konfigurací backendu a stejně připnuta v CI.
+Commitnutý `backend/uv.lock` je autoritativní. Pro běžnou instalaci bez změny závislostí použijte
+pouze uzamčenou synchronizaci:
+
+```bash
+cd backend
+uv sync --locked --all-groups
+```
+
+Při záměrné změně závislostí v `backend/pyproject.toml` regenerujte lockfile výhradně pomocí `uv`
+a před commitem ověřte jeho konzistenci i úplnou instalaci:
+
+```bash
+cd backend
+uv lock
+uv lock --check
+uv sync --locked --all-groups
+```
+
 ## Bezpečnost
 
 Projekt implementuje výhradně `PaperBroker`. Výchozí a demo režim je paper, bez možnosti

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
   "ruff>=0.12,<1",
 ]
 
+[tool.uv]
+required-version = "==0.12.3"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]


### PR DESCRIPTION
### Motivation
- Zajistit deterministické, reprodukovatelné instalace závislostí tím, že CI i projekt použijí jedinou připnutou verzi `uv` (0.12.3) a lockfile (`backend/uv.lock`) bude autoritativní.
- Zabránit automatické nebo neověřené regeneraci `uv.lock` v CI a v PR tím, že CI pouze ověří lockfile a provede `uv sync --locked --all-groups`. 
- Zavést pravidla pro Codex/agent workflow, aby se ruční editace lockfile a commit neověřeného lockfile nikdy neopakovaly.

### Description
- Přidáno do `backend/pyproject.toml` nastavení `[tool.uv] required-version = "==0.12.3"` tak, aby projekt nativně vynucoval přesnou verzi `uv`.
- Přepsána `.github/workflows/ci.yml` tak, aby každá job nejprve nastavila `python 3.12`, pak instalovala přesně `uv 0.12.3` s `working-directory: backend`, volala `uv --version`, `uv lock --check` a `uv sync --locked --all-groups`, a nepoužívala mutující `uv lock` v CI. 
- Doplněno `AGENTS.md` o sekci "Dependency and uv.lock policy" s pravidly (autorita lockfile, zákaz ručních úprav, commit gate, postup při změně závislostí a chování při chybě registru/PyPI). 
- Upraven `Makefile` přidáním explicitních targetů `install` a `check` které využívají `uv sync --locked --all-groups` a `uv lock --check`, a doplněn `README.md` o stručný návod dependency workflow; `backend/uv.lock` nebyl měněn.

### Testing
- Spuštěno `UV_NO_CONFIG=1 uv lock --check` v `backend` pro diagnostiku konfigurace a tato neintervenční kontrola prošla (PASS) v dostupném prostředí. 
- Statické kontroly `python -m ruff format --check .` a `python -m ruff check .` proběhly bez nálezů (PASS). 
- Typová kontrola `python -m mypy src/quantlab` proběhla bez chyb (PASS). 
- Jednotkové/integrational testy spuštěné přímo v `backend` zahrnující `pytest` pro research sadu a část platformy proběhly (řada `pytest` běhů vykázala `25 passed`, `7 passed, 1 skipped` apod.), avšak uzavřená verifikace `uv sync --locked --all-groups` a úplné CI běhy byly v tomto prostředí zablokovány (BLOCKED BY ENVIRONMENT) kvůli nemožnosti stáhnout balíčky a nainstalovat `uv 0.12.3` přes síť/proxy (HTTP 403/tunnel error), takže finální „locked install“ a end-to-end CI ověření nebyly dokončeny.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae1ff9cc88332b9f03a2a5a38e597)