### PR TITLE
Obnovení oprav review Phase 6

### DIFF
--- a/backend/src/quantlab/market_data.py
+++ b/backend/src/quantlab/market_data.py
@@ -12,7 +12,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, timedelta
 from datetime import time as clock
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from enum import StrEnum
 from typing import Protocol
 from uuid import uuid4
@@ -159,8 +159,19 @@ class XNYSCalendar:
         thanksgiving = date(day.year, 11, 1) + timedelta(
             days=(3 - date(day.year, 11, 1).weekday()) % 7 + 21
         )
-        return day == thanksgiving + timedelta(days=1) or (
-            day.month == 12 and day.day == 24 and self.is_session(day)
+        independence_day = date(day.year, 7, 4)
+        observed_independence_day = (
+            independence_day - timedelta(days=1)
+            if independence_day.weekday() == 5
+            else independence_day + timedelta(days=1)
+            if independence_day.weekday() == 6
+            else independence_day
+        )
+        session_before_independence_day = self.previous_session(observed_independence_day)
+        return (
+            day == thanksgiving + timedelta(days=1)
+            or day == session_before_independence_day
+            or (day.month == 12 and day.day == 24 and self.is_session(day))
         )
 
     def session_open(self, day: date) -> datetime:
@@ -243,15 +254,27 @@ def normalize_bar(
         raise InvalidMarketData("Ceny musí být konečné a kladné a volume nezáporný")
     if bar.high < max(*values) or bar.low > min(*values):
         raise InvalidMarketData("Provider bar porušuje OHLC invariant")
+    timeframe = "1d"
     payload = "|".join(
-        map(str, (instrument.instrument_id, bar.session_date, *values, bar.volume, bar.source_id))
+        map(
+            str,
+            (
+                instrument.instrument_id,
+                provider,
+                timeframe,
+                bar.session_date,
+                *values,
+                bar.volume,
+                bar.source_id,
+            ),
+        )
     )
     digest = hashlib.sha256(payload.encode()).hexdigest()
     return Observation(
         digest,
         instrument.instrument_id,
         provider,
-        "1d",
+        timeframe,
         bar.session_date,
         calendar.session_close(bar.session_date),
         *values,
@@ -392,7 +415,7 @@ class StooqProvider:
                 )
                 for r in rows
             ]
-        except (KeyError, ValueError, UnicodeError) as exc:
+        except (InvalidOperation, KeyError, ValueError, UnicodeError) as exc:
             raise InvalidProviderResponse("Provider vrátil neplatné CSV") from exc
         if len({bar.session_date for bar in bars}) != len(bars):
             raise InvalidProviderResponse("Provider vrátil duplicitní bary")
@@ -510,6 +533,7 @@ def build_snapshot(
     start: date,
     end: date,
     minimum_coverage: Decimal = Decimal("0.8"),
+    calendar: XNYSCalendar | None = None,
 ) -> DatasetSnapshot:
     ids = frozenset(instrument_ids)
     rows = tuple(
@@ -517,8 +541,11 @@ def build_snapshot(
         for r in store.as_known_at(as_of)
         if r.instrument_id in ids and r.provider == provider and start <= r.session_date <= end
     )
-    used = {r.instrument_id for r in rows}
-    coverage = Decimal(len(used)) / Decimal(len(ids)) if ids else Decimal("1")
+    active_calendar = calendar or XNYSCalendar()
+    sessions = active_calendar.sessions_between(start, end)
+    expected = len(ids) * len(sessions)
+    present = {(r.instrument_id, r.session_date) for r in rows}
+    coverage = Decimal(len(present)) / Decimal(expected) if expected else Decimal("1")
     canonical = [
         {"id": r.observation_id, "revision": r.revision, "hash": r.source_hash}
         for r in sorted(rows, key=lambda r: (r.instrument_id, r.session_date))

--- a/backend/src/quantlab/multi_asset.py
+++ b/backend/src/quantlab/multi_asset.py
@@ -7,7 +7,12 @@ from decimal import ROUND_DOWN, Decimal
 from enum import StrEnum
 
 from quantlab.domain import Side, require_utc
-from quantlab.market_data import CorporateAction, CorporateActionKind, Observation
+from quantlab.market_data import (
+    CorporateAction,
+    CorporateActionKind,
+    Observation,
+    causal_adjusted_close,
+)
 from quantlab.universe import PointInTimeUniverse
 
 
@@ -22,13 +27,23 @@ class StrategyContext:
     decision_time: datetime
     history: Mapping[str, tuple[Observation, ...]]
     eligible_instruments: tuple[str, ...]
+    signal_prices: Mapping[str, tuple[Decimal, ...]]
 
     def __post_init__(self) -> None:
         cutoff = require_utc(self.decision_time)
-        if any(bar.timestamp > cutoff for bars in self.history.values() for bar in bars):
+        if any(
+            bar.timestamp > cutoff or bar.observed_at > cutoff
+            for bars in self.history.values()
+            for bar in bars
+        ):
             raise ValueError("Strategy context obsahuje budoucí observation")
         if any(symbol not in self.eligible_instruments for symbol in self.history):
             raise ValueError("Strategy context obsahuje asset mimo PIT universe")
+        if set(self.signal_prices) != set(self.history) or any(
+            len(self.signal_prices[instrument]) != len(bars)
+            for instrument, bars in self.history.items()
+        ):
+            raise ValueError("Adjusted signal series neodpovídá causal observation history")
 
 
 @dataclass(frozen=True)
@@ -79,7 +94,7 @@ class TrendStrategy(PortfolioStrategy):
     def generate_targets(self, context: StrategyContext) -> TargetPortfolio:
         selected = []
         for instrument in context.eligible_instruments:
-            prices = [bar.close for bar in context.history.get(instrument, ())]
+            prices = context.signal_prices.get(instrument, ())
             if (
                 len(prices) >= self.slow
                 and sum(prices[-self.fast :]) / self.fast > sum(prices[-self.slow :]) / self.slow
@@ -108,9 +123,9 @@ class CrossSectionalMomentumStrategy(PortfolioStrategy):
     def generate_targets(self, context: StrategyContext) -> TargetPortfolio:
         ranks: list[tuple[Decimal, str]] = []
         for instrument in context.eligible_instruments:
-            bars = context.history.get(instrument, ())
-            if len(bars) >= self.required_lookback:
-                ranks.append((bars[-1].close / bars[-self.required_lookback].close - 1, instrument))
+            prices = context.signal_prices.get(instrument, ())
+            if len(prices) >= self.required_lookback:
+                ranks.append((prices[-1] / prices[-self.required_lookback] - 1, instrument))
         # Vyšší výnos první, ticker-independent canonical ID řeší tie deterministicky.
         chosen = [
             instrument for _, instrument in sorted(ranks, key=lambda x: (-x[0], x[1]))[: self.top_n]
@@ -140,12 +155,10 @@ class MeanReversionStrategy(PortfolioStrategy):
     def generate_targets(self, context: StrategyContext) -> TargetPortfolio:
         selected = []
         for instrument in context.eligible_instruments:
-            bars = context.history.get(instrument, ())
-            if len(bars) >= self.lookback:
-                mean = (
-                    sum((bar.close for bar in bars[-self.lookback :]), Decimal("0")) / self.lookback
-                )
-                if bars[-1].close / mean <= self.threshold:
+            prices = context.signal_prices.get(instrument, ())
+            if len(prices) >= self.lookback:
+                mean = sum(prices[-self.lookback :], Decimal("0")) / self.lookback
+                if prices[-1] / mean <= self.threshold:
                     selected.append(instrument)
         weight = Decimal("1") / len(selected) if selected else Decimal("0")
         return TargetPortfolio(
@@ -223,6 +236,9 @@ class MultiAssetResult:
     requested_assets: int
     used_assets: int
     excluded: tuple[tuple[str, str], ...]
+    final_cash: Decimal
+    final_positions: tuple[tuple[str, Decimal], ...]
+    dividend_income: Decimal
 
 
 def _rebalance(day: datetime, previous: datetime | None, frequency: RebalanceFrequency) -> bool:
@@ -241,15 +257,17 @@ def run_multi_asset(
     commission_bps: Decimal = Decimal("1"),
     stale_sessions: int = 1,
     currencies: Mapping[str, str] | None = None,
+    corporate_actions: Sequence[CorporateAction] = (),
 ) -> MultiAssetResult:
     if currencies and len(set(currencies.values())) > 1:
         raise ValueError("Multi-currency portfolio bez FX konverze není podporováno")
-    by_time: dict[datetime, dict[str, Observation]] = {}
-    for row in observations:
-        by_time.setdefault(row.timestamp, {})[row.instrument_id] = row
-    times = sorted(by_time)
+    revisions: dict[tuple[str, datetime], list[Observation]] = {}
+    for row in sorted(
+        observations, key=lambda item: (item.timestamp, item.observed_at, item.revision)
+    ):
+        revisions.setdefault((row.instrument_id, row.timestamp), []).append(row)
+    times = sorted({row.timestamp for row in observations})
     portfolio = MultiAssetPortfolio(initial_cash)
-    history: dict[str, list[Observation]] = {}
     pending: TargetPortfolio | None = None
     fills: list[MultiAssetFill] = []
     decisions: list[tuple[datetime, TargetPortfolio]] = []
@@ -257,23 +275,53 @@ def run_multi_asset(
     last_rebalance: datetime | None = None
     last_prices: dict[str, tuple[Decimal, int]] = {}
     excluded: dict[str, str] = {}
+    ordered_actions = sorted(
+        corporate_actions, key=lambda action: (action.effective_at, action.action_id)
+    )
     for index, when in enumerate(times):
-        current = by_time[when]
+        known_rows = {
+            key: max(
+                (row for row in rows if row.observed_at <= when),
+                key=lambda row: (row.observed_at, row.revision),
+            )
+            for key, rows in revisions.items()
+            if key[1] <= when and any(row.observed_at <= when for row in rows)
+        }
+        current = {
+            instrument: row
+            for (instrument, timestamp), row in known_rows.items()
+            if timestamp == when
+        }
+        for action in ordered_actions:
+            if action.effective_at <= when and action.known_at <= when:
+                portfolio.apply_action(action)
         # Pending close T targets se realizují až na raw open další dostupné společné session.
         if pending is not None:
             prices = {instrument: bar.open for instrument, bar in current.items()}
-            values = {
-                instrument: portfolio.positions.get(instrument, Decimal("0")) * price
-                for instrument, price in prices.items()
-            }
-            total = portfolio.cash + sum(values.values())
-            desired = {
-                instrument: (total * weight / prices[instrument]).to_integral_value(
-                    rounding=ROUND_DOWN
-                )
-                for instrument, weight in pending.weights
-                if instrument in prices
-            }
+            missing_positions = [
+                instrument
+                for instrument, quantity in portfolio.positions.items()
+                if quantity and instrument not in prices
+            ]
+            if missing_positions:
+                for instrument in missing_positions:
+                    excluded[instrument] = "missing_rebalance_execution_bar"
+            total = portfolio.cash + sum(
+                quantity * prices[instrument]
+                for instrument, quantity in portfolio.positions.items()
+                if quantity and instrument in prices
+            )
+            desired = (
+                {}
+                if missing_positions
+                else {
+                    instrument: (total * weight / prices[instrument]).to_integral_value(
+                        rounding=ROUND_DOWN
+                    )
+                    for instrument, weight in pending.weights
+                    if instrument in prices
+                }
+            )
             # Pozice, které již nejsou v targetu (včetně PIT leaverů), se bezpečně uzavřou
             # pouze tehdy, když existuje čerstvý executable open; cenu nikdy nedopočítáváme.
             for instrument, quantity in portfolio.positions.items():
@@ -301,18 +349,29 @@ def run_multi_asset(
                     fill = MultiAssetFill(instrument, side, quantity, price, fee, when)
                     portfolio.apply_fill(fill)
                     fills.append(fill)
-            pending = None
+            if not missing_positions:
+                pending = None
         for instrument, bar in current.items():
-            history.setdefault(instrument, []).append(bar)
             last_prices[instrument] = (bar.close, index)
+        history: dict[str, list[Observation]] = {}
+        for (instrument, _), bar in sorted(known_rows.items(), key=lambda item: item[0][1]):
+            history.setdefault(instrument, []).append(bar)
         eligible = universe.eligible(when)
         visible = {instrument: tuple(history.get(instrument, ())) for instrument in eligible}
-        if _rebalance(when, last_rebalance, strategy.rebalance_frequency):
+        if pending is None and _rebalance(when, last_rebalance, strategy.rebalance_frequency):
             fresh = tuple(instrument for instrument in eligible if instrument in current)
             for instrument in eligible:
                 if instrument not in fresh:
                     excluded[instrument] = "stale_or_missing_execution_bar"
-            context = StrategyContext(when, {k: visible[k] for k in fresh}, fresh)
+            causal_history = {k: visible[k] for k in fresh}
+            signal_prices = {
+                instrument: tuple(
+                    causal_adjusted_close(bars, ordered_actions, when)[bar.session_date]
+                    for bar in bars
+                )
+                for instrument, bars in causal_history.items()
+            }
+            context = StrategyContext(when, causal_history, fresh, signal_prices)
             pending = strategy.generate_targets(context)
             decisions.append((when, pending))
             last_rebalance = when
@@ -334,4 +393,7 @@ def run_multi_asset(
         requested,
         used,
         tuple(sorted(excluded.items())),
+        portfolio.cash,
+        tuple(sorted(portfolio.positions.items())),
+        portfolio.dividend_income,
     )

--- a/backend/tests/test_phase6.py
+++ b/backend/tests/test_phase6.py
@@ -27,6 +27,7 @@ from quantlab.multi_asset import (
     MeanReversionStrategy,
     MultiAssetFill,
     MultiAssetPortfolio,
+    RebalanceFrequency,
     StrategyContext,
     TargetPortfolio,
     TrendStrategy,
@@ -65,18 +66,20 @@ def bar(day, close="10", source=None):
     return ProviderBar(day, value, value, value, value, Decimal("100"), source or str(day))
 
 
-def obs(instrument, day, close, observed=NOW, ingestion="x"):
+def obs(instrument, day, close, observed=None, ingestion="x"):
     if isinstance(instrument, str):
         instrument = Instrument(
             instrument, instrument, "XNYS", "XNYS", "USD", AssetType.EQUITY, date(2000, 1, 1)
         )
-    return normalize_bar(bar(day, close), instrument, "fixture", observed, ingestion, CAL)
+    known_at = observed or CAL.session_close(day)
+    return normalize_bar(bar(day, close), instrument, "fixture", known_at, ingestion, CAL)
 
 
 def test_calendar_holiday_early_close_and_next_session():
     assert not CAL.is_session(date(2024, 7, 4))
     assert CAL.next_session(date(2024, 7, 3)) == date(2024, 7, 5)
     assert CAL.session_close(date(2024, 11, 29)).hour == 18  # 13:00 New York v UTC
+    assert CAL.session_close(date(2024, 7, 3)).hour == 17
     assert CAL.session_close(date(2024, 11, 27)).hour == 21
 
 
@@ -128,6 +131,11 @@ def test_stooq_fixture_contract_valid_partial_empty_malformed_duplicate_rate_lim
         ).historical_daily("A", date(2024, 1, 1), date(2024, 1, 2))
     with pytest.raises(InvalidSymbol):
         provider.resolve("../secret")
+    invalid_decimal = b"Date,Open,High,Low,Close,Volume\n2024-01-02,N/D,2,1,2,10\n"
+    with pytest.raises(InvalidProviderResponse):
+        StooqProvider(lambda u, t: (200, {}, invalid_decimal), max_attempts=1).historical_daily(
+            "A", date(2024, 1, 1), date(2024, 1, 2)
+        )
 
 
 def test_ingestion_idempotency_overlap_revision_and_snapshot_immutability():
@@ -241,13 +249,14 @@ def test_targets_validation_ties_and_missing_lookback():
     histories = {
         x: tuple(obs(x, d, c) for d, c in [(d1, "10"), (d2, "11"), (d3, "12")]) for x in ("a", "b")
     }
+    signals = {key: tuple(bar.close for bar in bars) for key, bars in histories.items()}
     target = strategy.generate_targets(
-        StrategyContext(CAL.session_close(d3), histories, ("a", "b"))
+        StrategyContext(CAL.session_close(d3), histories, ("a", "b"), signals)
     )
     assert target.weights[0][0] == "a"
     assert (
         CrossSectionalMomentumStrategy(5, 2)
-        .generate_targets(StrategyContext(CAL.session_close(d3), histories, ("a", "b")))
+        .generate_targets(StrategyContext(CAL.session_close(d3), histories, ("a", "b"), signals))
         .weights
         == ()
     )
@@ -258,10 +267,15 @@ def test_targets_validation_ties_and_missing_lookback():
 def test_context_and_prefix_invariance_reject_future_data():
     past = obs("a", date(2024, 1, 8), "10")
     future = obs("a", date(2024, 1, 9), "999")
-    context = StrategyContext(past.timestamp, {"a": (past,)}, ("a",))
+    context = StrategyContext(past.timestamp, {"a": (past,)}, ("a",), {"a": (past.close,)})
     assert CrossSectionalMomentumStrategy(2, 1).generate_targets(context).weights == ()
     with pytest.raises(ValueError):
-        StrategyContext(past.timestamp, {"a": (past, future)}, ("a",))
+        StrategyContext(
+            past.timestamp,
+            {"a": (past, future)},
+            ("a",),
+            {"a": (past.close, future.close)},
+        )
 
 
 def test_multi_asset_accounting_split_dividend_and_cash_constraint():
@@ -330,3 +344,96 @@ def test_multi_asset_next_session_shared_cash_and_master_future_mutation():
         for t, target in rerun.decisions
         if t <= CAL.session_close(date(2024, 1, 5))
     )
+
+
+def single_asset_universe() -> PointInTimeUniverse:
+    return PointInTimeUniverse(
+        UniverseDefinition("single", "pit", UniverseKind.POINT_IN_TIME_MEMBERSHIP),
+        [
+            UniverseMembership(
+                "single",
+                "a",
+                datetime(2020, 1, 1, tzinfo=UTC),
+                None,
+                datetime(2020, 1, 1, tzinfo=UTC),
+            )
+        ],
+    )
+
+
+def test_observation_identity_contains_provider_and_coverage_counts_sessions():
+    first = normalize_bar(bar(date(2024, 1, 8)), INST, "first", NOW, "x", CAL)
+    second = normalize_bar(bar(date(2024, 1, 8)), INST, "second", NOW, "x", CAL)
+    assert first.observation_id != second.observation_id
+    store = InMemoryObservationStore()
+    store.ingest(
+        FixtureProvider([bar(date(2024, 1, 8))]),
+        INST,
+        date(2024, 1, 8),
+        date(2024, 1, 12),
+        NOW,
+        CAL,
+    )
+    snapshot = build_snapshot(
+        store,
+        as_of=NOW,
+        provider="fixture",
+        calendar_identity=CAL.identity,
+        universe_id="u",
+        instrument_ids=["i-a"],
+        start=date(2024, 1, 8),
+        end=date(2024, 1, 12),
+    )
+    assert snapshot.coverage == Decimal("0.2")
+    assert snapshot.status == "INVALID"
+
+
+def test_revision_known_later_does_not_change_earlier_decision():
+    days = [date(2024, 1, day) for day in (3, 4, 5, 8)]
+    rows = [obs("a", day, str(10 + index)) for index, day in enumerate(days)]
+    correction = obs(
+        "a",
+        days[0],
+        "999",
+        observed=CAL.session_close(days[-1]),
+        ingestion="correction",
+    )
+    strategy = TrendStrategy(1, 2, rebalance_frequency=RebalanceFrequency.DAILY)
+    baseline = run_multi_asset(rows, single_asset_universe(), strategy)
+    revised = run_multi_asset([*rows, correction], single_asset_universe(), strategy)
+    cutoff = CAL.session_close(days[2])
+    assert [(when, target.weights) for when, target in baseline.decisions if when <= cutoff] == [
+        (when, target.weights) for when, target in revised.decisions if when <= cutoff
+    ]
+
+
+def test_runner_uses_adjusted_signals_and_applies_actions():
+    days = [date(2024, 1, day) for day in (3, 4, 5, 8)]
+    closes = ("90", "100", "55", "60")
+    rows = [obs("a", day, close) for day, close in zip(days, closes, strict=True)]
+    split = CorporateAction(
+        "split",
+        "a",
+        CorporateActionKind.SPLIT,
+        CAL.session_close(days[2]),
+        CAL.session_close(days[2]),
+        Decimal("2"),
+    )
+    dividend = CorporateAction(
+        "dividend",
+        "a",
+        CorporateActionKind.CASH_DIVIDEND,
+        CAL.session_close(days[3]),
+        CAL.session_close(days[3]),
+        Decimal("1"),
+    )
+    result = run_multi_asset(
+        rows,
+        single_asset_universe(),
+        TrendStrategy(1, 2, rebalance_frequency=RebalanceFrequency.DAILY),
+        initial_cash=Decimal("1000"),
+        commission_bps=Decimal("0"),
+        corporate_actions=(split, dividend),
+    )
+    assert dict(result.decisions)[CAL.session_close(days[2])].weights == (("a", Decimal("1")),)
+    assert result.dividend_income > 0


### PR DESCRIPTION
### Shrnutí

Obnovuje opravy osmi stále nevyřešených Codex review připomínek z Phase 6, které byly po pozdějším merge omylem přepsány starší variantou.

### Opravy

- filtruje observation revisions podle `observed_at <= decision_time` a vybírá as-known revision;
- strategie používají kauzálně adjusted signal prices, raw ceny zůstávají pro execution/valuation;
- `run_multi_asset` aplikuje corporate actions kauzálně během backtestu;
- rebalance se při chybějícím executable baru existující pozice odloží místo podhodnocení equity;
- snapshot coverage počítá očekávané instrument/session observations;
- doplněn XNYS pre-Independence-Day early close;
- observation hash zahrnuje provider a timeframe;
- malformed Decimal payload je mapován na `InvalidProviderResponse`;
- přidány odpovídající regresní testy.

Diff proti aktuálnímu `main` mění pouze `market_data.py`, `multi_asset.py` a `test_phase6.py`; žádné jiné pozdější změny se nevracejí.

Review thready v PR #17 jsem záměrně nekomentoval ani neřešil automaticky.