### PR TITLE
Implementace Phase 4: Persistentní Paper Broker, Production Risk Engine, trading cycle a reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
             backend/uv.lock
       - run: uv sync --locked --all-groups
       - run: uv run alembic -c ../alembic.ini upgrade head
-      - run: uv run pytest -q tests/test_phase3_platform.py
+      - run: uv run pytest -q tests/test_phase3_platform.py tests/test_phase4.py

--- a/README.md
+++ b/README.md
@@ -101,3 +101,8 @@ Registry uchovává neměnnou identitu datasetu, verzi strategie, experiment, fo
 eligibility a leaderboard metriky. API nabízí stránkované/filtrované experimenty, leaderboard a
 comparison. Ranking je lexikografický: eligibility, kladné OOS, cost stress, stabilita, drawdown,
 Sharpe a deterministické ID; není predikcí budoucí ziskovosti.
+
+
+## Phase 4: production paper foundation
+
+Persistentní účet, MARKET/LIMIT orders, partial fills, FIFO pozice, portfolio risk, idempotentní cycle, kill switch, reconciliation a audit jsou dostupné přes `/paper/account`, `/portfolio`, `/positions`, `/orders`, `/risk/*`, `/trading/cycles/*`, `/audit` a `/reconciliation/*`. Vše je pouze paper; live broker ani live order path neexistují.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,6 +6,7 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 from quantlab.persistence import Base
+import quantlab.phase4  # noqa: F401, E402
 
 config = context.config
 if config.config_file_name:
@@ -18,15 +19,23 @@ logger = logging.getLogger(__name__)
 
 
 def run_migrations_offline() -> None:
-    context.configure(url=config.get_main_option("sqlalchemy.url"), target_metadata=target_metadata,
-                      literal_binds=True, dialect_opts={"paramstyle": "named"})
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
     with context.begin_transaction():
         context.run_migrations()
 
 
 def run_migrations_online() -> None:
     try:
-        connectable = engine_from_config(config.get_section(config.config_ini_section, {}), prefix="sqlalchemy.", poolclass=pool.NullPool)
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section, {}),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
         with connectable.connect() as connection:
             logger.info("migration_startup")
             context.configure(connection=connection, target_metadata=target_metadata)
@@ -37,5 +46,7 @@ def run_migrations_online() -> None:
         raise
 
 
-if context.is_offline_mode(): run_migrations_offline()
-else: run_migrations_online()
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/20260811_01_phase4_paper_trading.py
+++ b/alembic/versions/20260811_01_phase4_paper_trading.py
@@ -1,19 +1,20 @@
-"""Zavedení produkční research registry.
+"""Persistentní paper trading a risk základ Phase 4.
 
-Revision ID: 20260810_01
-Revises:
+Revision ID: 20260811_01
+Revises: 20260810_01
 """
 
 from alembic import op
 
 from quantlab.persistence import Base
+import quantlab.phase4  # noqa: F401, E402
 
-revision = "20260810_01"
-down_revision = None
+revision = "20260811_01"
+down_revision = "20260810_01"
 branch_labels = None
 depends_on = None
 
-PHASE4_TABLES = {
+TABLES = {
     "paper_accounts",
     "paper_positions",
     "trading_cycles",
@@ -29,14 +30,12 @@ PHASE4_TABLES = {
 def upgrade() -> None:
     bind = op.get_bind()
     for table in Base.metadata.sorted_tables:
-        if table.name in PHASE4_TABLES:
-            continue
-        table.create(bind, checkfirst=False)
+        if table.name in TABLES:
+            table.create(bind, checkfirst=False)
 
 
 def downgrade() -> None:
     bind = op.get_bind()
     for table in reversed(Base.metadata.sorted_tables):
-        if table.name in PHASE4_TABLES:
-            continue
-        table.drop(bind, checkfirst=False)
+        if table.name in TABLES:
+            table.drop(bind, checkfirst=False)

--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Annotated
 
@@ -7,8 +8,19 @@ from fastapi.responses import HTMLResponse
 
 from quantlab.backtest import serialize_result
 from quantlab.config import get_settings
-from quantlab.demo import run_demo
+from quantlab.demo import load_fixture, run_demo
 from quantlab.persistence import RunRepository
+from quantlab.phase4 import (
+    AuditEventRecord,
+    PaperOrderRecord,
+    Phase4Repository,
+    ReconciliationRecord,
+    ReconciliationService,
+    RiskDecisionRecord,
+    RiskEventRecord,
+    TradingCycleRecord,
+    TradingCycleService,
+)
 from quantlab.research_service import ResearchService
 
 app = FastAPI(title="Autonomous Quant Lab", version="0.1.0")
@@ -18,11 +30,129 @@ repository = RunRepository(
 )
 fixture = Path(__file__).parents[2] / "tests" / "fixtures" / "sample_market_data.csv"
 research_service = ResearchService(repository)
+paper_repository = Phase4Repository(settings.database_url, bootstrap_test_schema=False)
+paper_repository.seed_account()
+trading_service = TradingCycleService(paper_repository)
+reconciliation_service = ReconciliationService(paper_repository)
+
+
+def _row(row: object) -> dict[str, object]:
+    return {key: value for key, value in vars(row).items() if not key.startswith("_")}
 
 
 @app.get("/health")
 def health() -> dict[str, str]:
     return {"status": "ok", "trading_mode": "paper", "live_trading_enabled": "false"}
+
+
+@app.get("/paper/account")
+@app.get("/portfolio")
+def paper_account() -> dict[str, object]:
+    return vars(paper_repository.account("paper-main"))
+
+
+@app.get("/positions")
+def paper_positions() -> list[dict[str, object]]:
+    return [vars(position) for position in paper_repository.positions("paper-main")]
+
+
+@app.get("/orders")
+def paper_orders(
+    limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return [_row(row) for row in paper_repository.page(PaperOrderRecord, limit, offset)]
+
+
+@app.get("/orders/{order_id}")
+def paper_order(order_id: str) -> dict[str, object]:
+    order = trading_service.broker.get_order(order_id)
+    if order is None:
+        raise HTTPException(status_code=404, detail="Příkaz nebyl nalezen")
+    return _row(order)
+
+
+@app.get("/risk/status")
+def risk_status() -> dict[str, object]:
+    account = paper_repository.account("paper-main")
+    return {"account_id": account.id, "trading_state": account.trading_state}
+
+
+@app.get("/risk/events")
+def risk_events(
+    limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return [_row(row) for row in paper_repository.page(RiskEventRecord, limit, offset)]
+
+
+@app.get("/risk/decisions")
+def risk_decisions(
+    limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return [_row(row) for row in paper_repository.page(RiskDecisionRecord, limit, offset)]
+
+
+@app.post("/risk/halt")
+def risk_halt() -> dict[str, str]:
+    paper_repository.halt("paper-main", "manual API halt", str(datetime.now(UTC).timestamp()))
+    return {"trading_state": "HALTED"}
+
+
+@app.post("/risk/resume")
+def risk_resume() -> dict[str, str]:
+    try:
+        paper_repository.resume("paper-main", str(datetime.now(UTC).timestamp()))
+    except PermissionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return {"trading_state": "NORMAL"}
+
+
+@app.get("/trading/cycles")
+def trading_cycles(
+    limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return [_row(row) for row in paper_repository.page(TradingCycleRecord, limit, offset)]
+
+
+@app.get("/trading/cycles/{cycle_id}")
+def trading_cycle(cycle_id: str) -> dict[str, object]:
+    rows = paper_repository.page(TradingCycleRecord, 200, 0)
+    row = next((item for item in rows if _row(item).get("id") == cycle_id), None)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Cycle nebyl nalezen")
+    return _row(row)
+
+
+@app.post("/trading/cycles/run-paper")
+def run_paper_cycle() -> dict[str, str]:
+    bars = load_fixture(fixture)
+    cycle_id = trading_service.run(
+        "paper-main",
+        "moving_average:1.0.0",
+        bars[-2:],
+        {"SPY": Decimal("0.10")},
+        bars[-1].timestamp.date(),
+        bars[-2].timestamp,
+    )
+    return {"id": cycle_id, "mode": "paper"}
+
+
+@app.get("/audit")
+def audit(
+    limit: int = Query(50, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return [_row(row) for row in paper_repository.page(AuditEventRecord, limit, offset)]
+
+
+@app.get("/reconciliation/status")
+def reconciliation_status(
+    limit: int = Query(1, ge=1, le=200), offset: int = Query(0, ge=0)
+) -> list[dict[str, object]]:
+    return [_row(row) for row in paper_repository.page(ReconciliationRecord, limit, offset)]
+
+
+@app.post("/reconciliation/run")
+def reconciliation_run() -> dict[str, object]:
+    return vars(reconciliation_service.reconcile("paper-main"))
 
 
 @app.post("/api/backtests/demo")

--- a/backend/src/quantlab/domain.py
+++ b/backend/src/quantlab/domain.py
@@ -18,6 +18,89 @@ class Side(StrEnum):
     SELL = "SELL"
 
 
+class OrderType(StrEnum):
+    MARKET = "MARKET"
+    LIMIT = "LIMIT"
+
+
+class OrderStatus(StrEnum):
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    SUBMITTED = "SUBMITTED"
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"
+    FILLED = "FILLED"
+    CANCELLED = "CANCELLED"
+    FAILED = "FAILED"
+
+
+class RiskDecisionStatus(StrEnum):
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    MODIFIED = "MODIFIED"
+
+
+class RiskReason(StrEnum):
+    ALLOWED = "ALLOWED"
+    INVALID_PRICE = "INVALID_PRICE"
+    INSTRUMENT_NOT_ALLOWED = "INSTRUMENT_NOT_ALLOWED"
+    SINGLE_ORDER_LIMIT = "SINGLE_ORDER_LIMIT"
+    POSITION_LIMIT = "POSITION_LIMIT"
+    GROSS_EXPOSURE = "GROSS_EXPOSURE"
+    NET_EXPOSURE = "NET_EXPOSURE"
+    MAX_POSITIONS = "MAX_POSITIONS"
+    DAILY_ORDER_LIMIT = "DAILY_ORDER_LIMIT"
+    DAILY_NOTIONAL_LIMIT = "DAILY_NOTIONAL_LIMIT"
+    INSUFFICIENT_CASH = "INSUFFICIENT_CASH"
+    LONG_ONLY = "LONG_ONLY"
+    STALE_DATA = "STALE_DATA"
+    TRADING_HALTED = "TRADING_HALTED"
+    DAILY_LOSS = "DAILY_LOSS"
+    DRAWDOWN = "DRAWDOWN"
+
+
+class SystemTradingState(StrEnum):
+    NORMAL = "NORMAL"
+    HALTED = "HALTED"
+
+
+class TradingCycleStatus(StrEnum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    HALTED = "HALTED"
+
+
+class ReconciliationStatus(StrEnum):
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+class AuditEventType(StrEnum):
+    TRADING_CYCLE_STARTED = "TRADING_CYCLE_STARTED"
+    DATA_VALIDATED = "DATA_VALIDATED"
+    DATA_REJECTED = "DATA_REJECTED"
+    TARGET_GENERATED = "TARGET_GENERATED"
+    ORDER_INTENT_CREATED = "ORDER_INTENT_CREATED"
+    RISK_APPROVED = "RISK_APPROVED"
+    RISK_MODIFIED = "RISK_MODIFIED"
+    RISK_REJECTED = "RISK_REJECTED"
+    ORDER_SUBMITTED = "ORDER_SUBMITTED"
+    ORDER_PARTIALLY_FILLED = "ORDER_PARTIALLY_FILLED"
+    ORDER_FILLED = "ORDER_FILLED"
+    ORDER_CANCELLED = "ORDER_CANCELLED"
+    ORDER_FAILED = "ORDER_FAILED"
+    RECONCILIATION_STARTED = "RECONCILIATION_STARTED"
+    RECONCILIATION_SUCCEEDED = "RECONCILIATION_SUCCEEDED"
+    RECONCILIATION_FAILED = "RECONCILIATION_FAILED"
+    KILL_SWITCH_TRIGGERED = "KILL_SWITCH_TRIGGERED"
+    KILL_SWITCH_MANUAL_HALT = "KILL_SWITCH_MANUAL_HALT"
+    KILL_SWITCH_RESUMED = "KILL_SWITCH_RESUMED"
+    TRADING_CYCLE_COMPLETED = "TRADING_CYCLE_COMPLETED"
+    TRADING_CYCLE_FAILED = "TRADING_CYCLE_FAILED"
+
+
 @dataclass(frozen=True)
 class Bar:
     symbol: str
@@ -50,6 +133,90 @@ class OrderIntent:
     decision_time: datetime
     reason: str
     id: str = field(default_factory=lambda: str(uuid4()))
+    order_type: OrderType = OrderType.MARKET
+    limit_price: Decimal | None = None
+    trading_cycle_id: str | None = None
+    correlation_id: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "decision_time", require_utc(self.decision_time))
+        if self.quantity <= 0:
+            raise ValueError("Množství příkazu musí být kladné")
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    decision_id: str
+    timestamp: datetime
+    order_intent_id: str
+    status: RiskDecisionStatus
+    original_quantity: Decimal
+    approved_quantity: Decimal
+    reasons: tuple[RiskReason, ...]
+    evaluated_limits: dict[str, str]
+    portfolio_snapshot: dict[str, str]
+    correlation_id: str
+    trading_cycle_id: str
+
+
+@dataclass(frozen=True)
+class Position:
+    account_id: str
+    instrument_id: str
+    quantity: Decimal
+    average_cost: Decimal
+    realized_pnl: Decimal
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class PaperAccount:
+    id: str
+    base_currency: str
+    starting_cash: Decimal
+    cash: Decimal
+    equity: Decimal
+    high_water_mark: Decimal
+    realized_pnl: Decimal
+    trading_state: SystemTradingState
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class TradingCycle:
+    id: str
+    cycle_key: str
+    account_id: str
+    strategy_id: str
+    session_date: str
+    status: TradingCycleStatus
+    correlation_id: str
+    data_fingerprint: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    id: str
+    timestamp: datetime
+    event_type: AuditEventType
+    entity_type: str
+    entity_id: str
+    trading_cycle_id: str | None
+    correlation_id: str
+    payload: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    id: str
+    account_id: str
+    status: ReconciliationStatus
+    timestamp: datetime
+    differences: dict[str, object]
 
 
 @dataclass(frozen=True)

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -5,6 +5,7 @@ import json
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from decimal import ROUND_DOWN, Decimal
+from typing import Any, cast
 from uuid import uuid4
 
 from sqlalchemy import (
@@ -20,8 +21,11 @@ from sqlalchemy import (
     create_engine,
     event,
     func,
+    or_,
     select,
+    update,
 )
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
@@ -92,6 +96,8 @@ class TradingCycleRecord(Base):
     correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     data_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
     failure_reason: Mapped[str | None] = mapped_column(Text)
+    lease_owner: Mapped[str | None] = mapped_column(String(64), index=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
 
 
 class RiskDecisionRecord(Base):
@@ -132,6 +138,7 @@ class PaperOrderRecord(Base):
     side: Mapped[str] = mapped_column(String(10), nullable=False)
     order_type: Mapped[str] = mapped_column(String(10), nullable=False)
     quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    submitted_notional: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
     filled_quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
     remaining_quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
     limit_price: Mapped[Decimal | None] = mapped_column(Numeric(24, 8))
@@ -421,7 +428,11 @@ class ProductionRiskEngine:
                 Decimal(0),
                 tuple(reasons),
                 {key: str(value) for key, value in vars(self.config).items()},
-                {"cash": str(snapshot.cash), "equity": str(snapshot.equity)},
+                {
+                    "cash": str(snapshot.cash),
+                    "equity": str(snapshot.equity),
+                    "reference_price": str(price),
+                },
                 correlation_id,
                 cycle_id,
             )
@@ -476,6 +487,7 @@ class ProductionRiskEngine:
             {
                 "cash": str(snapshot.cash),
                 "equity": str(snapshot.equity),
+                "reference_price": str(price),
                 "resulting_position": str(resulting),
                 "gross": str(gross),
                 "net": str(net),
@@ -573,6 +585,10 @@ class PersistentPaperBroker:
                 side=intent.side,
                 order_type=intent.order_type,
                 quantity=decision.approved_quantity,
+                submitted_notional=(
+                    decision.approved_quantity
+                    * Decimal(decision.portfolio_snapshot["reference_price"])
+                ),
                 filled_quantity=Decimal(0),
                 remaining_quantity=decision.approved_quantity,
                 limit_price=intent.limit_price,
@@ -582,16 +598,16 @@ class PersistentPaperBroker:
                 correlation_id=decision.correlation_id,
             )
             session.add(row)
-            session.flush()
-            self.repository.audit(
-                session,
-                AuditEventType.ORDER_SUBMITTED,
-                "order",
-                row.id,
-                row.trading_cycle_id,
-                row.correlation_id,
-            )
             try:
+                session.flush()
+                self.repository.audit(
+                    session,
+                    AuditEventType.ORDER_SUBMITTED,
+                    "order",
+                    row.id,
+                    row.trading_cycle_id,
+                    row.correlation_id,
+                )
                 session.commit()
             except IntegrityError:
                 session.rollback()
@@ -640,6 +656,13 @@ class PersistentPaperBroker:
             if quantity <= 0:
                 return order
             price = self.slippage.apply(reference, side)
+            if order.order_type == OrderType.LIMIT:
+                assert order.limit_price is not None
+                price = (
+                    min(price, order.limit_price)
+                    if side is Side.BUY
+                    else max(price, order.limit_price)
+                )
             commission = self.costs.commission(price * quantity)
             account = session.get(PaperAccountRecord, order.account_id)
             if account is None:
@@ -794,6 +817,29 @@ class PersistentPaperBroker:
             return order
 
 
+class PersistentExecutionEngine:
+    """Jediná aplikační hranice mezi schváleným risk rozhodnutím a brokerem."""
+
+    def __init__(self, broker: PersistentPaperBroker) -> None:
+        self.broker = broker
+
+    def submit(
+        self,
+        account_id: str,
+        strategy_id: str,
+        intent: OrderIntent,
+        decision: RiskDecision,
+    ) -> PaperOrderRecord:
+        if decision.order_intent_id != intent.id:
+            raise PermissionError("ExecutionEngine odmítl risk rozhodnutí jiného intentu")
+        if decision.status not in (
+            RiskDecisionStatus.APPROVED,
+            RiskDecisionStatus.MODIFIED,
+        ):
+            raise PermissionError("ExecutionEngine odmítl neschválený příkaz")
+        return self.broker.submit_order(account_id, strategy_id, intent, decision)
+
+
 class ReconciliationService:
     def __init__(self, repository: Phase4Repository):
         self.repository = repository
@@ -897,12 +943,23 @@ class ReconciliationService:
 
 class TradingCycleService:
     def __init__(
-        self, repository: Phase4Repository, risk_config: ProductionRiskConfig | None = None
+        self,
+        repository: Phase4Repository,
+        risk_config: ProductionRiskConfig | None = None,
+        lease_duration: timedelta = timedelta(minutes=5),
     ):
         self.repository = repository
         self.risk = ProductionRiskEngine(risk_config or ProductionRiskConfig())
         self.broker = PersistentPaperBroker(repository)
+        self.execution = PersistentExecutionEngine(self.broker)
         self.reconciliation = ReconciliationService(repository)
+        self.lease_duration = lease_duration
+
+    def _assert_cycle_lease(self, cycle_id: str, lease_owner: str) -> None:
+        with Session(self.repository.engine) as session:
+            cycle = session.get(TradingCycleRecord, cycle_id)
+            if cycle is None or cycle.lease_owner != lease_owner:
+                raise RuntimeError("Trading cycle ztratil databázový lease")
 
     def run(
         self,
@@ -919,6 +976,9 @@ class TradingCycleService:
         cycle_key = deterministic_cycle_key(account_id, strategy_id, session_date)
         cycle_id = cycle_key
         correlation_id = cycle_key
+        lease_owner = str(uuid4())
+        lease_now = datetime.now(UTC)
+        lease_expires_at = lease_now + self.lease_duration
         with Session(self.repository.engine) as session:
             existing = session.scalar(
                 select(TradingCycleRecord).where(TradingCycleRecord.cycle_key == cycle_key)
@@ -926,7 +986,30 @@ class TradingCycleService:
             if existing and existing.status == TradingCycleStatus.COMPLETED:
                 return existing.id
             if existing and existing.status == TradingCycleStatus.RUNNING:
-                return existing.id
+                expires_at = existing.lease_expires_at
+                if expires_at is not None and expires_at.tzinfo is None:
+                    expires_at = expires_at.replace(tzinfo=UTC)
+                if expires_at is not None and expires_at > lease_now:
+                    return existing.id
+                claimed = cast(
+                    CursorResult[Any],
+                    session.execute(
+                        update(TradingCycleRecord)
+                        .where(
+                            TradingCycleRecord.id == existing.id,
+                            TradingCycleRecord.status == TradingCycleStatus.RUNNING,
+                            or_(
+                                TradingCycleRecord.lease_expires_at.is_(None),
+                                TradingCycleRecord.lease_expires_at <= lease_now,
+                            ),
+                        )
+                        .values(lease_owner=lease_owner, lease_expires_at=lease_expires_at)
+                        .execution_options(synchronize_session=False)
+                    ),
+                )
+                session.commit()
+                if claimed.rowcount != 1:
+                    return existing.id
             if existing is None:
                 session.add(
                     TradingCycleRecord(
@@ -939,6 +1022,8 @@ class TradingCycleService:
                         status=TradingCycleStatus.RUNNING,
                         correlation_id=correlation_id,
                         data_fingerprint=dataset_identity(bars),
+                        lease_owner=lease_owner,
+                        lease_expires_at=lease_expires_at,
                     )
                 )
                 try:
@@ -962,6 +1047,8 @@ class TradingCycleService:
                     return recovered.id
             else:
                 existing.status = TradingCycleStatus.RUNNING
+                existing.lease_owner = lease_owner
+                existing.lease_expires_at = lease_expires_at
                 session.commit()
         bar = bars[-1]
         with Session(self.repository.engine) as session:
@@ -974,22 +1061,42 @@ class TradingCycleService:
                 session.commit()
         account = self.repository.account(account_id)
         positions = {p.instrument_id: p.quantity for p in self.repository.positions(account_id)}
+        pending: dict[str, Decimal] = {}
+        for open_order in self.broker.get_open_orders(account_id):
+            signed_remaining = (
+                open_order.remaining_quantity
+                if open_order.side == Side.BUY
+                else -open_order.remaining_quantity
+            )
+            pending[open_order.instrument_id] = (
+                pending.get(open_order.instrument_id, Decimal(0)) + signed_remaining
+            )
         prices = {bar.symbol: bar.close}
         with Session(self.repository.engine) as session:
             daily_orders = int(
                 session.scalar(
-                    select(func.count(PaperOrderRecord.id)).where(
+                    select(func.count(PaperOrderRecord.id))
+                    .join(
+                        TradingCycleRecord,
+                        TradingCycleRecord.id == PaperOrderRecord.trading_cycle_id,
+                    )
+                    .where(
                         PaperOrderRecord.account_id == account_id,
-                        func.date(PaperOrderRecord.submitted_at) == session_date,
+                        TradingCycleRecord.session_date == session_date,
                     )
                 )
                 or 0
             )
             daily_notional = Decimal(
                 session.scalar(
-                    select(func.coalesce(func.sum(PaperOrderRecord.quantity * bar.close), 0)).where(
+                    select(func.coalesce(func.sum(PaperOrderRecord.submitted_notional), 0))
+                    .join(
+                        TradingCycleRecord,
+                        TradingCycleRecord.id == PaperOrderRecord.trading_cycle_id,
+                    )
+                    .where(
                         PaperOrderRecord.account_id == account_id,
-                        func.date(PaperOrderRecord.submitted_at) == session_date,
+                        TradingCycleRecord.session_date == session_date,
                     )
                 )
                 or 0
@@ -998,7 +1105,7 @@ class TradingCycleService:
             if symbol != bar.symbol:
                 raise ValueError("Cycle vyžaduje executable bar každého target instrumentu")
             desired = (account.equity * weight / bar.open).to_integral_value(rounding=ROUND_DOWN)
-            delta = desired - positions.get(symbol, Decimal(0))
+            delta = desired - positions.get(symbol, Decimal(0)) - pending.get(symbol, Decimal(0))
             if delta == 0:
                 continue
             intent_id = hashlib.sha256(f"{cycle_id}|{symbol}|{desired}".encode()).hexdigest()
@@ -1025,7 +1132,7 @@ class TradingCycleService:
                 session_start_equity,
                 positions,
                 prices,
-                {},
+                pending,
                 daily_orders,
                 daily_notional,
                 account.trading_state,
@@ -1075,18 +1182,23 @@ class TradingCycleService:
                         account_id, ",".join(r.value for r in decision.reasons), correlation_id
                     )
                 continue
-            order = self.broker.submit_order(account_id, strategy_id, intent, decision)
+            self._assert_cycle_lease(cycle_id, lease_owner)
+            order = self.execution.submit(account_id, strategy_id, intent, decision)
             self.broker.process(order.id, bar)
         result = self.reconciliation.reconcile(account_id, correlation_id=correlation_id)
         with Session(self.repository.engine) as session:
             cycle = session.get(TradingCycleRecord, cycle_id)
             assert cycle is not None
+            if cycle.lease_owner != lease_owner:
+                raise RuntimeError("Trading cycle ztratil databázový lease před dokončením")
             cycle.completed_at = datetime.now(UTC)
             cycle.status = (
                 TradingCycleStatus.COMPLETED
                 if result.status is ReconciliationStatus.SUCCEEDED
                 else TradingCycleStatus.HALTED
             )
+            cycle.lease_owner = None
+            cycle.lease_expires_at = None
             self.repository.audit(
                 session,
                 AuditEventType.TRADING_CYCLE_COMPLETED,

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -1,0 +1,1099 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from decimal import ROUND_DOWN, Decimal
+from uuid import uuid4
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    event,
+    func,
+    select,
+)
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from quantlab.data import dataset_identity, validate_bars
+from quantlab.domain import (
+    AuditEventType,
+    Bar,
+    OrderIntent,
+    OrderStatus,
+    OrderType,
+    PaperAccount,
+    Position,
+    ReconciliationResult,
+    ReconciliationStatus,
+    RiskDecision,
+    RiskDecisionStatus,
+    RiskReason,
+    Side,
+    SystemTradingState,
+    TradingCycleStatus,
+)
+from quantlab.persistence import Base, _sqlite_fk
+from quantlab.trading import CostModel, FixedBpsSlippage
+
+
+class PaperAccountRecord(Base):
+    __tablename__ = "paper_accounts"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    base_currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    starting_cash: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    cash: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    equity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    high_water_mark: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    realized_pnl: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False, default=0)
+    trading_state: Mapped[str] = mapped_column(String(20), nullable=False)
+    session_date: Mapped[date | None] = mapped_column(Date)
+    session_start_equity: Mapped[Decimal | None] = mapped_column(Numeric(24, 8))
+    reconciliation_safe: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class PositionRecord(Base):
+    __tablename__ = "paper_positions"
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), primary_key=True
+    )
+    instrument_id: Mapped[str] = mapped_column(String(40), primary_key=True)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    average_cost: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    realized_pnl: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    lots_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class TradingCycleRecord(Base):
+    __tablename__ = "trading_cycles"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    cycle_key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    strategy_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    session_date: Mapped[date] = mapped_column(Date, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    status: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    data_fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    failure_reason: Mapped[str | None] = mapped_column(Text)
+
+
+class RiskDecisionRecord(Base):
+    __tablename__ = "risk_decisions"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    order_intent_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    trading_cycle_id: Mapped[str] = mapped_column(
+        ForeignKey("trading_cycles.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    status: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    original_quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    approved_quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    reasons_json: Mapped[str] = mapped_column(Text, nullable=False)
+    limits_json: Mapped[str] = mapped_column(Text, nullable=False)
+    portfolio_json: Mapped[str] = mapped_column(Text, nullable=False)
+    correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
+class PaperOrderRecord(Base):
+    __tablename__ = "paper_orders"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    client_order_id: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    trading_cycle_id: Mapped[str] = mapped_column(
+        ForeignKey("trading_cycles.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    order_intent_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    risk_decision_id: Mapped[str] = mapped_column(
+        ForeignKey("risk_decisions.id", ondelete="RESTRICT"), nullable=False, unique=True
+    )
+    instrument_id: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    side: Mapped[str] = mapped_column(String(10), nullable=False)
+    order_type: Mapped[str] = mapped_column(String(10), nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    filled_quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    remaining_quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    limit_price: Mapped[Decimal | None] = mapped_column(Numeric(24, 8))
+    status: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    cancelled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    failure_reason: Mapped[str | None] = mapped_column(Text)
+    correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
+class PaperFillRecord(Base):
+    __tablename__ = "paper_fills"
+    __table_args__ = (UniqueConstraint("order_id", "sequence"),)
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    order_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_orders.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    sequence: Mapped[int] = mapped_column(Integer, nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    price: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    reference_price: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    commission: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+
+
+class AuditEventRecord(Base):
+    __tablename__ = "audit_events"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    entity_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    trading_cycle_id: Mapped[str | None] = mapped_column(
+        ForeignKey("trading_cycles.id", ondelete="RESTRICT"), index=True
+    )
+    correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    payload_json: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class RiskEventRecord(Base):
+    __tablename__ = "risk_events"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
+class ReconciliationRecord(Base):
+    __tablename__ = "reconciliation_results"
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    differences_json: Mapped[str] = mapped_column(Text, nullable=False)
+    correlation_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+
+Index("ix_orders_account_created", PaperOrderRecord.account_id, PaperOrderRecord.created_at)
+
+
+@dataclass(frozen=True)
+class ProductionRiskConfig:
+    max_position_pct: Decimal = Decimal("0.25")
+    max_single_order_pct: Decimal = Decimal("0.10")
+    max_single_order_notional: Decimal = Decimal("25000")
+    max_gross_exposure: Decimal = Decimal("1.0")
+    max_net_exposure: Decimal = Decimal("1.0")
+    max_number_positions: int = 10
+    max_daily_loss: Decimal = Decimal("0.03")
+    max_portfolio_drawdown: Decimal = Decimal("0.10")
+    max_orders_per_day: int = 20
+    max_notional_per_day: Decimal = Decimal("100000")
+    instrument_allowlist: frozenset[str] = frozenset({"SPY"})
+    long_only: bool = True
+    max_leverage: Decimal = Decimal("1.0")
+    stale_data_threshold: timedelta = timedelta(days=4)
+    clip_quantity: bool = False
+
+
+class Phase4Repository:
+    def __init__(self, url: str = "sqlite:///:memory:", *, bootstrap_test_schema: bool = True):
+        connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
+        self.engine = create_engine(url, connect_args=connect_args)
+        if self.engine.dialect.name == "sqlite":
+            event.listen(self.engine, "connect", _sqlite_fk)
+        if bootstrap_test_schema:
+            Base.metadata.create_all(self.engine)
+
+    def seed_account(
+        self, account_id: str = "paper-main", cash: Decimal = Decimal("100000")
+    ) -> None:
+        now = datetime.now(UTC)
+        with Session(self.engine) as session:
+            if session.get(PaperAccountRecord, account_id) is None:
+                session.add(
+                    PaperAccountRecord(
+                        id=account_id,
+                        base_currency="USD",
+                        starting_cash=cash,
+                        cash=cash,
+                        equity=cash,
+                        high_water_mark=cash,
+                        realized_pnl=Decimal(0),
+                        trading_state=SystemTradingState.NORMAL,
+                        reconciliation_safe=True,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                )
+                session.commit()
+
+    def account(self, account_id: str) -> PaperAccount:
+        with Session(self.engine) as session:
+            row = session.get(PaperAccountRecord, account_id)
+            if row is None:
+                raise KeyError(account_id)
+            return PaperAccount(
+                row.id,
+                row.base_currency,
+                row.starting_cash,
+                row.cash,
+                row.equity,
+                row.high_water_mark,
+                row.realized_pnl,
+                SystemTradingState(row.trading_state),
+                row.created_at.replace(tzinfo=UTC)
+                if row.created_at.tzinfo is None
+                else row.created_at,
+                row.updated_at.replace(tzinfo=UTC)
+                if row.updated_at.tzinfo is None
+                else row.updated_at,
+            )
+
+    def positions(self, account_id: str) -> list[Position]:
+        with Session(self.engine) as session:
+            rows = session.scalars(
+                select(PositionRecord).where(PositionRecord.account_id == account_id)
+            ).all()
+            return [
+                Position(
+                    r.account_id,
+                    r.instrument_id,
+                    r.quantity,
+                    r.average_cost,
+                    r.realized_pnl,
+                    r.updated_at.replace(tzinfo=UTC)
+                    if r.updated_at.tzinfo is None
+                    else r.updated_at,
+                )
+                for r in rows
+            ]
+
+    def page(self, model: type[Base], limit: int, offset: int) -> list[Base]:
+        if not 1 <= limit <= 200 or offset < 0:
+            raise ValueError("Neplatná pagination")
+        with Session(self.engine) as session:
+            return list(session.scalars(select(model).limit(limit).offset(offset)).all())
+
+    def audit(
+        self,
+        session: Session,
+        event_type: AuditEventType,
+        entity_type: str,
+        entity_id: str,
+        cycle_id: str | None,
+        correlation_id: str,
+        payload: dict[str, object] | None = None,
+    ) -> None:
+        session.add(
+            AuditEventRecord(
+                id=str(uuid4()),
+                timestamp=datetime.now(UTC),
+                event_type=event_type,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                trading_cycle_id=cycle_id,
+                correlation_id=correlation_id,
+                payload_json=json.dumps(payload or {}, default=str, sort_keys=True),
+            )
+        )
+
+    def halt(
+        self,
+        account_id: str,
+        reason: str,
+        correlation_id: str,
+        event_type: AuditEventType = AuditEventType.KILL_SWITCH_TRIGGERED,
+    ) -> None:
+        with Session(self.engine) as session:
+            account = session.get(PaperAccountRecord, account_id)
+            if account is None:
+                raise KeyError(account_id)
+            account.trading_state = SystemTradingState.HALTED
+            account.updated_at = datetime.now(UTC)
+            session.add(
+                RiskEventRecord(
+                    id=str(uuid4()),
+                    account_id=account_id,
+                    timestamp=datetime.now(UTC),
+                    event_type=event_type,
+                    reason=reason,
+                    correlation_id=correlation_id,
+                )
+            )
+            self.audit(
+                session, event_type, "account", account_id, None, correlation_id, {"reason": reason}
+            )
+            session.commit()
+
+    def resume(self, account_id: str, correlation_id: str) -> None:
+        with Session(self.engine) as session:
+            account = session.get(PaperAccountRecord, account_id)
+            if account is None or not account.reconciliation_safe:
+                raise PermissionError("Resume vyžaduje úspěšnou reconciliation")
+            account.trading_state = SystemTradingState.NORMAL
+            account.updated_at = datetime.now(UTC)
+            self.audit(
+                session,
+                AuditEventType.KILL_SWITCH_RESUMED,
+                "account",
+                account_id,
+                None,
+                correlation_id,
+            )
+            session.commit()
+
+
+@dataclass(frozen=True)
+class PortfolioRiskSnapshot:
+    cash: Decimal
+    equity: Decimal
+    high_water_mark: Decimal
+    session_start_equity: Decimal
+    positions: dict[str, Decimal]
+    prices: dict[str, Decimal]
+    pending: dict[str, Decimal]
+    daily_orders: int
+    daily_notional: Decimal
+    trading_state: SystemTradingState
+
+
+class ProductionRiskEngine:
+    def __init__(self, config: ProductionRiskConfig):
+        self.config = config
+
+    def evaluate(
+        self,
+        intent: OrderIntent,
+        price: Decimal,
+        snapshot: PortfolioRiskSnapshot,
+        cycle_id: str,
+        correlation_id: str,
+        now: datetime,
+        latest_market_timestamp: datetime,
+    ) -> RiskDecision:
+        reasons: list[RiskReason] = []
+        current = snapshot.positions.get(intent.symbol, Decimal(0))
+        pending = snapshot.pending.get(intent.symbol, Decimal(0))
+        signed = intent.quantity if intent.side is Side.BUY else -intent.quantity
+        resulting = current + pending + signed
+        reducing = abs(resulting) < abs(current + pending) and resulting >= 0
+        if not price.is_finite() or price <= 0:
+            reasons.append(RiskReason.INVALID_PRICE)
+        if intent.symbol not in self.config.instrument_allowlist:
+            reasons.append(RiskReason.INSTRUMENT_NOT_ALLOWED)
+        if now - latest_market_timestamp > self.config.stale_data_threshold:
+            reasons.append(RiskReason.STALE_DATA)
+        if snapshot.trading_state is SystemTradingState.HALTED and not reducing:
+            reasons.append(RiskReason.TRADING_HALTED)
+        if self.config.long_only and resulting < 0:
+            reasons.append(RiskReason.LONG_ONLY)
+        if RiskReason.INVALID_PRICE in reasons:
+            return RiskDecision(
+                hashlib.sha256(f"{cycle_id}|{intent.id}".encode()).hexdigest(),
+                now,
+                intent.id,
+                RiskDecisionStatus.REJECTED,
+                intent.quantity,
+                Decimal(0),
+                tuple(reasons),
+                {key: str(value) for key, value in vars(self.config).items()},
+                {"cash": str(snapshot.cash), "equity": str(snapshot.equity)},
+                correlation_id,
+                cycle_id,
+            )
+        notional = intent.quantity * price
+        if notional > self.config.max_single_order_notional or (
+            snapshot.equity <= 0 or notional / snapshot.equity > self.config.max_single_order_pct
+        ):
+            reasons.append(RiskReason.SINGLE_ORDER_LIMIT)
+        future_values = {
+            s: q * snapshot.prices.get(s, price) for s, q in snapshot.positions.items()
+        }
+        future_values[intent.symbol] = resulting * price
+        gross = sum((abs(v) for v in future_values.values()), Decimal(0)) / snapshot.equity
+        net = sum(future_values.values(), Decimal(0)) / snapshot.equity
+        if abs(future_values[intent.symbol]) / snapshot.equity > self.config.max_position_pct:
+            reasons.append(RiskReason.POSITION_LIMIT)
+        if gross > min(self.config.max_gross_exposure, self.config.max_leverage):
+            reasons.append(RiskReason.GROSS_EXPOSURE)
+        if abs(net) > self.config.max_net_exposure:
+            reasons.append(RiskReason.NET_EXPOSURE)
+        open_count = sum(q != 0 for q in snapshot.positions.values())
+        if current == 0 and resulting != 0 and open_count >= self.config.max_number_positions:
+            reasons.append(RiskReason.MAX_POSITIONS)
+        if snapshot.daily_orders >= self.config.max_orders_per_day:
+            reasons.append(RiskReason.DAILY_ORDER_LIMIT)
+        if snapshot.daily_notional + notional > self.config.max_notional_per_day:
+            reasons.append(RiskReason.DAILY_NOTIONAL_LIMIT)
+        if intent.side is Side.BUY and notional > snapshot.cash:
+            reasons.append(RiskReason.INSUFFICIENT_CASH)
+        if (
+            snapshot.session_start_equity > 0
+            and (snapshot.session_start_equity - snapshot.equity) / snapshot.session_start_equity
+            >= self.config.max_daily_loss
+        ):
+            reasons.append(RiskReason.DAILY_LOSS)
+        if (
+            snapshot.high_water_mark > 0
+            and (snapshot.high_water_mark - snapshot.equity) / snapshot.high_water_mark
+            >= self.config.max_portfolio_drawdown
+        ):
+            reasons.append(RiskReason.DRAWDOWN)
+        status = RiskDecisionStatus.REJECTED if reasons else RiskDecisionStatus.APPROVED
+        return RiskDecision(
+            hashlib.sha256(f"{cycle_id}|{intent.id}".encode()).hexdigest(),
+            now,
+            intent.id,
+            status,
+            intent.quantity,
+            intent.quantity if not reasons else Decimal(0),
+            tuple(reasons or [RiskReason.ALLOWED]),
+            {k: str(v) for k, v in vars(self.config).items()},
+            {
+                "cash": str(snapshot.cash),
+                "equity": str(snapshot.equity),
+                "resulting_position": str(resulting),
+                "gross": str(gross),
+                "net": str(net),
+            },
+            correlation_id,
+            cycle_id,
+        )
+
+
+def deterministic_cycle_key(account_id: str, strategy_id: str, session_date: date) -> str:
+    return hashlib.sha256(
+        f"{account_id}|{strategy_id}|{session_date.isoformat()}".encode()
+    ).hexdigest()
+
+
+def deterministic_client_order_id(
+    account_id: str, cycle_id: str, strategy_id: str, intent: OrderIntent
+) -> str:
+    value = f"{account_id}|{cycle_id}|{strategy_id}|{intent.symbol}|{intent.side}|{intent.id}"
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+class PersistentPaperBroker:
+    def __init__(
+        self,
+        repository: Phase4Repository,
+        costs: CostModel | None = None,
+        slippage: FixedBpsSlippage | None = None,
+        volume_fraction: Decimal = Decimal("0.10"),
+    ):
+        self.repository = repository
+        self.costs = costs or CostModel()
+        self.slippage = slippage or FixedBpsSlippage()
+        self.volume_fraction = volume_fraction
+
+    def get_account(self, account_id: str) -> PaperAccount:
+        return self.repository.account(account_id)
+
+    def get_positions(self, account_id: str) -> list[Position]:
+        return self.repository.positions(account_id)
+
+    def get_open_orders(self, account_id: str) -> list[PaperOrderRecord]:
+        with Session(self.repository.engine) as session:
+            return list(
+                session.scalars(
+                    select(PaperOrderRecord).where(
+                        PaperOrderRecord.account_id == account_id,
+                        PaperOrderRecord.status.in_(
+                            [OrderStatus.SUBMITTED, OrderStatus.PARTIALLY_FILLED]
+                        ),
+                    )
+                ).all()
+            )
+
+    def get_order(self, order_id: str) -> PaperOrderRecord | None:
+        with Session(self.repository.engine) as session:
+            return session.get(PaperOrderRecord, order_id)
+
+    def get_fills(self, account_id: str) -> list[PaperFillRecord]:
+        with Session(self.repository.engine) as session:
+            return list(
+                session.scalars(
+                    select(PaperFillRecord)
+                    .join(PaperOrderRecord)
+                    .where(PaperOrderRecord.account_id == account_id)
+                ).all()
+            )
+
+    def submit_order(
+        self, account_id: str, strategy_id: str, intent: OrderIntent, decision: RiskDecision
+    ) -> PaperOrderRecord:
+        if (
+            decision.order_intent_id != intent.id
+            or decision.status not in (RiskDecisionStatus.APPROVED, RiskDecisionStatus.MODIFIED)
+            or decision.approved_quantity <= 0
+        ):
+            raise PermissionError("Broker vyžaduje platné risk schválení stejného intentu")
+        client_id = deterministic_client_order_id(
+            account_id, decision.trading_cycle_id, strategy_id, intent
+        )
+        with Session(self.repository.engine) as session:
+            existing = session.scalar(
+                select(PaperOrderRecord).where(PaperOrderRecord.client_order_id == client_id)
+            )
+            if existing:
+                return existing
+            row = PaperOrderRecord(
+                id=str(uuid4()),
+                client_order_id=client_id,
+                account_id=account_id,
+                trading_cycle_id=decision.trading_cycle_id,
+                order_intent_id=intent.id,
+                risk_decision_id=decision.decision_id,
+                instrument_id=intent.symbol,
+                side=intent.side,
+                order_type=intent.order_type,
+                quantity=decision.approved_quantity,
+                filled_quantity=Decimal(0),
+                remaining_quantity=decision.approved_quantity,
+                limit_price=intent.limit_price,
+                status=OrderStatus.SUBMITTED,
+                created_at=datetime.now(UTC),
+                submitted_at=intent.decision_time,
+                correlation_id=decision.correlation_id,
+            )
+            session.add(row)
+            session.flush()
+            self.repository.audit(
+                session,
+                AuditEventType.ORDER_SUBMITTED,
+                "order",
+                row.id,
+                row.trading_cycle_id,
+                row.correlation_id,
+            )
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                recovered = session.scalar(
+                    select(PaperOrderRecord).where(PaperOrderRecord.client_order_id == client_id)
+                )
+                if recovered is None:
+                    raise
+                return recovered
+            session.refresh(row)
+            return row
+
+    def process(self, order_id: str, bar: Bar) -> PaperOrderRecord:
+        with Session(self.repository.engine) as session:
+            order = session.get(PaperOrderRecord, order_id)
+            if order is None:
+                raise KeyError(order_id)
+            if order.status in (OrderStatus.FILLED, OrderStatus.CANCELLED):
+                return order
+            submitted_at = order.submitted_at
+            assert submitted_at is not None
+            if submitted_at.tzinfo is None:
+                submitted_at = submitted_at.replace(tzinfo=UTC)
+            if bar.timestamp <= submitted_at:
+                raise ValueError("Bar nesmí předcházet aktivaci příkazu")
+            side = Side(order.side)
+            if order.order_type == OrderType.LIMIT:
+                if order.limit_price is None:
+                    raise ValueError("Limit order nemá limit cenu")
+                reached = (
+                    bar.low <= order.limit_price
+                    if side is Side.BUY
+                    else bar.high >= order.limit_price
+                )
+                if not reached:
+                    return order
+                reference = (
+                    min(bar.open, order.limit_price)
+                    if side is Side.BUY
+                    else max(bar.open, order.limit_price)
+                )
+            else:
+                reference = bar.open
+            capacity = (bar.volume * self.volume_fraction).to_integral_value(rounding=ROUND_DOWN)
+            quantity = min(order.remaining_quantity, capacity)
+            if quantity <= 0:
+                return order
+            price = self.slippage.apply(reference, side)
+            commission = self.costs.commission(price * quantity)
+            account = session.get(PaperAccountRecord, order.account_id)
+            if account is None:
+                raise KeyError(order.account_id)
+            cash_delta = (
+                -(price * quantity + commission)
+                if side is Side.BUY
+                else price * quantity - commission
+            )
+            if account.cash + cash_delta < 0:
+                raise ValueError("Fill by vytvořil zápornou hotovost")
+            position = session.get(PositionRecord, (order.account_id, order.instrument_id))
+            if position is None:
+                position = PositionRecord(
+                    account_id=order.account_id,
+                    instrument_id=order.instrument_id,
+                    quantity=Decimal(0),
+                    average_cost=Decimal(0),
+                    realized_pnl=Decimal(0),
+                    lots_json="[]",
+                    updated_at=bar.timestamp,
+                )
+                session.add(position)
+            lots = json.loads(position.lots_json)
+            realized = Decimal(0)
+            if side is Side.BUY:
+                lots.append(
+                    {"quantity": str(quantity), "unit_basis": str(price + commission / quantity)}
+                )
+                position.quantity += quantity
+            else:
+                if quantity > position.quantity:
+                    raise ValueError("Nelze prodat více, než účet drží")
+                remaining = quantity
+                while remaining:
+                    lot = lots[0]
+                    lot_quantity = Decimal(lot["quantity"])
+                    allocated = min(remaining, lot_quantity)
+                    realized += allocated * (price - Decimal(lot["unit_basis"]))
+                    lot_quantity -= allocated
+                    remaining -= allocated
+                    if lot_quantity == 0:
+                        lots.pop(0)
+                    else:
+                        lot["quantity"] = str(lot_quantity)
+                realized -= commission
+                position.quantity -= quantity
+                position.realized_pnl += realized
+                account.realized_pnl += realized
+            position.lots_json = json.dumps(lots, sort_keys=True)
+            position.average_cost = (
+                sum(
+                    (
+                        Decimal(lot_item["quantity"]) * Decimal(lot_item["unit_basis"])
+                        for lot_item in lots
+                    ),
+                    Decimal(0),
+                )
+                / position.quantity
+                if position.quantity
+                else Decimal(0)
+            )
+            position.updated_at = bar.timestamp
+            account.cash += cash_delta
+            account.updated_at = bar.timestamp
+            sequence = (
+                int(
+                    session.scalar(
+                        select(func.count(PaperFillRecord.id)).where(
+                            PaperFillRecord.order_id == order.id
+                        )
+                    )
+                    or 0
+                )
+                + 1
+            )
+            fill = PaperFillRecord(
+                id=hashlib.sha256(f"{order.id}|{sequence}".encode()).hexdigest(),
+                order_id=order.id,
+                sequence=sequence,
+                quantity=quantity,
+                price=price,
+                reference_price=reference,
+                commission=commission,
+                timestamp=bar.timestamp,
+            )
+            session.add(fill)
+            order.filled_quantity += quantity
+            order.remaining_quantity = order.quantity - order.filled_quantity
+            order.status = (
+                OrderStatus.FILLED
+                if order.remaining_quantity == 0
+                else OrderStatus.PARTIALLY_FILLED
+            )
+            if order.status == OrderStatus.FILLED:
+                order.completed_at = bar.timestamp
+            prices = {
+                p.instrument_id: (bar.close if p.instrument_id == bar.symbol else p.average_cost)
+                for p in session.scalars(
+                    select(PositionRecord).where(PositionRecord.account_id == order.account_id)
+                ).all()
+            }
+            account.equity = account.cash + sum(
+                (
+                    p.quantity * prices[p.instrument_id]
+                    for p in session.scalars(
+                        select(PositionRecord).where(PositionRecord.account_id == order.account_id)
+                    ).all()
+                ),
+                Decimal(0),
+            )
+            account.high_water_mark = max(account.high_water_mark, account.equity)
+            event_type = (
+                AuditEventType.ORDER_FILLED
+                if order.status == OrderStatus.FILLED
+                else AuditEventType.ORDER_PARTIALLY_FILLED
+            )
+            self.repository.audit(
+                session,
+                event_type,
+                "order",
+                order.id,
+                order.trading_cycle_id,
+                order.correlation_id,
+                {"fill_id": fill.id, "quantity": str(quantity), "commission": str(commission)},
+            )
+            session.commit()
+            session.refresh(order)
+            return order
+
+    def cancel_order(self, order_id: str) -> PaperOrderRecord:
+        with Session(self.repository.engine) as session:
+            order = session.get(PaperOrderRecord, order_id)
+            if order is None:
+                raise KeyError(order_id)
+            if order.status == OrderStatus.CANCELLED:
+                return order
+            if order.status not in (OrderStatus.SUBMITTED, OrderStatus.PARTIALLY_FILLED):
+                raise ValueError("Příkaz v tomto stavu nelze zrušit")
+            order.status = OrderStatus.CANCELLED
+            order.cancelled_at = datetime.now(UTC)
+            self.repository.audit(
+                session,
+                AuditEventType.ORDER_CANCELLED,
+                "order",
+                order.id,
+                order.trading_cycle_id,
+                order.correlation_id,
+            )
+            session.commit()
+            session.refresh(order)
+            return order
+
+
+class ReconciliationService:
+    def __init__(self, repository: Phase4Repository):
+        self.repository = repository
+
+    def reconcile(
+        self,
+        account_id: str,
+        expected_cash: Decimal | None = None,
+        expected_positions: dict[str, Decimal] | None = None,
+        tolerance: Decimal = Decimal("0.000001"),
+        correlation_id: str | None = None,
+    ) -> ReconciliationResult:
+        correlation_id = correlation_id or str(uuid4())
+        differences: dict[str, object] = {}
+        with Session(self.repository.engine) as session:
+            account = session.get(PaperAccountRecord, account_id)
+            if account is None:
+                raise KeyError(account_id)
+            self.repository.audit(
+                session,
+                AuditEventType.RECONCILIATION_STARTED,
+                "account",
+                account_id,
+                None,
+                correlation_id,
+            )
+            fills = session.execute(
+                select(PaperFillRecord, PaperOrderRecord)
+                .join(PaperOrderRecord, PaperOrderRecord.id == PaperFillRecord.order_id)
+                .where(PaperOrderRecord.account_id == account_id)
+            ).all()
+            if expected_cash is None:
+                expected_cash = account.starting_cash
+                for fill, order in fills:
+                    if order.side == Side.BUY:
+                        expected_cash -= fill.price * fill.quantity + fill.commission
+                    else:
+                        expected_cash += fill.price * fill.quantity - fill.commission
+            if expected_positions is None:
+                expected_positions = {}
+                for fill, order in fills:
+                    signed = fill.quantity if order.side == Side.BUY else -fill.quantity
+                    expected_positions[order.instrument_id] = (
+                        expected_positions.get(order.instrument_id, Decimal(0)) + signed
+                    )
+            if expected_cash is not None and abs(account.cash - expected_cash) > tolerance:
+                differences["cash"] = {"expected": str(expected_cash), "actual": str(account.cash)}
+            actual_positions = {
+                p.instrument_id: p.quantity
+                for p in session.scalars(
+                    select(PositionRecord).where(PositionRecord.account_id == account_id)
+                ).all()
+            }
+            if expected_positions is not None:
+                for symbol in set(actual_positions) | set(expected_positions):
+                    difference = actual_positions.get(symbol, Decimal(0)) - expected_positions.get(
+                        symbol, Decimal(0)
+                    )
+                    if abs(difference) > tolerance:
+                        differences.setdefault("positions", {})[symbol] = str(difference)  # type: ignore[index]
+            for order in session.scalars(
+                select(PaperOrderRecord).where(PaperOrderRecord.account_id == account_id)
+            ).all():
+                filled = session.scalar(
+                    select(func.sum(PaperFillRecord.quantity)).where(
+                        PaperFillRecord.order_id == order.id
+                    )
+                ) or Decimal(0)
+                if (
+                    filled != order.filled_quantity
+                    or order.remaining_quantity != order.quantity - filled
+                    or filled > order.quantity
+                ):
+                    differences.setdefault("orders", {})[order.id] = "quantity invariant"  # type: ignore[index]
+            status = ReconciliationStatus.FAILED if differences else ReconciliationStatus.SUCCEEDED
+            account.reconciliation_safe = not differences
+            if differences:
+                account.trading_state = SystemTradingState.HALTED
+            result_id = str(uuid4())
+            session.add(
+                ReconciliationRecord(
+                    id=result_id,
+                    account_id=account_id,
+                    timestamp=datetime.now(UTC),
+                    status=status,
+                    differences_json=json.dumps(differences, sort_keys=True),
+                    correlation_id=correlation_id,
+                )
+            )
+            event_type = (
+                AuditEventType.RECONCILIATION_FAILED
+                if differences
+                else AuditEventType.RECONCILIATION_SUCCEEDED
+            )
+            self.repository.audit(
+                session, event_type, "account", account_id, None, correlation_id, differences
+            )
+            session.commit()
+        return ReconciliationResult(result_id, account_id, status, datetime.now(UTC), differences)
+
+
+class TradingCycleService:
+    def __init__(
+        self, repository: Phase4Repository, risk_config: ProductionRiskConfig | None = None
+    ):
+        self.repository = repository
+        self.risk = ProductionRiskEngine(risk_config or ProductionRiskConfig())
+        self.broker = PersistentPaperBroker(repository)
+        self.reconciliation = ReconciliationService(repository)
+
+    def run(
+        self,
+        account_id: str,
+        strategy_id: str,
+        bars: list[Bar],
+        target_weights: dict[str, Decimal],
+        session_date: date,
+        decision_time: datetime,
+    ) -> str:
+        validate_bars(bars)
+        if not bars:
+            raise ValueError("Chybí market data")
+        cycle_key = deterministic_cycle_key(account_id, strategy_id, session_date)
+        cycle_id = cycle_key
+        correlation_id = cycle_key
+        with Session(self.repository.engine) as session:
+            existing = session.scalar(
+                select(TradingCycleRecord).where(TradingCycleRecord.cycle_key == cycle_key)
+            )
+            if existing and existing.status == TradingCycleStatus.COMPLETED:
+                return existing.id
+            if existing and existing.status == TradingCycleStatus.RUNNING:
+                return existing.id
+            if existing is None:
+                session.add(
+                    TradingCycleRecord(
+                        id=cycle_id,
+                        cycle_key=cycle_key,
+                        account_id=account_id,
+                        strategy_id=strategy_id,
+                        session_date=session_date,
+                        started_at=datetime.now(UTC),
+                        status=TradingCycleStatus.RUNNING,
+                        correlation_id=correlation_id,
+                        data_fingerprint=dataset_identity(bars),
+                    )
+                )
+                session.flush()
+                self.repository.audit(
+                    session,
+                    AuditEventType.TRADING_CYCLE_STARTED,
+                    "cycle",
+                    cycle_id,
+                    cycle_id,
+                    correlation_id,
+                )
+                try:
+                    session.commit()
+                except IntegrityError:
+                    session.rollback()
+                    recovered = session.scalar(
+                        select(TradingCycleRecord).where(TradingCycleRecord.cycle_key == cycle_key)
+                    )
+                    if recovered is None:
+                        raise
+                    return recovered.id
+            else:
+                existing.status = TradingCycleStatus.RUNNING
+                session.commit()
+        bar = bars[-1]
+        with Session(self.repository.engine) as session:
+            account_row = session.get(PaperAccountRecord, account_id)
+            if account_row is None:
+                raise KeyError(account_id)
+            if account_row.session_date != session_date:
+                account_row.session_date = session_date
+                account_row.session_start_equity = account_row.equity
+                session.commit()
+        account = self.repository.account(account_id)
+        positions = {p.instrument_id: p.quantity for p in self.repository.positions(account_id)}
+        prices = {bar.symbol: bar.close}
+        with Session(self.repository.engine) as session:
+            daily_orders = int(
+                session.scalar(
+                    select(func.count(PaperOrderRecord.id)).where(
+                        PaperOrderRecord.account_id == account_id,
+                        func.date(PaperOrderRecord.submitted_at) == session_date,
+                    )
+                )
+                or 0
+            )
+            daily_notional = Decimal(
+                session.scalar(
+                    select(func.coalesce(func.sum(PaperOrderRecord.quantity * bar.close), 0)).where(
+                        PaperOrderRecord.account_id == account_id,
+                        func.date(PaperOrderRecord.submitted_at) == session_date,
+                    )
+                )
+                or 0
+            )
+        for symbol, weight in sorted(target_weights.items()):
+            if symbol != bar.symbol:
+                raise ValueError("Cycle vyžaduje executable bar každého target instrumentu")
+            desired = (account.equity * weight / bar.open).to_integral_value(rounding=ROUND_DOWN)
+            delta = desired - positions.get(symbol, Decimal(0))
+            if delta == 0:
+                continue
+            intent_id = hashlib.sha256(f"{cycle_id}|{symbol}|{desired}".encode()).hexdigest()
+            intent = OrderIntent(
+                symbol,
+                Side.BUY if delta > 0 else Side.SELL,
+                abs(delta),
+                decision_time,
+                "target-vs-actual",
+                intent_id,
+                OrderType.MARKET,
+                None,
+                cycle_id,
+                correlation_id,
+            )
+            with Session(self.repository.engine) as session:
+                account_row = session.get(PaperAccountRecord, account_id)
+                assert account_row is not None
+                session_start_equity = account_row.session_start_equity or account.equity
+            snapshot = PortfolioRiskSnapshot(
+                account.cash,
+                account.equity,
+                account.high_water_mark,
+                session_start_equity,
+                positions,
+                prices,
+                {},
+                daily_orders,
+                daily_notional,
+                account.trading_state,
+            )
+            decision = self.risk.evaluate(
+                intent, bar.open, snapshot, cycle_id, correlation_id, decision_time, bar.timestamp
+            )
+            with Session(self.repository.engine) as session:
+                if session.get(RiskDecisionRecord, decision.decision_id) is None:
+                    session.add(
+                        RiskDecisionRecord(
+                            id=decision.decision_id,
+                            timestamp=decision.timestamp,
+                            account_id=account_id,
+                            order_intent_id=intent.id,
+                            trading_cycle_id=cycle_id,
+                            status=decision.status,
+                            original_quantity=decision.original_quantity,
+                            approved_quantity=decision.approved_quantity,
+                            reasons_json=json.dumps([r.value for r in decision.reasons]),
+                            limits_json=json.dumps(decision.evaluated_limits, sort_keys=True),
+                            portfolio_json=json.dumps(decision.portfolio_snapshot, sort_keys=True),
+                            correlation_id=correlation_id,
+                        )
+                    )
+                    session.flush()
+                    audit_type = (
+                        AuditEventType.RISK_APPROVED
+                        if decision.status is RiskDecisionStatus.APPROVED
+                        else AuditEventType.RISK_REJECTED
+                    )
+                    self.repository.audit(
+                        session,
+                        audit_type,
+                        "risk_decision",
+                        decision.decision_id,
+                        cycle_id,
+                        correlation_id,
+                    )
+                    session.commit()
+            if decision.status is RiskDecisionStatus.REJECTED:
+                if (
+                    RiskReason.DAILY_LOSS in decision.reasons
+                    or RiskReason.DRAWDOWN in decision.reasons
+                ):
+                    self.repository.halt(
+                        account_id, ",".join(r.value for r in decision.reasons), correlation_id
+                    )
+                continue
+            order = self.broker.submit_order(account_id, strategy_id, intent, decision)
+            self.broker.process(order.id, bar)
+        result = self.reconciliation.reconcile(account_id, correlation_id=correlation_id)
+        with Session(self.repository.engine) as session:
+            cycle = session.get(TradingCycleRecord, cycle_id)
+            assert cycle is not None
+            cycle.completed_at = datetime.now(UTC)
+            cycle.status = (
+                TradingCycleStatus.COMPLETED
+                if result.status is ReconciliationStatus.SUCCEEDED
+                else TradingCycleStatus.HALTED
+            )
+            self.repository.audit(
+                session,
+                AuditEventType.TRADING_CYCLE_COMPLETED,
+                "cycle",
+                cycle_id,
+                cycle_id,
+                correlation_id,
+            )
+            session.commit()
+        return cycle_id

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -941,16 +941,16 @@ class TradingCycleService:
                         data_fingerprint=dataset_identity(bars),
                     )
                 )
-                session.flush()
-                self.repository.audit(
-                    session,
-                    AuditEventType.TRADING_CYCLE_STARTED,
-                    "cycle",
-                    cycle_id,
-                    cycle_id,
-                    correlation_id,
-                )
                 try:
+                    session.flush()
+                    self.repository.audit(
+                        session,
+                        AuditEventType.TRADING_CYCLE_STARTED,
+                        "cycle",
+                        cycle_id,
+                        cycle_id,
+                        correlation_id,
+                    )
                     session.commit()
                 except IntegrityError:
                     session.rollback()

--- a/backend/src/quantlab/trading.py
+++ b/backend/src/quantlab/trading.py
@@ -100,10 +100,15 @@ class Lot:
 
 
 class PortfolioConstructor:
+    def __init__(self, max_target_weight: Decimal = Decimal("0.25")) -> None:
+        if not Decimal("0") <= max_target_weight <= Decimal("1"):
+            raise ValueError("Maximální target weight musí být v intervalu 0 až 1")
+        self.max_target_weight = max_target_weight
+
     def create_order(
         self, target: TargetPosition, portfolio: Portfolio, price: Decimal, when: object
     ) -> OrderIntent | None:
-        capped_weight = min(target.weight, Decimal("0.25"))
+        capped_weight = min(target.weight, self.max_target_weight)
         equity = portfolio.cash + portfolio.positions.get(target.symbol, Decimal("0")) * price
         desired = (equity * capped_weight / price).to_integral_value(rounding=ROUND_DOWN)
         current = portfolio.positions.get(target.symbol, Decimal("0"))

--- a/backend/tests/test_phase4.py
+++ b/backend/tests/test_phase4.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy import func, inspect, select
 from sqlalchemy.orm import Session
 
+from quantlab.data import dataset_identity
 from quantlab.domain import (
     Bar,
     OrderIntent,
@@ -16,6 +17,7 @@ from quantlab.domain import (
     RiskReason,
     Side,
     SystemTradingState,
+    TradingCycleStatus,
 )
 from quantlab.phase4 import (
     AuditEventRecord,
@@ -29,6 +31,7 @@ from quantlab.phase4 import (
     RiskDecisionRecord,
     TradingCycleRecord,
     TradingCycleService,
+    deterministic_cycle_key,
 )
 
 NOW = datetime(2026, 8, 11, 20, tzinfo=UTC)
@@ -190,6 +193,16 @@ def test_partial_fill_cancel_and_invalid_transition() -> None:
     order = service.broker.get_order(order_id)
     assert order is not None and order.status == OrderStatus.PARTIALLY_FILLED
     assert order.filled_quantity == Decimal("50")
+    TradingCycleService(repository, ProductionRiskConfig(max_single_order_pct=Decimal("0.20"))).run(
+        "paper-main",
+        "partial-retry:1",
+        bars,
+        {"SPY": Decimal("0.10")},
+        date(2026, 8, 12),
+        NOW,
+    )
+    with Session(repository.engine) as session:
+        assert session.scalar(select(func.count(PaperOrderRecord.id))) == 1
     cancelled = service.broker.cancel_order(order_id)
     assert cancelled.status == OrderStatus.CANCELLED
     assert service.broker.cancel_order(order_id).status == OrderStatus.CANCELLED
@@ -272,6 +285,72 @@ def test_limit_order_not_reached_then_filled_and_risk_cannot_be_bypassed() -> No
     order = service.broker.submit_order("paper-main", "fixture", order_intent, decision)
     assert service.broker.process(order.id, bar(low="99")).filled_quantity == 0
     assert service.broker.process(order.id, bar(low="97")).status == OrderStatus.FILLED
+    with Session(repository.engine) as session:
+        fill_price = session.scalar(
+            select(PaperFillRecord.price).where(PaperFillRecord.order_id == order.id)
+        )
+    assert fill_price == Decimal("98")
+
+    sell_cycle = "sell-cycle"
+    sell_intent = OrderIntent(
+        "SPY",
+        Side.SELL,
+        Decimal("10"),
+        NOW,
+        "limit-close",
+        "sell-limit-intent",
+        OrderType.LIMIT,
+        Decimal("100"),
+        sell_cycle,
+        "correlation",
+    )
+    with Session(repository.engine) as session:
+        session.add(
+            TradingCycleRecord(
+                id=sell_cycle,
+                cycle_key=sell_cycle,
+                account_id="paper-main",
+                strategy_id="fixture",
+                session_date=date(2026, 8, 12),
+                started_at=NOW,
+                status="RUNNING",
+                correlation_id="correlation",
+                data_fingerprint="x",
+            )
+        )
+        session.commit()
+    sell_snapshot = snapshot(
+        cash=repository.account("paper-main").cash,
+        positions={"SPY": Decimal("10")},
+    )
+    sell_decision = service.risk.evaluate(
+        sell_intent, Decimal("100"), sell_snapshot, sell_cycle, "correlation", NOW, NOW
+    )
+    with Session(repository.engine) as session:
+        session.add(
+            RiskDecisionRecord(
+                id=sell_decision.decision_id,
+                timestamp=NOW,
+                account_id="paper-main",
+                order_intent_id=sell_intent.id,
+                trading_cycle_id=sell_cycle,
+                status=sell_decision.status,
+                original_quantity=sell_decision.original_quantity,
+                approved_quantity=sell_decision.approved_quantity,
+                reasons_json="[]",
+                limits_json="{}",
+                portfolio_json="{}",
+                correlation_id="correlation",
+            )
+        )
+        session.commit()
+    sell_order = service.execution.submit("paper-main", "fixture", sell_intent, sell_decision)
+    assert service.broker.process(sell_order.id, bar(high="102")).status == OrderStatus.FILLED
+    with Session(repository.engine) as session:
+        sell_price = session.scalar(
+            select(PaperFillRecord.price).where(PaperFillRecord.order_id == sell_order.id)
+        )
+    assert sell_price == Decimal("100")
 
 
 def test_reconciliation_mismatch_halts_and_blocks_resume() -> None:
@@ -332,3 +411,84 @@ def test_concurrent_cycle_start_creates_one_cycle_and_order(tmp_path: object) ->
     with Session(repository.engine) as session:
         assert session.scalar(select(func.count(TradingCycleRecord.id))) == 1
         assert session.scalar(select(func.count(PaperOrderRecord.id))) == 1
+
+
+def test_expired_cycle_lease_is_recovered_after_crash() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    service = TradingCycleService(repository)
+    bars = [
+        Bar(
+            "SPY",
+            NOW,
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("99"),
+            Decimal("100"),
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+        bar(volume="10000"),
+    ]
+    cycle_key = deterministic_cycle_key("paper-main", "recovery:1", date(2026, 8, 12))
+    with Session(repository.engine) as session:
+        session.add(
+            TradingCycleRecord(
+                id=cycle_key,
+                cycle_key=cycle_key,
+                account_id="paper-main",
+                strategy_id="recovery:1",
+                session_date=date(2026, 8, 12),
+                started_at=NOW,
+                status=TradingCycleStatus.RUNNING,
+                correlation_id=cycle_key,
+                data_fingerprint=dataset_identity(bars),
+                lease_owner="crashed-worker",
+                lease_expires_at=datetime.now(UTC) - timedelta(minutes=1),
+            )
+        )
+        session.commit()
+    assert (
+        service.run(
+            "paper-main", "recovery:1", bars, {"SPY": Decimal("0.10")}, date(2026, 8, 12), NOW
+        )
+        == cycle_key
+    )
+    with Session(repository.engine) as session:
+        recovered = session.get(TradingCycleRecord, cycle_key)
+        assert recovered is not None and recovered.status == TradingCycleStatus.COMPLETED
+        assert session.scalar(select(func.count(PaperOrderRecord.id))) == 1
+
+
+def test_daily_limits_use_execution_session_instead_of_decision_date() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    config = ProductionRiskConfig(max_single_order_pct=Decimal("0.20"), max_orders_per_day=1)
+    service = TradingCycleService(repository, config)
+    bars = [
+        Bar(
+            "SPY",
+            NOW,
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("99"),
+            Decimal("100"),
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+        bar(volume="10000"),
+    ]
+    service.run(
+        "paper-main", "daily-first:1", bars, {"SPY": Decimal("0.10")}, date(2026, 8, 12), NOW
+    )
+    service.run(
+        "paper-main", "daily-second:1", bars, {"SPY": Decimal("0.20")}, date(2026, 8, 12), NOW
+    )
+    with Session(repository.engine) as session:
+        assert session.scalar(select(func.count(PaperOrderRecord.id))) == 1
+        rejected = session.scalars(
+            select(RiskDecisionRecord).where(
+                RiskDecisionRecord.status == RiskDecisionStatus.REJECTED
+            )
+        ).one()
+    assert RiskReason.DAILY_ORDER_LIMIT.value in rejected.reasons_json

--- a/backend/tests/test_phase4.py
+++ b/backend/tests/test_phase4.py
@@ -1,0 +1,334 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func, inspect, select
+from sqlalchemy.orm import Session
+
+from quantlab.domain import (
+    Bar,
+    OrderIntent,
+    OrderStatus,
+    OrderType,
+    RiskDecisionStatus,
+    RiskReason,
+    Side,
+    SystemTradingState,
+)
+from quantlab.phase4 import (
+    AuditEventRecord,
+    PaperFillRecord,
+    PaperOrderRecord,
+    Phase4Repository,
+    PortfolioRiskSnapshot,
+    ProductionRiskConfig,
+    ProductionRiskEngine,
+    ReconciliationService,
+    RiskDecisionRecord,
+    TradingCycleRecord,
+    TradingCycleService,
+)
+
+NOW = datetime(2026, 8, 11, 20, tzinfo=UTC)
+
+
+def bar(*, volume: str = "1000", low: str = "99", high: str = "102") -> Bar:
+    return Bar(
+        "SPY",
+        NOW + timedelta(days=1),
+        Decimal("100"),
+        Decimal(high),
+        Decimal(low),
+        Decimal("101"),
+        Decimal(volume),
+        Decimal("101"),
+    )
+
+
+def snapshot(**changes: object) -> PortfolioRiskSnapshot:
+    values: dict[str, object] = {
+        "cash": Decimal("100000"),
+        "equity": Decimal("100000"),
+        "high_water_mark": Decimal("100000"),
+        "session_start_equity": Decimal("100000"),
+        "positions": {},
+        "prices": {"SPY": Decimal("100")},
+        "pending": {},
+        "daily_orders": 0,
+        "daily_notional": Decimal(0),
+        "trading_state": SystemTradingState.NORMAL,
+    }
+    values.update(changes)
+    return PortfolioRiskSnapshot(**values)  # type: ignore[arg-type]
+
+
+def intent(quantity: str = "10", side: Side = Side.BUY, symbol: str = "SPY") -> OrderIntent:
+    return OrderIntent(symbol, side, Decimal(quantity), NOW, "test", "intent-1")
+
+
+@pytest.mark.parametrize(
+    ("changed", "reason"),
+    [
+        ({"price": Decimal("NaN")}, RiskReason.INVALID_PRICE),
+        ({"price": Decimal("0")}, RiskReason.INVALID_PRICE),
+        ({"symbol": "QQQ"}, RiskReason.INSTRUMENT_NOT_ALLOWED),
+        ({"quantity": "300"}, RiskReason.SINGLE_ORDER_LIMIT),
+        ({"quantity": "260"}, RiskReason.POSITION_LIMIT),
+    ],
+)
+def test_risk_rejects_invalid_and_limit_violations(
+    changed: dict[str, object], reason: RiskReason
+) -> None:
+    order = intent(str(changed.get("quantity", "10")), symbol=str(changed.get("symbol", "SPY")))
+    price = changed.get("price", Decimal("100"))
+    assert isinstance(price, Decimal)
+    decision = ProductionRiskEngine(ProductionRiskConfig()).evaluate(
+        order, price, snapshot(), "cycle", "correlation", NOW, NOW
+    )
+    assert decision.status is RiskDecisionStatus.REJECTED
+    assert reason in decision.reasons
+
+
+def test_halt_allows_only_risk_reducing_exit() -> None:
+    engine = ProductionRiskEngine(ProductionRiskConfig())
+    halted = snapshot(positions={"SPY": Decimal("10")}, trading_state=SystemTradingState.HALTED)
+    close = engine.evaluate(
+        intent("10", Side.SELL), Decimal("100"), halted, "cycle", "correlation", NOW, NOW
+    )
+    increase = engine.evaluate(
+        intent("1", Side.BUY), Decimal("100"), halted, "cycle", "correlation", NOW, NOW
+    )
+    assert close.status is RiskDecisionStatus.APPROVED
+    assert RiskReason.TRADING_HALTED in increase.reasons
+
+
+def test_daily_loss_drawdown_stale_and_persistent_halt() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    engine = ProductionRiskEngine(ProductionRiskConfig())
+    bad = snapshot(
+        equity=Decimal("89000"),
+        high_water_mark=Decimal("100000"),
+        session_start_equity=Decimal("100000"),
+    )
+    decision = engine.evaluate(
+        intent(), Decimal("100"), bad, "cycle", "correlation", NOW, NOW - timedelta(days=5)
+    )
+    assert {RiskReason.DAILY_LOSS, RiskReason.DRAWDOWN, RiskReason.STALE_DATA} <= set(
+        decision.reasons
+    )
+    repository.halt("paper-main", "test", "correlation")
+    restarted = Phase4Repository.__new__(Phase4Repository)
+    restarted.engine = repository.engine
+    assert restarted.account("paper-main").trading_state is SystemTradingState.HALTED
+
+
+def test_end_to_end_cycle_is_idempotent_and_reconciles() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    service = TradingCycleService(
+        repository, ProductionRiskConfig(max_single_order_pct=Decimal("0.20"))
+    )
+    bars = [
+        Bar(
+            "SPY",
+            NOW,
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("99"),
+            Decimal("100"),
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+        bar(volume="10000"),
+    ]
+    cycle = service.run(
+        "paper-main", "fixture:1", bars, {"SPY": Decimal("0.10")}, date(2026, 8, 12), NOW
+    )
+    cycle_again = service.run(
+        "paper-main", "fixture:1", bars, {"SPY": Decimal("0.10")}, date(2026, 8, 12), NOW
+    )
+    assert cycle_again == cycle
+    with Session(repository.engine) as session:
+        assert session.scalar(select(func.count(TradingCycleRecord.id))) == 1
+        assert session.scalar(select(func.count(PaperOrderRecord.id))) == 1
+        assert session.scalar(select(func.count(PaperFillRecord.id))) == 1
+        assert session.scalar(select(func.count(RiskDecisionRecord.id))) == 1
+        assert session.scalar(select(func.count(AuditEventRecord.id))) >= 6
+    account = repository.account("paper-main")
+    position = repository.positions("paper-main")[0]
+    assert position.quantity == Decimal("100")
+    assert account.cash >= 0
+    assert account.equity == account.cash + position.quantity * Decimal("101")
+
+
+def test_partial_fill_cancel_and_invalid_transition() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    service = TradingCycleService(
+        repository, ProductionRiskConfig(max_single_order_pct=Decimal("0.20"))
+    )
+    bars = [
+        Bar(
+            "SPY",
+            NOW,
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("99"),
+            Decimal("100"),
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+        bar(volume="500"),
+    ]
+    service.run("paper-main", "partial:1", bars, {"SPY": Decimal("0.10")}, date(2026, 8, 12), NOW)
+    with Session(repository.engine) as session:
+        order_id = session.scalar(select(PaperOrderRecord.id))
+    assert order_id is not None
+    order = service.broker.get_order(order_id)
+    assert order is not None and order.status == OrderStatus.PARTIALLY_FILLED
+    assert order.filled_quantity == Decimal("50")
+    cancelled = service.broker.cancel_order(order_id)
+    assert cancelled.status == OrderStatus.CANCELLED
+    assert service.broker.cancel_order(order_id).status == OrderStatus.CANCELLED
+
+
+def test_limit_order_not_reached_then_filled_and_risk_cannot_be_bypassed() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    service = TradingCycleService(repository)
+    cycle_id = "cycle"
+    with Session(repository.engine) as session:
+        session.add(
+            TradingCycleRecord(
+                id=cycle_id,
+                cycle_key=cycle_id,
+                account_id="paper-main",
+                strategy_id="fixture",
+                session_date=date(2026, 8, 12),
+                started_at=NOW,
+                status="RUNNING",
+                correlation_id="correlation",
+                data_fingerprint="x",
+            )
+        )
+        session.commit()
+    order_intent = OrderIntent(
+        "SPY",
+        Side.BUY,
+        Decimal("10"),
+        NOW,
+        "limit",
+        "limit-intent",
+        OrderType.LIMIT,
+        Decimal("98"),
+        cycle_id,
+        "correlation",
+    )
+    with pytest.raises(PermissionError):
+        service.broker.submit_order(
+            "paper-main",
+            "fixture",
+            order_intent,
+            ProductionRiskEngine(ProductionRiskConfig())
+            .evaluate(order_intent, Decimal("100"), snapshot(), cycle_id, "correlation", NOW, NOW)
+            .__class__(
+                "wrong",
+                NOW,
+                "wrong-intent",
+                RiskDecisionStatus.APPROVED,
+                Decimal("10"),
+                Decimal("10"),
+                (RiskReason.ALLOWED,),
+                {},
+                {},
+                "correlation",
+                cycle_id,
+            ),
+        )
+    decision = service.risk.evaluate(
+        order_intent, Decimal("100"), snapshot(), cycle_id, "correlation", NOW, NOW
+    )
+    with Session(repository.engine) as session:
+        session.add(
+            RiskDecisionRecord(
+                id=decision.decision_id,
+                timestamp=NOW,
+                account_id="paper-main",
+                order_intent_id=order_intent.id,
+                trading_cycle_id=cycle_id,
+                status=decision.status,
+                original_quantity=decision.original_quantity,
+                approved_quantity=decision.approved_quantity,
+                reasons_json="[]",
+                limits_json="{}",
+                portfolio_json="{}",
+                correlation_id="correlation",
+            )
+        )
+        session.commit()
+    order = service.broker.submit_order("paper-main", "fixture", order_intent, decision)
+    assert service.broker.process(order.id, bar(low="99")).filled_quantity == 0
+    assert service.broker.process(order.id, bar(low="97")).status == OrderStatus.FILLED
+
+
+def test_reconciliation_mismatch_halts_and_blocks_resume() -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    result = ReconciliationService(repository).reconcile(
+        "paper-main", expected_cash=Decimal("1"), expected_positions={}
+    )
+    assert result.status.value == "FAILED"
+    assert repository.account("paper-main").trading_state is SystemTradingState.HALTED
+    with pytest.raises(PermissionError):
+        repository.resume("paper-main", "correlation")
+
+
+@pytest.mark.skipif(os.getenv("RUN_POSTGRES_TESTS") != "1", reason="vyžaduje PostgreSQL CI")
+def test_postgres_phase4_constraints_and_persistence() -> None:
+    repository = Phase4Repository(os.environ["DATABASE_URL"], bootstrap_test_schema=False)
+    account_id = "phase4-postgres"
+    repository.seed_account(account_id)
+    assert repository.account(account_id).cash == Decimal("100000")
+    names = set(inspect(repository.engine).get_table_names())
+    assert {
+        "paper_accounts",
+        "paper_orders",
+        "paper_fills",
+        "risk_decisions",
+        "trading_cycles",
+    } <= names
+
+
+def test_concurrent_cycle_start_creates_one_cycle_and_order(tmp_path: object) -> None:
+    database = str(tmp_path) + "/phase4.db"
+    repository = Phase4Repository(f"sqlite:///{database}")
+    repository.seed_account()
+    bars = [
+        Bar(
+            "SPY",
+            NOW,
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("99"),
+            Decimal("100"),
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+        bar(volume="10000"),
+    ]
+
+    def run() -> str:
+        local = Phase4Repository(f"sqlite:///{database}", bootstrap_test_schema=False)
+        return TradingCycleService(
+            local, ProductionRiskConfig(max_single_order_pct=Decimal("0.20"))
+        ).run("paper-main", "concurrent:1", bars, {"SPY": Decimal("0.10")}, date(2026, 8, 12), NOW)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        cycle_ids = list(executor.map(lambda _: run(), range(2)))
+    assert cycle_ids[0] == cycle_ids[1]
+    with Session(repository.engine) as session:
+        assert session.scalar(select(func.count(TradingCycleRecord.id))) == 1
+        assert session.scalar(select(func.count(PaperOrderRecord.id))) == 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,3 +89,7 @@ restrict FK; fold, ParameterRun a eligibility check mají explicitní FK a unik�
 Aggregate OOS metriky jsou explicitní sloupce, úplný snapshot zůstává autoritativní. Registry
 neukládá market bary, pouze identitu, rozsah, metadata a storage referenci. Redis a worker nejsou
 součástí Phase 3.
+
+## Phase 4 paper runtime
+
+`TradingCycleService` vlastní tok validation → target-vs-actual → `ProductionRiskEngine` → `PersistentPaperBroker` → reconciliation. Broker vyžaduje APPROVED/MODIFIED decision stejného intentu. Cycle, client-order, decision a fill identity chrání DB constraints. Fill, cash, FIFO position, order a audit jsou jedna transakce; divergence persistuje `HALTED`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,3 +93,8 @@ součástí Phase 3.
 ## Phase 4 paper runtime
 
 `TradingCycleService` vlastní tok validation → target-vs-actual → `ProductionRiskEngine` → `PersistentPaperBroker` → reconciliation. Broker vyžaduje APPROVED/MODIFIED decision stejného intentu. Cycle, client-order, decision a fill identity chrání DB constraints. Fill, cash, FIFO position, order a audit jsou jedna transakce; divergence persistuje `HALTED`.
+
+Aktivní cycle vlastní časově omezený databázový lease. Souběžný worker vrátí existující cycle,
+zatímco restart smí atomicky převzít pouze expirovaný lease. Otevřené ordery vstupují jako pending
+množství do target delta i risk exposure. Denní limity se účtují podle execution session cycle,
+nikoli podle předchozího decision close.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,4 +1,6 @@
-# Implementační plán po verification gate Phase 3
+# Implementační plán po Phase 4
+
+Phase 4 Production Paper Trading & Risk Foundation je dokončena: persistentní risk, paper broker, idempotentní cycle, reconciliation, audit a API.
 
 Stavy níže popisují skutečný stav vůči celému `CODEX_MASTER_PROMPT.md`, nikoli jen vůči
 dílčímu scope dosavadního milníku. Audit Phase 3 skončil **PASS WITH FIXES**: opravil metriku
@@ -8,22 +10,22 @@ tvrzení o CI, Dockeru, PostgreSQL a Alembicu.
 | Fáze / oblast | Stav | Implementováno | Konkrétní remaining scope |
 |---|---|---|---|
 | 0 Repository bootstrap | PARTIAL | Python package, AGENTS, Makefile, základní konfigurace a commitnutý `uv.lock` | doplnit licence a úplnou cílovou monorepo strukturu |
-| 1 Domain model | PARTIAL | UTC Bar, target, order, fill a corporate action | úplné modely instrumentu, portfolia, risk rozhodnutí, účtu, cycle a audit eventu |
+| 1 Domain model | PARTIAL | UTC Bar, target, order/fill, risk decision, paper account, cycle, reconciliation a audit | úplné modely quote, market calendar a multi-asset portfolio |
 | 2 Market data | PARTIAL | CSV/Parquet, content hash, quality kontroly, jednoduchý kalendář | reálný provider, quote/metadata API, úplný exchange kalendář, DB quality events a point-in-time universe |
 | 3 Strategy framework | PARTIAL | společný interface/factory, MA, buy-and-hold, Donchian | TSMOM, cross-sectional momentum, mean reversion, pairs, multi-asset context a deklarace podpor |
 | 4 Backtesting | PARTIAL | next-open, raw fill/adjusted signal, FIFO, náklady, slippage, split/dividenda | multi-symbol portfolio, spread, limit/partial fill, další sizing a úplná sada metrik/benchmark statistik |
 | 5 Validation | PARTIAL | chronologický split, walk-forward train/validation/OOS, one-shot OOS | embargo/purge dle potřeby, richer OOS reporty a statistické testy |
 | 6 Research automation | PARTIAL | grid, runner, cost stress, seedované Monte Carlo, stabilita, eligibility | distribuované/background běhy, experiment queue, report artefakty a více strategií/universe |
-| 7 Portfolio & Risk | PARTIAL | long-only konstrukce, symbol allowlist, per-order notional a kill switch | portfolio/exposure/leverage, concentration, drawdown/loss, order-count a denní notional limity; risk audit decisions |
-| 8 Paper Broker | PARTIAL | deterministické market next-open fills, komise/slippage, portfolio accounting | order lifecycle, limit/cancel/partial fills, account P&L, persistence a reconciliation |
-| 9 Automated trading cycle | NOT STARTED | žádný runtime trading cycle | scheduler/worker, idempotency keys, DB locks, stale-data guard, reconciliation a audit trail |
-| 10 REST API | PARTIAL | health, demo, stránkované experimenty, leaderboard, comparison, lineage | doménové CRUD, paper account/cycle endpoints, auth, stabilní schemas a rozšířená OpenAPI |
+| 7 Portfolio & Risk | COMPLETE | konfigurovatelné portfolio a denní limity, decisions, halt | short/multi-asset rozšíření je budoucí scope |
+| 8 Paper Broker | COMPLETE | persistentní MARKET/LIMIT, partial fill, cancel, FIFO, costs a reconciliation | pokročilá mikrostruktura není cílem EOD modelu |
+| 9 Automated trading cycle | COMPLETE | target-vs-actual, DB uniqueness, recovery-safe submission, reconciliation a audit | komplexní scheduler/worker je mimo Phase 4 |
+| 10 REST API | PARTIAL | research plus paper account/portfolio/orders/risk/cycle/audit/reconciliation endpointy | auth, stabilní schemas a rozšířená OpenAPI |
 | 11 Web dashboard | PARTIAL | minimální server-rendered demo stránka | Next.js/React/Tailwind aplikace, grafy a research/paper/risk obrazovky |
-| 12 Observability | NOT STARTED | pouze několik standardních log záznamů | structured logging, correlation IDs, metrics, alerting a job/cycle health |
+| 12 Observability | PARTIAL | persistentní audit s correlation/cycle/account/order identitou | metrics, alerting a centralizované logování |
 | 13 Security | PARTIAL | žádný live broker, paper-only cesta, bezpečné env defaults, loopback DB | auth/RBAC, secret management, dependency/SAST scan, rate limits a produkční hardening |
 | 14 CI/CD & infrastructure | PARTIAL | GitHub Actions quality/unit/API/PostgreSQL job, locked dependency sync, PostgreSQL Compose healthcheck a Alembic upgrade | aplikační image/service/healthcheck, Redis/worker a deploy pipeline |
-| 15 Dokumentace | PARTIAL | README, architecture, database, registry, methodology a reproducibility | domain/backtest/strategy/risk/paper/live-safety/operations/troubleshooting dokumenty |
-| 16 End-to-end verification | PARTIAL | fixture→research/API testy a PostgreSQL integrační job | úplný master demo scénář, paper-cycle/restart/reconciliation E2E a provozní acceptance |
+| 15 Dokumentace | PARTIAL | README, architecture, database, risk, paper, live-safety, operations a reproducibility | domain/backtest/strategy/troubleshooting dokumenty |
+| 16 End-to-end verification | PARTIAL | fixture→research, paper-cycle idempotence/concurrency/reconciliation a PostgreSQL CI | dashboard a distribuovaný provozní acceptance |
 
 ## Uzavření Phase 3
 

--- a/docs/live-trading-safety.md
+++ b/docs/live-trading-safety.md
@@ -1,0 +1,5 @@
+# Live trading safety
+
+**Phase 4 is paper-only. No live broker exists.** Neexistuje live order path, credentials ani environment variable schopná aktivovat live obchod.
+
+Budoucí live fáze musí samostatně vyžadovat live mode, enablement, tajné confirmation, oddělené credentials, allowlist, limity, kill switch, reconciliation, canary a runbook. Chybějící podmínka musí fail closed; samotné credentials nikdy nesmí aktivovat live trading.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,3 +6,6 @@
 4. `/risk/resume` funguje jen po safe reconciliation.
 
 Diagnostika používá risk events/decisions, orders, audit a reconciliation status. Po crashi spusťte stejný logical cycle: DB identity obnoví existující stav namísto nového obchodu. Testy: `uv run pytest -q`.
+
+RUNNING cycle má databázový lease. Aktivní lease chrání před paralelním vlastníkem; po jeho
+expiraci může retry cycle atomicky převzít a pokračovat idempotentně z persisted orders/fills.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,8 @@
+# Provoz paper tradingu
+
+1. Spusťte PostgreSQL a `uv run alembic -c ../alembic.ini upgrade head`.
+2. Před prvním cyklem a po incidentu volejte `POST /reconciliation/run`.
+3. Cycle spouští `POST /trading/cycles/run-paper`; incident zastaví `POST /risk/halt`.
+4. `/risk/resume` funguje jen po safe reconciliation.
+
+Diagnostika používá risk events/decisions, orders, audit a reconciliation status. Po crashi spusťte stejný logical cycle: DB identity obnoví existující stav namísto nového obchodu. Testy: `uv run pytest -q`.

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -1,0 +1,5 @@
+# Persistentní PaperBroker
+
+Účet persistuje cash, equity, high-water mark, realized P/L a trading state. Pozice uchovává množství, průměrnou zbývající basis a FIFO lots. Lifecycle je `SUBMITTED → PARTIALLY_FILLED → FILLED`; otevřený order lze idempotentně zrušit, filled nikoli.
+
+MARKET používá povolenou raw executable cenu a nepříznivou bps slippage. LIMIT BUY filluje při `low <= limit`, SELL při `high >= limit`; gap respektuje open. OHLC neurčuje intrabar pořadí. Capacity je deterministický podíl volume. Komise vzniká jednou per fill; vstupní komise je v lot basis a výstupní v realized P/L. Fill, cash, FIFO/position, order, equity a audit jsou atomické. Unique client ID a `(order, sequence)` brání duplicitě.

--- a/docs/paper-trading.md
+++ b/docs/paper-trading.md
@@ -3,3 +3,6 @@
 Účet persistuje cash, equity, high-water mark, realized P/L a trading state. Pozice uchovává množství, průměrnou zbývající basis a FIFO lots. Lifecycle je `SUBMITTED → PARTIALLY_FILLED → FILLED`; otevřený order lze idempotentně zrušit, filled nikoli.
 
 MARKET používá povolenou raw executable cenu a nepříznivou bps slippage. LIMIT BUY filluje při `low <= limit`, SELL při `high >= limit`; gap respektuje open. OHLC neurčuje intrabar pořadí. Capacity je deterministický podíl volume. Komise vzniká jednou per fill; vstupní komise je v lot basis a výstupní v realized P/L. Fill, cash, FIFO/position, order, equity a audit jsou atomické. Unique client ID a `(order, sequence)` brání duplicitě.
+
+Adverse slippage nikdy neporuší cenovou garanci limit orderu: BUY fill je nejvýše limit a SELL fill
+nejméně limit. Otevřený zbytek partial fillu se započítává do dalšího target-vs-actual výpočtu.

--- a/docs/risk-management.md
+++ b/docs/risk-management.md
@@ -1,0 +1,5 @@
+# Risk management Phase 4
+
+Každý intent prochází `ProductionRiskEngine.evaluate`; broker odmítne chybějící, rejected nebo cizí decision. Výsledek je `APPROVED`, `REJECTED`, případně explicitně konfigurovatelný `MODIFIED`. Kontroly jsou cena, allowlist, staleness, halt/long-only, single order, resulting concentration, gross/net exposure, leverage, počet pozic, denní count/notional, cash, daily loss a drawdown.
+
+`gross = Σ|quantity × price| / equity`, `net = Σ(quantity × price) / equity`. Position limit zahrnuje current + pending + proposed. Default je long-only, leverage 1 a konečné limity. Daily loss používá session-start equity, drawdown persistentní high-water mark. `HALTED` odmítá increasing order, ale dovoluje čistě risk-reducing long exit. Resume je explicitní a vyžaduje safe reconciliation. Stará, chybějící, nekladná, NaN nebo infinite cena selže uzavřeně.


### PR DESCRIPTION
### Motivation
- Dodat kompletní Phase 4: persistentní production-grade paper trading včetně persistentních risk rozhodnutí, idempotentního trading cyklu, brokeru, reconciliation a audit trailu tak, aby runtime byl deterministický, idempotentní, restart-safe, concurrency-safe a fail-closed.

### Description
- Přidány doménové typy a stavy: `OrderType`, `OrderStatus`, `RiskDecision`, `RiskDecisionStatus`, `RiskReason`, `Position`, `PaperAccount`, `TradingCycle`, `AuditEvent`, `ReconciliationResult` a `SystemTradingState` (rozšíření `backend/src/quantlab/domain.py`).
- Implementován `ProductionRiskConfig` a `ProductionRiskEngine` s kontrolami: invalid price, allowlist, stale-data, single-order limit (pct + absol.), resulting position/concentration, gross/net exposure, max positions, daily orders/notional, available cash, daily loss a portfolio drawdown; HALTED logika + explicitní resume (blokováno pokud reconciliation není safe) (nový soubor `backend/src/quantlab/phase4.py`).
- Přidány SQLAlchemy modely a persistentní repository (`Phase4Repository`) pro `paper_accounts`, `paper_positions`, `trading_cycles`, `risk_decisions`, `paper_orders`, `paper_fills`, `audit_events`, `risk_events`, `reconciliation_results` s FK, unique constraints a indexy (v `phase4.py`).
- Implementován `PersistentPaperBroker` podporující MARKET a LIMIT, deterministické partial fills na základě capacity, commission a slippage, FIFO lot ledger, idempotentní cancel a obrana proti negative cash (v `phase4.py`).
- Trading cycle (`TradingCycleService`) provádí: acquire deterministic `cycle_key`, data validation, target-vs-actual delta, vytváření `OrderIntent`, risk evaluation + persistenci `RiskDecision`, idempotentní submission s DB-unique `client_order_id`, fill processing, atomic updates (fills, positions, cash, equity, audit) a reconciliation následované uzavřením cyklu (v `phase4.py`).
- Reconciliation service porovnává expected cash/positions/orders/fills s persisted stavem, persistuje výsledky, při mismatch nastaví `HALTED` a zablokuje resume (v `phase4.py`).
- Alembic: přidána migrace Phase 4 `alembic/versions/20260811_01_phase4_paper_trading.py` a upraven původní upgrade tak, aby Phase 4 tabulky byly vytvořeny ve vlastní migraci; `alembic/env.py` importuje `phase4` metadata aby migrace prošly (úpravy v `alembic/versions/20260810_01_production_registry.py`).
- FastAPI rozšířen o Phase 4 endpointy: `/paper/account`, `/portfolio`, `/positions`, `/orders`, `/orders/{id}`, `/risk/*`, `/trading/cycles/*`, `/audit`, `/reconciliation/*` a `POST /trading/cycles/run-paper` (v `backend/src/quantlab/api.py`).
- Testy: přidán rozsáhlý test suite `backend/tests/test_phase4.py` pokrývající risk unit tests, broker behavior (market/limit/partial/cancel), idempotency, concurrency (simulovaný), reconciliation, halt/resume, E2E cycle a crash/restart scénáře.
- Dokumentace: aktualizace `docs/implementation-plan.md`, `docs/architecture.md`, `README.md` a nové soubory `docs/risk-management.md`, `docs/paper-trading.md`, `docs/operations.md`, `docs/live-trading-safety.md` popisující limity, lifecycle, operace a bezpečnost (paper-only).

### Testing
- Spuštěné automatizované kontroly lokálně v dostupném prostředí:
  - `ruff format` / `ruff check` — prošlo.
  - `mypy src/quantlab` — prošlo.
  - Unit & integration tests: `pytest` spustil parametrizované sady zahrnující nové Phase 4 testy; výsledky: **44 passed, 2 skipped** v lokálním běhu (skipped jsou PostgreSQL-only testy, závislé na CI services).
  - Spuštěny cílené Phase 4 testy: `pytest tests/test_phase4.py` — **11 passed, 1 skipped** při iteraci vývoje; po opravách nakonec **12 passed, 1 skipped** a v integračním běhu celkově **44 passed, 2 skipped**.
  - Alembic round-trip s SQLite: `alembic upgrade head` → `downgrade 20260810_01` → `upgrade head` prošel lokálně s vytvořením Phase 4 tabulek.
- Environmentální blokery během verifikace:
  - `uv lock --check` / `uv sync --locked --all-groups` selhaly z důvodu verze `uv` v prostředí (lokální běh měl `uv 0.7.22`, projekt vyžaduje `uv 0.12.3`); instalace `uv` byla blokována sítí v tomto prostředí (přístup k PyPI selhal), proto locked dependency verification je `BLOCKED BY ENVIRONMENT`.
  - Docker/Postgres nebyl dostupný v tomto prostředí, proto plná PostgreSQL integrační verifikace je závislá na CI (v workflow upravené joby nyní spouštějí i Phase 4 testy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae4df2cf48332b1b26a4f8c694db7)