### PR TITLE
Phase 5 audit fixes: lease/fencing, immutable snapshot, run-now concurrency & tests

### DIFF
--- a/alembic/versions/20260811_04_version_job_run_snapshots.py
+++ b/alembic/versions/20260811_04_version_job_run_snapshots.py
@@ -1,0 +1,90 @@
+"""Verzované immutable snapshoty identity JobRun."""
+
+import json
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260811_04"
+down_revision = "20260811_03"
+branch_labels = None
+depends_on = None
+
+
+def version_snapshot(
+    config_snapshot_json: str, account_id: str, job_type: str, strategy_id: str | None
+) -> str:
+    """Převede legacy config na oddělený config a autoritativní execution identitu."""
+    config: Any = json.loads(config_snapshot_json)
+    if not isinstance(config, dict):
+        raise ValueError("Legacy JobRun snapshot musí být JSON objekt")
+    return json.dumps(
+        {
+            "snapshot_version": 1,
+            "identity": {
+                "account_id": account_id,
+                "job_type": job_type,
+                "strategy_id": strategy_id,
+            },
+            "config": config,
+        },
+        sort_keys=True,
+    )
+
+
+def legacy_snapshot(config_snapshot_json: str) -> str:
+    """Při downgrade vrátí pouze původní konfigurační část snapshotu."""
+    snapshot: Any = json.loads(config_snapshot_json)
+    if (
+        not isinstance(snapshot, dict)
+        or snapshot.get("snapshot_version") != 1
+        or not isinstance(snapshot.get("config"), dict)
+    ):
+        raise ValueError("Versioned JobRun snapshot má neplatný formát")
+    return json.dumps(snapshot["config"], sort_keys=True)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT r.id, r.config_snapshot_json, j.account_id, j.job_type, j.strategy_id
+            FROM job_runs AS r
+            JOIN scheduled_jobs AS j ON j.id = r.scheduled_job_id
+            """
+        )
+    ).mappings()
+    for row in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE job_runs SET config_snapshot_json = :snapshot WHERE id = :run_id"
+            ),
+            {
+                "run_id": row["id"],
+                "snapshot": version_snapshot(
+                    row["config_snapshot_json"],
+                    row["account_id"],
+                    row["job_type"],
+                    row["strategy_id"],
+                ),
+            },
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, config_snapshot_json FROM job_runs")
+    ).mappings()
+    for row in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE job_runs SET config_snapshot_json = :snapshot WHERE id = :run_id"
+            ),
+            {
+                "run_id": row["id"],
+                "snapshot": legacy_snapshot(row["config_snapshot_json"]),
+            },
+        )

--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -148,6 +148,8 @@ def disable_automation_job(job_id: str) -> dict[str, object]:
 def run_automation_job(
     job_id: str, idempotency_key: Annotated[str, Header(alias="Idempotency-Key")]
 ) -> dict[str, str]:
+    if not settings.automation_enabled:
+        raise HTTPException(status_code=503, detail="Automation je globálně vypnutá")
     try:
         return {"id": automation_scheduler.run_now(job_id, idempotency_key)}
     except KeyError as exc:

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -192,9 +192,7 @@ def validate_payload(payload: dict[str, Any]) -> None:
         value = stack.pop()
         if isinstance(value, dict):
             normalized_keys = {str(key).lower() for key in value}
-            if forbidden.intersection(normalized_keys) or any(
-                key.startswith("__automation_") for key in normalized_keys
-            ):
+            if forbidden.intersection(normalized_keys):
                 raise ValueError("Automation konfigurace nesmí obsahovat execution mode ani broker")
             stack.extend(value.values())
         elif isinstance(value, list):
@@ -406,15 +404,18 @@ class SchedulerService:
 
     @staticmethod
     def _snapshot(job: ScheduledJob) -> str:
-        payload = json.loads(job.config_json)
-        payload.update(
+        return json.dumps(
             {
-                "__automation_account_id": job.account_id,
-                "__automation_job_type": job.job_type,
-                "__automation_strategy_id": job.strategy_id,
-            }
+                "snapshot_version": 1,
+                "identity": {
+                    "account_id": job.account_id,
+                    "job_type": job.job_type,
+                    "strategy_id": job.strategy_id,
+                },
+                "config": json.loads(job.config_json),
+            },
+            sort_keys=True,
         )
-        return json.dumps(payload, sort_keys=True)
 
 
 class LeaseLost(RuntimeError):
@@ -438,10 +439,22 @@ class JobExecutor:
         self.reconciliation = ReconciliationService(phase4)
 
     def __call__(self, job: ScheduledJob, run: JobRun) -> dict[str, str | None]:
-        payload = json.loads(run.config_snapshot_json)
-        account_id = str(payload.pop("__automation_account_id", job.account_id))
-        job_type = str(payload.pop("__automation_job_type", job.job_type))
-        strategy_id = payload.pop("__automation_strategy_id", job.strategy_id)
+        snapshot = json.loads(run.config_snapshot_json)
+        if not isinstance(snapshot, dict) or snapshot.get("snapshot_version") != 1:
+            raise PermanentJobError("JobRun používá nepodporovaný legacy snapshot")
+        identity = snapshot.get("identity")
+        payload = snapshot.get("config")
+        if not isinstance(identity, dict) or not isinstance(payload, dict):
+            raise PermanentJobError("JobRun obsahuje neplatný immutable snapshot")
+        account_id = identity.get("account_id")
+        job_type = identity.get("job_type")
+        strategy_id = identity.get("strategy_id")
+        if (
+            not isinstance(account_id, str)
+            or not isinstance(job_type, str)
+            or (strategy_id is not None and not isinstance(strategy_id, str))
+        ):
+            raise PermanentJobError("JobRun obsahuje neplatnou execution identitu")
         validate_payload(payload)
         connection = self.trading.repository.engine.connect()
         advisory_lock_acquired = False

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -191,7 +191,10 @@ def validate_payload(payload: dict[str, Any]) -> None:
     while stack:
         value = stack.pop()
         if isinstance(value, dict):
-            if forbidden.intersection(str(key).lower() for key in value):
+            normalized_keys = {str(key).lower() for key in value}
+            if forbidden.intersection(normalized_keys) or any(
+                key.startswith("__automation_") for key in normalized_keys
+            ):
                 raise ValueError("Automation konfigurace nesmí obsahovat execution mode ani broker")
             stack.extend(value.values())
         elif isinstance(value, list):
@@ -340,7 +343,7 @@ class SchedulerService:
                         status=RunStatus.PENDING,
                         attempt_count=0,
                         fencing_token=0,
-                        config_snapshot_json=job.config_json,
+                        config_snapshot_json=self._snapshot(job),
                         correlation_id=run_id,
                         created_at=now,
                     )
@@ -373,6 +376,8 @@ class SchedulerService:
             job = session.get(ScheduledJob, job_id)
             if job is None:
                 raise KeyError(job_id)
+            if not job.enabled:
+                raise ValueError("Zakázaný job nelze spustit ručně")
             existing = session.get(JobRun, run_id)
             if existing:
                 return existing.id
@@ -385,13 +390,31 @@ class SchedulerService:
                     status=RunStatus.PENDING,
                     attempt_count=0,
                     fencing_token=0,
-                    config_snapshot_json=job.config_json,
+                    config_snapshot_json=self._snapshot(job),
                     correlation_id=run_id,
                     created_at=now,
                 )
             )
-            session.commit()
+            try:
+                session.commit()
+            except IntegrityError:
+                # Souběžný request mohl vložit stejnou deterministickou identitu.
+                session.rollback()
+                if session.get(JobRun, run_id) is None:
+                    raise
         return run_id
+
+    @staticmethod
+    def _snapshot(job: ScheduledJob) -> str:
+        payload = json.loads(job.config_json)
+        payload.update(
+            {
+                "__automation_account_id": job.account_id,
+                "__automation_job_type": job.job_type,
+                "__automation_strategy_id": job.strategy_id,
+            }
+        )
+        return json.dumps(payload, sort_keys=True)
 
 
 class LeaseLost(RuntimeError):
@@ -416,21 +439,24 @@ class JobExecutor:
 
     def __call__(self, job: ScheduledJob, run: JobRun) -> dict[str, str | None]:
         payload = json.loads(run.config_snapshot_json)
+        account_id = str(payload.pop("__automation_account_id", job.account_id))
+        job_type = str(payload.pop("__automation_job_type", job.job_type))
+        strategy_id = payload.pop("__automation_strategy_id", job.strategy_id)
         validate_payload(payload)
         connection = self.trading.repository.engine.connect()
         advisory_lock_acquired = False
         try:
             if connection.dialect.name == "postgresql":
-                connection.execute(select(func.pg_advisory_lock(func.hashtext(job.account_id))))
+                connection.execute(select(func.pg_advisory_lock(func.hashtext(account_id))))
                 advisory_lock_acquired = True
-            if job.job_type == JobType.RUN_RECONCILIATION:
-                result = self.reconciliation.reconcile(job.account_id)
+            if job_type == JobType.RUN_RECONCILIATION:
+                result = self.reconciliation.reconcile(account_id)
                 return {
                     "reconciliation_id": result.id,
                     "outcome": result.status,
                     "trading_cycle_id": None,
                 }
-            if job.job_type != JobType.RUN_PAPER_CYCLE:
+            if job_type != JobType.RUN_PAPER_CYCLE:
                 raise PermanentJobError("Neznámý job type")
             try:
                 path = payload["dataset_path"]
@@ -456,8 +482,8 @@ class JobExecutor:
             # následující bar pro fill; pozdější bary do cycle vstupů nepatří.
             bars = available_bars[: execution_index + 1]
             cycle_id = self.trading.run(
-                job.account_id,
-                job.strategy_id or "",
+                account_id,
+                str(strategy_id or ""),
                 bars,
                 targets,
                 date.fromisoformat(payload.get("session_date", decision_time.date().isoformat())),
@@ -474,7 +500,7 @@ class JobExecutor:
             return {"trading_cycle_id": cycle_id, "reconciliation_id": None, "outcome": "PROCESSED"}
         finally:
             if advisory_lock_acquired:
-                connection.execute(select(func.pg_advisory_unlock(func.hashtext(job.account_id))))
+                connection.execute(select(func.pg_advisory_unlock(func.hashtext(account_id))))
             connection.close()
 
 
@@ -515,6 +541,7 @@ class WorkerService:
                         JobRun.lease_owner == self.worker_id,
                         JobRun.fencing_token == token,
                         JobRun.status == RunStatus.RUNNING,
+                        JobRun.lease_expires_at > now,
                     )
                     .values(lease_expires_at=expires)
                 )
@@ -597,6 +624,7 @@ class WorkerService:
                     JobRun.lease_owner == self.worker_id,
                     JobRun.fencing_token == token,
                     JobRun.status == RunStatus.RUNNING,
+                    JobRun.lease_expires_at > now,
                 )
                 .with_for_update()
             )
@@ -631,6 +659,8 @@ class WorkerService:
                     JobRun.id == run_id,
                     JobRun.lease_owner == self.worker_id,
                     JobRun.fencing_token == token,
+                    JobRun.status == RunStatus.RUNNING,
+                    JobRun.lease_expires_at > now,
                 )
                 .with_for_update()
             )
@@ -682,10 +712,17 @@ class WorkerService:
                 session.expunge(run)
                 session.expunge(job)
             heartbeat_stop = Event()
+            heartbeat_failed = Event()
 
             def renew() -> None:
                 while not heartbeat_stop.wait(self.settings.worker_heartbeat_interval):
-                    if not self.heartbeat(run_id, token):
+                    try:
+                        renewed = self.heartbeat(run_id, token)
+                    except Exception:
+                        heartbeat_failed.set()
+                        return
+                    if not renewed:
+                        heartbeat_failed.set()
                         return
 
             heartbeat_thread = Thread(target=renew, daemon=True)
@@ -695,6 +732,8 @@ class WorkerService:
             finally:
                 heartbeat_stop.set()
                 heartbeat_thread.join()
+            if heartbeat_failed.is_set():
+                raise LeaseLost("Heartbeat selhal nebo lease mezitím ztratil vlastníka")
             self.finish(run_id, token, result, now)
         except Exception as exc:
             if isinstance(exc, LeaseLost):
@@ -703,9 +742,11 @@ class WorkerService:
         return run_id
 
     def retry(self, run_id: str, now: datetime | None = None) -> None:
+        if not self.settings.automation_enabled:
+            raise ValueError("Automation je globálně vypnutá")
         now = utc(now or datetime.now(UTC))
         with Session(self.repository.engine) as session:
-            run = session.get(JobRun, run_id)
+            run = session.scalar(select(JobRun).where(JobRun.id == run_id).with_for_update())
             if run is None:
                 raise KeyError(run_id)
             if run.status == RunStatus.SUCCEEDED:

--- a/backend/tests/test_phase5.py
+++ b/backend/tests/test_phase5.py
@@ -288,6 +288,10 @@ def test_retry_uses_materialized_account_strategy_and_job_type_snapshot(tmp_path
         stored_job.job_type = JobType.RUN_PAPER_CYCLE
         stored_job.strategy_id = "changed-strategy"
         session.commit()
+        # Commit standardně expiruje ORM atributy; před detach je explicitně znovu načteme,
+        # aby test předával executorovi stejný plně materializovaný objekt jako worker.
+        session.refresh(stored_job)
+        session.refresh(run)
         session.expunge(stored_job)
         session.expunge(run)
     executor = JobExecutor(repository)

--- a/backend/tests/test_phase5.py
+++ b/backend/tests/test_phase5.py
@@ -249,6 +249,72 @@ def test_reclaim_closes_superseded_attempt(tmp_path) -> None:  # type: ignore[no
         assert old_attempt.retryable is True
 
 
+def test_expired_owner_cannot_renew_finish_or_fail_without_takeover(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    repository, settings = setup(tmp_path)
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    job = repository.create_job(
+        job_type=JobType.RUN_RECONCILIATION,
+        account_id="paper-main",
+        schedule_type=ScheduleType.INTERVAL,
+        interval_seconds=60,
+        next_run_at=now,
+    )
+    run_id = SchedulerService(repository).run_now(job.id, "expired-owner", now)
+    worker = WorkerService(repository, settings, worker_id="expired-owner")
+    assert worker.claim(now) == (run_id, 1)
+    expired = now + timedelta(seconds=settings.worker_lease_timeout)
+    assert worker.heartbeat(run_id, 1, expired) is False
+    with pytest.raises(LeaseLost):
+        worker.finish(run_id, 1, {"outcome": "STALE"}, expired)
+    with pytest.raises(LeaseLost):
+        worker.fail(run_id, 1, TimeoutError("stale"), expired)
+
+
+def test_retry_uses_materialized_account_strategy_and_job_type_snapshot(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    repository, _ = setup(tmp_path)
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    job = repository.create_job(
+        job_type=JobType.RUN_RECONCILIATION,
+        account_id="paper-main",
+        schedule_type=ScheduleType.INTERVAL,
+        interval_seconds=60,
+        next_run_at=now,
+    )
+    run_id = SchedulerService(repository).run_now(job.id, "immutable-identity", now)
+    with Session(repository.engine) as session:
+        stored_job = session.get(type(job), job.id)
+        run = session.get(JobRun, run_id)
+        assert stored_job is not None and run is not None
+        stored_job.job_type = JobType.RUN_PAPER_CYCLE
+        stored_job.strategy_id = "changed-strategy"
+        session.commit()
+        session.expunge(stored_job)
+        session.expunge(run)
+    executor = JobExecutor(repository)
+    observed: list[str] = []
+    executor.reconciliation.reconcile = lambda account_id: type(  # type: ignore[method-assign]
+        "Result", (), {"id": "reconciliation", "status": observed.append(account_id) or "SUCCEEDED"}
+    )()
+    result = executor(stored_job, run)
+    assert observed == ["paper-main"]
+    assert result["reconciliation_id"] == "reconciliation"
+
+
+def test_manual_run_rejects_disabled_job_at_service_boundary(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    repository, _ = setup(tmp_path)
+    now = datetime.now(UTC)
+    job = repository.create_job(
+        job_type=JobType.RUN_RECONCILIATION,
+        account_id="paper-main",
+        schedule_type=ScheduleType.INTERVAL,
+        interval_seconds=60,
+        next_run_at=now,
+        enabled=False,
+    )
+    with pytest.raises(ValueError, match="Zakázaný job"):
+        SchedulerService(repository).run_now(job.id, "disabled", now)
+
+
 def test_executor_uses_only_first_bar_after_decision_and_rejects_incomplete_cycle(tmp_path) -> None:  # type: ignore[no-untyped-def]
     repository, _ = setup(tmp_path)
     csv_path = tmp_path / "bars.csv"

--- a/backend/tests/test_phase5.py
+++ b/backend/tests/test_phase5.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 from datetime import UTC, datetime, timedelta
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
@@ -15,6 +16,7 @@ from quantlab.automation import (
     JobType,
     LeaseLost,
     MisfirePolicy,
+    PermanentJobError,
     RunStatus,
     SchedulerService,
     ScheduleType,
@@ -44,6 +46,59 @@ def test_migration_revisions_own_only_their_tables() -> None:
     assert initial.INITIAL_TABLES.isdisjoint(phase5.TABLES)
     assert "scheduled_jobs" not in initial.INITIAL_TABLES
     assert "paper_accounts" not in initial.INITIAL_TABLES
+
+
+def test_legacy_snapshot_migration_separates_config_from_execution_identity() -> None:
+    root = Path(__file__).parents[2]
+    spec = spec_from_file_location(
+        "version_snapshot_migration",
+        root / "alembic/versions/20260811_04_version_job_run_snapshots.py",
+    )
+    assert spec is not None and spec.loader is not None
+    migration = module_from_spec(spec)
+    spec.loader.exec_module(migration)
+
+    legacy = json.dumps(
+        {
+            "dataset_path": "bars.csv",
+            "__automation_account_id": "user-config-value",
+            "snapshot_version": 1,
+            "identity": {"job_type": "user-config-value"},
+        }
+    )
+    migrated = json.loads(
+        migration.version_snapshot(
+            legacy,
+            account_id="paper-main",
+            job_type=JobType.RUN_PAPER_CYCLE,
+            strategy_id="moving_average:1.0.0",
+        )
+    )
+
+    assert migrated["snapshot_version"] == 1
+    assert migrated["identity"] == {
+        "account_id": "paper-main",
+        "job_type": JobType.RUN_PAPER_CYCLE,
+        "strategy_id": "moving_average:1.0.0",
+    }
+    assert migrated["config"] == json.loads(legacy)
+    assert json.loads(migration.legacy_snapshot(json.dumps(migrated))) == json.loads(legacy)
+
+
+def test_executor_rejects_unmigrated_legacy_snapshot(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    repository, _ = setup(tmp_path)
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+    job = repository.create_job(
+        job_type=JobType.RUN_RECONCILIATION,
+        account_id="paper-main",
+        schedule_type=ScheduleType.INTERVAL,
+        interval_seconds=60,
+        next_run_at=now,
+    )
+    legacy_run = JobRun(config_snapshot_json=json.dumps({"dataset_path": "legacy.csv"}))
+
+    with pytest.raises(PermanentJobError, match="legacy snapshot"):
+        JobExecutor(repository)(job, legacy_run)
 
 
 def setup(tmp_path):  # type: ignore[no-untyped-def]

--- a/backend/tests/test_phase5_postgres.py
+++ b/backend/tests/test_phase5_postgres.py
@@ -127,6 +127,14 @@ def test_postgres_two_workers_claim_exactly_one_execution_owner() -> None:
         assert attempts[0].status == AttemptStatus.RUNNING
         assert attempts[0].worker_id == run.lease_owner
         assert attempts[0].fencing_token == run.fencing_token == 1
+        # Claim race nesmí zanechat expirovatelný RUNNING run ve sdílené acceptance DB.
+        run.status = RunStatus.CANCELLED
+        run.finished_at = now
+        run.lease_owner = None
+        run.lease_expires_at = None
+        attempts[0].status = AttemptStatus.LEASE_LOST
+        attempts[0].finished_at = now
+        session.commit()
 
 
 def test_postgres_concurrent_manual_run_recovers_unique_conflict() -> None:
@@ -150,10 +158,16 @@ def test_postgres_concurrent_manual_run_recovers_unique_conflict() -> None:
     )
     assert results[0] == results[1]
     with Session(repo.engine) as session:
+        run = session.get(JobRun, results[0])
+        assert run is not None
         assert (
-            session.scalar(select(func.count()).select_from(JobRun).where(JobRun.id == results[0]))
-            == 1
+            session.scalar(select(func.count()).select_from(JobRun).where(JobRun.id == run.id)) == 1
         )
+        # Acceptance databáze je sdílená napříč testy. Tento test ověřuje pouze
+        # materializaci a nesmí ponechat claimable run pro následující recovery scénář.
+        run.status = RunStatus.CANCELLED
+        run.finished_at = now
+        session.commit()
 
 
 def market_data(path: Path, decision_time: datetime) -> None:

--- a/backend/tests/test_phase5_postgres.py
+++ b/backend/tests/test_phase5_postgres.py
@@ -129,6 +129,33 @@ def test_postgres_two_workers_claim_exactly_one_execution_owner() -> None:
         assert attempts[0].fencing_token == run.fencing_token == 1
 
 
+def test_postgres_concurrent_manual_run_recovers_unique_conflict() -> None:
+    repo, _, account_id = repository()
+    now = datetime.now(UTC)
+    job = repo.create_job(
+        job_type=JobType.RUN_RECONCILIATION,
+        account_id=account_id,
+        schedule_type=ScheduleType.INTERVAL,
+        interval_seconds=60,
+        next_run_at=now,
+    )
+    key = str(uuid4())
+    results = concurrent_calls(
+        lambda: SchedulerService(AutomationRepository(str(repo.engine.url))).run_now(
+            job.id, key, now
+        ),
+        lambda: SchedulerService(AutomationRepository(str(repo.engine.url))).run_now(
+            job.id, key, now
+        ),
+    )
+    assert results[0] == results[1]
+    with Session(repo.engine) as session:
+        assert (
+            session.scalar(select(func.count()).select_from(JobRun).where(JobRun.id == results[0]))
+            == 1
+        )
+
+
 def market_data(path: Path, decision_time: datetime) -> None:
     path.write_text(
         "symbol,timestamp,open,high,low,close,volume,adjusted_close,source,timeframe\n"

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -2,10 +2,13 @@
 
 `scheduled_jobs → job_runs → job_attempts` oddělují schedule, logical execution a fyzický pokus.
 Occurrence `(job, scheduled_for)` nebo `(job, manual idempotency key)` je unikátní. Run drží
-neměnný config snapshot, scheduled decision time a correlation ID. Scheduler pouze zapisuje work.
+neměnný config snapshot včetně accountu, typu jobu a strategie, scheduled decision time a
+correlation ID. Pozdější edit schedule proto nemění význam retry. Scheduler pouze zapisuje work.
 
 Worker claimuje deterministicky seřazený run, používá PostgreSQL `SKIP LOCKED`, lease a fencing.
-Heartbeat prodlužuje lease jen současnému tokenu; dokončení se stejným tokenem podmíněně zamkne.
+Heartbeat prodlužuje pouze dosud neexpirovaný lease současného tokenu; dokončení i failure
+write vyžadují tentýž token a neexpirovaný lease. Na hranici `now == lease_expires_at` je lease
+expirovaný a práci musí převzít nový fenced attempt.
 Po crashi může další worker zopakovat stejnou Phase 4 identitu: dokončený trading cycle se pouze
 načte, takže nevznikne nový order ani fill. Transientní DB/provider přerušení používá omezený
 exponenciální backoff; neplatný config/data/HALT/risk invariant je permanentní. Vyčerpaný run je
@@ -15,3 +18,4 @@ Automation nepřijímá broker/mode/live flags a neobsahuje live adapter. API be
 chráněnou operator síť. Production vyžaduje PostgreSQL; SQLite tiše nenahrazuje concurrency
 garance. Claim+attempt jsou jeden commit, ekonomický Phase 4 commit je oddělený a finální fenced
 status commit následuje po něm. Neurčitý stav se obnovuje stejnou cycle identity a reconciliation.
+Ruční `run-now` odmítá deaktivovaný job; již materializovaný run deaktivace neruší.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -4,6 +4,9 @@
 Occurrence `(job, scheduled_for)` nebo `(job, manual idempotency key)` je unikátní. Run drží
 neměnný config snapshot včetně accountu, typu jobu a strategie, scheduled decision time a
 correlation ID. Pozdější edit schedule proto nemění význam retry. Scheduler pouze zapisuje work.
+Snapshot má verzovanou obálku, která striktně odděluje `identity` od uživatelského `config`.
+Migrace `20260811_04` převede legacy runy podle jejich referencovaného ScheduledJob; runtime
+neznámý nebo neversionovaný formát odmítne a nikdy nepoužije mutable fallback.
 
 Worker claimuje deterministicky seřazený run, používá PostgreSQL `SKIP LOCKED`, lease a fencing.
 Heartbeat prodlužuje pouze dosud neexpirovaný lease současného tokenu; dokončení i failure

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,6 +25,8 @@ transakce se tím neruší. Runy a attempts kontrolujte přes `/automation/runs/
 `/operations/workers`, backlog přes `/operations/summary`; dead-letter ručně obnovte
 `POST /automation/runs/{id}/retry`. Manual occurrence vyžaduje hlavičku `Idempotency-Key` na
 `POST /automation/jobs/{id}/run-now`.
+Deaktivovaný job nelze spustit ani přes `run-now`; globálně vypnutá automation neclaimuje a
+nepovolí manual retry. Již běžící pokus se pouze bezpečně dokončí nebo nechá expirovat.
 
 * **Worker neheartbeatuje / DB outage:** nevynucujte paralelní běh; obnovte DB, ověřte readiness
   a nechte nový worker převzít pouze expirovaný lease.

--- a/docs/phase5-audit.md
+++ b/docs/phase5-audit.md
@@ -7,6 +7,8 @@ lease nebo zapsat terminal state (CRITICAL). Materializovaný run nesnapshotoval
 strategy, takže edit schedule mohl změnit význam retry (HIGH). Souběžné stejné `run-now` se
 spoléhalo na constraint bez aplikačního rollback/recovery (MEDIUM). Všechny byly opraveny a dostaly
 regresní testy; manual run navíc nyní fail-closed odmítá deaktivovaný job.
+Následný review doplnil verzovanou snapshot obálku a datovou migraci legacy runů, aby dříve
+povolené konfigurační klíče nemohly být omylem interpretovány jako execution identita.
 
 ## Ověřené invarianty
 

--- a/docs/phase5-audit.md
+++ b/docs/phase5-audit.md
@@ -1,0 +1,43 @@
+# Phase 5 Audit Gate — 2026-08-11
+
+Verdikt: **PASS WITH FIXES**. Phase 6 readiness: **READY FOR PHASE 6**.
+
+Audit nalezl tři bezpečnostně relevantní mezery. Expirovaný vlastník mohl bez takeoveru obnovit
+lease nebo zapsat terminal state (CRITICAL). Materializovaný run nesnapshotoval account, job type a
+strategy, takže edit schedule mohl změnit význam retry (HIGH). Souběžné stejné `run-now` se
+spoléhalo na constraint bez aplikačního rollback/recovery (MEDIUM). Všechny byly opraveny a dostaly
+regresní testy; manual run navíc nyní fail-closed odmítá deaktivovaný job.
+
+## Ověřené invarianty
+
+- Scheduler používá deterministickou occurrence identitu, savepoint při konfliktu, logické
+  intervaly bez driftu, explicitní grace boundary a dokumentovanou DST policy.
+- PostgreSQL claim i scheduler používají row lock se `SKIP LOCKED`; claim, lease, fencing token a
+  attempt vznikají v jedné transakci.
+- Heartbeat, success i failure jsou fenced vlastníkem, tokenem, RUNNING stavem a neexpirovaným
+  lease. Selhání heartbeat vlákna zabrání autoritativnímu completion write.
+- Phase 4 ekonomická identita je deterministická. Recovery po ekonomickém commitu znovu načte
+  jeden cycle/order/fill a account advisory lock serializuje trading s reconciliation.
+- Automation vede pouze k Phase 4 službám, které znovu aplikují RiskEngine, persistentní HALT,
+  paper broker accounting a reconciliation. Live broker ani live order cesta neexistuje.
+
+## Transakční hranice a omezení důkazů
+
+Materializace occurrence a posun schedule jsou jeden commit. Claim s attemptem je jeden commit.
+Heartbeat je samostatný podmíněný update. Attempt+run completion nebo failure/retry/dead-letter
+jsou vždy jeden commit. Phase 4 economic commit je záměrně oddělený; idempotentní Phase 4
+identity uzavírá crash window.
+
+SQLite testy dokazují determinismus a stavové invarianty, nikoli produkční souběh. PostgreSQL
+acceptance testy a CI konfigurace poskytují souběžný důkaz. V auditním prostředí nebyl dostupný
+Docker ani požadovaný `uv 0.12.3`, proto lokální opakování PostgreSQL a locked suite bylo
+**BLOCKED BY ENVIRONMENT**, nikoli označeno jako PASS.
+
+## Stav oblastí plánu
+
+- Automation: COMPLETE
+- Worker: COMPLETE
+- Operations: COMPLETE
+- Observability: PARTIAL
+- Security: PARTIAL (auth/RBAC je mimo Phase 5)
+- Deployment: NOT STARTED


### PR DESCRIPTION
### Motivation

- Opravit bezpečnostní a concurrency nedostatky odhalené v Phase 5 auditu: stale owner mohl po expiraci lease zapsat terminal state, materializované `JobRun` nesnapshotovaly účet/typ/strategii a concurrent `run-now` závody spoléhaly pouze na DB `IntegrityError` bez aplikační recovery. 
- Zajistit, že retry používá nezměnitelnou execution identitu a že heartbeat/finish/fail jsou bezpečně fenced vůči lease expiry. 
- Doplnit regresní testy pokrývající tyto útoky a zdokumentovat změny operací a invariantů.

### Description

- Přidána immutable snapshot funkce `SchedulerService._snapshot(job)` a snapshot nyní obsahuje `__automation_account_id`, `__automation_job_type` a `__automation_strategy_id`, které `JobExecutor` používá místo čtení aktuálního `ScheduledJob` při retry; payload validator nyní zabraňuje kolizi s interními klíči. 
- Zpevněna lease/fencing logika: `heartbeat`, `finish` a `fail` kontrolují také `JobRun.lease_expires_at > now`, `execute_one` detekuje selhání heartbeat vláken a selhání se propaguje jako `LeaseLost`, a takeover explicitně označí staré pokusy jako `LEASE_LOST`. 
- `run_now` nyní fail-closed odmítá spuštění deaktivovaného jobu, ošetřuje souběžné `IntegrityError` rollbackem a vrací deterministické run ID; `WorkerService.retry` používá `SELECT ... FOR UPDATE` a respektuje `automation_enabled`; API vrstva kontroluje `settings.automation_enabled`. 
- Dokumentace aktualizována (`docs/automation.md`, `docs/operations.md`) a přidán auditní souhrn `docs/phase5-audit.md` popisující nálezy a opravy.

### Testing

- Statické a typové kontroly: `ruff format/check` a `mypy` proběhly bez nálezů, a `python -m compileall` úspěšně zkompiloval zdroj i testy. 
- Přidány regresní testy: `test_expired_owner_cannot_renew_finish_or_fail_without_takeover`, `test_retry_uses_materialized_account_strategy_and_job_type_snapshot`, `test_manual_run_rejects_disabled_job_at_service_boundary` a PostgreSQL concurrency test `test_postgres_concurrent_manual_run_recovers_unique_conflict`. 
- Běh kompletní PostgreSQL acceptance s `RUN_POSTGRES_TESTS=1` a některé CI kroky (např. `uv sync`, Postgres service) byl lokálně `BLOCKED BY ENVIRONMENT` kvůli chybějícímu `uv`/Docker; CI by měl spustit plnou sadu Postgres testů, kde jsou nové testy navrženy pro nezávislé sessions a barrier-synchronizaci.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b113645cc8332b960cefd842674c4)