### PR TITLE
Přidání persistentního Phase6 experiment runneru a lineage migrace

### DIFF
--- a/alembic/versions/20260812_01_phase6_experiment_lineage.py
+++ b/alembic/versions/20260812_01_phase6_experiment_lineage.py
@@ -1,0 +1,41 @@
+"""Doplnění typované identity a lineage Phase 6 experimentu."""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260812_01"
+down_revision = "20260811_06"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("research_experiments", sa.Column("idempotency_key", sa.String(64)))
+    op.add_column("research_experiments", sa.Column("code_sha", sa.String(64)))
+    op.add_column("research_experiments", sa.Column("seed", sa.Integer()))
+    op.add_column("research_experiments", sa.Column("cost_model_json", sa.Text()))
+    op.add_column(
+        "research_experiments", sa.Column("selected_parameters_json", sa.Text())
+    )
+    op.create_index(
+        "ix_research_experiments_idempotency_key",
+        "research_experiments",
+        ["idempotency_key"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_research_experiments_idempotency_key", table_name="research_experiments"
+    )
+    for name in (
+        "selected_parameters_json",
+        "cost_model_json",
+        "seed",
+        "code_sha",
+        "idempotency_key",
+    ):
+        op.drop_column("research_experiments", name)

--- a/alembic/versions/20260812_01_phase6_experiment_lineage.py
+++ b/alembic/versions/20260812_01_phase6_experiment_lineage.py
@@ -12,19 +12,31 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column("research_experiments", sa.Column("idempotency_key", sa.String(64)))
-    op.add_column("research_experiments", sa.Column("code_sha", sa.String(64)))
-    op.add_column("research_experiments", sa.Column("seed", sa.Integer()))
-    op.add_column("research_experiments", sa.Column("cost_model_json", sa.Text()))
-    op.add_column(
-        "research_experiments", sa.Column("selected_parameters_json", sa.Text())
-    )
-    op.create_index(
-        "ix_research_experiments_idempotency_key",
-        "research_experiments",
-        ["idempotency_key"],
-        unique=True,
-    )
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    columns = {
+        column["name"] for column in inspector.get_columns("research_experiments")
+    }
+    for name, kind in (
+        ("idempotency_key", sa.String(64)),
+        ("code_sha", sa.String(64)),
+        ("seed", sa.Integer()),
+        ("cost_model_json", sa.Text()),
+        ("selected_parameters_json", sa.Text()),
+    ):
+        # Initial migrace používá aktuální metadata, proto na prázdné DB sloupec už existuje.
+        if name not in columns:
+            op.add_column("research_experiments", sa.Column(name, kind))
+    indexes = {
+        index["name"] for index in sa.inspect(bind).get_indexes("research_experiments")
+    }
+    if "ix_research_experiments_idempotency_key" not in indexes:
+        op.create_index(
+            "ix_research_experiments_idempotency_key",
+            "research_experiments",
+            ["idempotency_key"],
+            unique=True,
+        )
 
 
 def downgrade() -> None:

--- a/backend/src/quantlab/market_data_service.py
+++ b/backend/src/quantlab/market_data_service.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from collections.abc import Callable, Sequence
 from dataclasses import replace
-from datetime import UTC, date, datetime, time
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import Decimal
 
 from sqlalchemy import Select, and_, func, select, text
@@ -278,16 +278,40 @@ class DatasetSnapshotService:
                     selected, key=lambda item: (item.instrument_id, item.session_date)
                 )
             ]
+            selected_instruments = {row.instrument_id for row in selected}
+            actions = tuple(
+                session.scalars(
+                    select(CorporateActionRecord).where(
+                        CorporateActionRecord.instrument_id.in_(selected_instruments),
+                        CorporateActionRecord.known_at <= cutoff,
+                        CorporateActionRecord.effective_at <= _instant(end + timedelta(days=1)),
+                    )
+                )
+            )
+            canonical_actions = [
+                {
+                    "action_id": action.action_id,
+                    "instrument_id": action.instrument_id,
+                    "kind": action.kind,
+                    "effective_at": action.effective_at.isoformat(),
+                    "known_at": action.known_at.isoformat(),
+                    "value": action.value,
+                    "new_symbol": action.new_symbol,
+                }
+                for action in sorted(actions, key=lambda item: item.action_id)
+            ]
+            immutable_content = {"observations": canonical, "corporate_actions": canonical_actions}
             content_hash = hashlib.sha256(
-                json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode()
+                json.dumps(immutable_content, sort_keys=True, separators=(",", ":")).encode()
             ).hexdigest()
             snapshot_id = hashlib.sha256(f"{logical}|{content_hash}".encode()).hexdigest()
             status = "VALID" if expected and coverage >= minimum_coverage else "INVALID"
             manifest = json.dumps(
                 {
-                    "schema_version": "2",
+                    "schema_version": "3",
                     "logical_identity": logical,
                     "observations": canonical,
+                    "corporate_actions": canonical_actions,
                     "expected_count": len(expected),
                     "present_count": len(present),
                 },

--- a/backend/src/quantlab/multi_asset.py
+++ b/backend/src/quantlab/multi_asset.py
@@ -259,6 +259,7 @@ def run_multi_asset(
     stale_sessions: int = 1,
     currencies: Mapping[str, str] | None = None,
     corporate_actions: Sequence[CorporateAction] = (),
+    evaluation_start: datetime | None = None,
 ) -> MultiAssetResult:
     if currencies and len(set(currencies.values())) > 1:
         raise ValueError("Multi-currency portfolio bez FX konverze není podporováno")
@@ -298,7 +299,8 @@ def run_multi_asset(
             if action.effective_at <= when and action.known_at <= when:
                 portfolio.apply_action(action)
         # Pending close T targets se realizují až na raw open další dostupné společné session.
-        if pending is not None:
+        in_evaluation = evaluation_start is None or when >= require_utc(evaluation_start)
+        if pending is not None and in_evaluation:
             prices = {instrument: bar.open for instrument, bar in current.items()}
             missing_positions = [
                 instrument
@@ -360,7 +362,11 @@ def run_multi_asset(
             history.setdefault(instrument, []).append(bar)
         eligible = universe.eligible(when)
         visible = {instrument: tuple(history.get(instrument, ())) for instrument in eligible}
-        if pending is None and _rebalance(when, last_rebalance, strategy.rebalance_frequency):
+        if (
+            in_evaluation
+            and pending is None
+            and _rebalance(when, last_rebalance, strategy.rebalance_frequency)
+        ):
             fresh = tuple(instrument for instrument in eligible if instrument in current)
             for instrument in eligible:
                 if instrument not in fresh:
@@ -385,8 +391,9 @@ def run_multi_asset(
             if price_info is None or index - price_info[1] > stale_sessions:
                 raise RuntimeError("Existing position nelze ocenit kvůli stale datům")
             value += quantity * price_info[0]
-        equity.append((when, value))
-        exposure.append((when, (value - portfolio.cash) / value if value else Decimal("0")))
+        if in_evaluation:
+            equity.append((when, value))
+            exposure.append((when, (value - portfolio.cash) / value if value else Decimal("0")))
     requested = len({m for when in times for m in universe.eligible(when)})
     used = len({fill.instrument_id for fill in fills})
     return MultiAssetResult(

--- a/backend/src/quantlab/persistence.py
+++ b/backend/src/quantlab/persistence.py
@@ -244,6 +244,11 @@ class ExperimentRecord(Base):
     time_weighted_exposure: Mapped[float | None] = mapped_column(Float)
     trade_count: Mapped[int | None] = mapped_column(Integer)
     total_costs: Mapped[float | None] = mapped_column(Float)
+    idempotency_key: Mapped[str | None] = mapped_column(String(64), unique=True, index=True)
+    code_sha: Mapped[str | None] = mapped_column(String(64))
+    seed: Mapped[int | None] = mapped_column(Integer)
+    cost_model_json: Mapped[str | None] = mapped_column(Text)
+    selected_parameters_json: Mapped[str | None] = mapped_column(Text)
     config_json: Mapped[str] = mapped_column(Text, nullable=False)
     result_json: Mapped[str] = mapped_column(Text, nullable=False)
 

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -136,12 +136,33 @@ class Phase6ExperimentRunner:
             strategy_type = STRATEGY_REGISTRY.get(request.strategy_name)
             if strategy_row is None or strategy_type is None:
                 raise DatasetInvalid("Přesná strategy version není registrována")
-            manifest = json.loads(snapshot.manifest_json)
+            try:
+                manifest: object = json.loads(snapshot.manifest_json)
+            except json.JSONDecodeError as exc:
+                raise DatasetInvalid("Snapshot manifest není validní JSON") from exc
+            if not isinstance(manifest, dict):
+                raise DatasetInvalid("Snapshot manifest musí být objekt")
             entries = manifest.get("observations")
             if not isinstance(entries, list) or not entries:
                 raise DatasetInvalid("Snapshot manifest neobsahuje observations")
-            ids = [entry.get("id") for entry in entries if isinstance(entry, dict)]
-            if len(ids) != len(entries) or len(set(ids)) != len(ids):
+            parsed_entries: list[tuple[str, int, str]] = []
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    raise DatasetInvalid("Snapshot manifest není interně konzistentní")
+                observation_id = entry.get("id")
+                revision = entry.get("revision")
+                source_hash = entry.get("hash")
+                if (
+                    not isinstance(observation_id, str)
+                    or not isinstance(revision, int)
+                    or isinstance(revision, bool)
+                    or revision <= 0
+                    or not isinstance(source_hash, str)
+                ):
+                    raise DatasetInvalid("Snapshot manifest není interně konzistentní")
+                parsed_entries.append((observation_id, revision, source_hash))
+            ids = [entry[0] for entry in parsed_entries]
+            if len(set(ids)) != len(ids):
                 raise DatasetInvalid("Snapshot manifest není interně konzistentní")
             rows = tuple(
                 session.scalars(
@@ -152,9 +173,9 @@ class Phase6ExperimentRunner:
             )
             by_id = {row.observation_id: row for row in rows}
             if set(by_id) != set(ids) or any(
-                by_id[entry["id"]].revision != entry["revision"]
-                or by_id[entry["id"]].source_hash != entry["hash"]
-                for entry in entries
+                by_id[observation_id].revision != revision
+                or by_id[observation_id].source_hash != source_hash
+                for observation_id, revision, source_hash in parsed_entries
             ):
                 raise DatasetInvalid("Snapshot manifest odkazuje na změněná nebo chybějící data")
             observations = tuple(_observation(by_id[item]) for item in ids)

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -13,12 +13,19 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from quantlab.domain import require_utc
-from quantlab.market_data import DatasetInvalid, Observation, XNYSCalendar
+from quantlab.market_data import (
+    CorporateAction,
+    CorporateActionKind,
+    DatasetInvalid,
+    Observation,
+    XNYSCalendar,
+)
 from quantlab.market_data_service import _lock, _observation
 from quantlab.multi_asset import STRATEGY_REGISTRY, MultiAssetResult, run_multi_asset
 from quantlab.persistence import (
     DatasetSnapshotRecord,
     ExperimentRecord,
+    InstrumentRecord,
     MarketDataIngestionRecord,
     MarketObservationRecord,
     StrategyDeploymentRecord,
@@ -118,6 +125,7 @@ class Phase6ExperimentRunner:
                 select(ExperimentRecord).where(ExperimentRecord.idempotency_key == identity)
             )
             if existing is not None:
+                session.expunge(existing)
                 return existing
             snapshot = session.get(DatasetSnapshotRecord, request.snapshot_id)
             if (
@@ -179,6 +187,27 @@ class Phase6ExperimentRunner:
             ):
                 raise DatasetInvalid("Snapshot manifest odkazuje na změněná nebo chybějící data")
             observations = tuple(_observation(by_id[item]) for item in ids)
+            action_entries = manifest.get("corporate_actions")
+            if not isinstance(action_entries, list):
+                raise DatasetInvalid("Snapshot manifest neobsahuje immutable corporate actions")
+            try:
+                corporate_actions = tuple(
+                    CorporateAction(
+                        action_id=entry["action_id"],
+                        instrument_id=entry["instrument_id"],
+                        kind=CorporateActionKind(entry["kind"]),
+                        effective_at=datetime.fromisoformat(entry["effective_at"]),
+                        known_at=datetime.fromisoformat(entry["known_at"]),
+                        value=Decimal(entry["value"]) if entry["value"] is not None else None,
+                        new_symbol=entry["new_symbol"],
+                    )
+                    for entry in action_entries
+                    if isinstance(entry, dict)
+                )
+            except (KeyError, TypeError, ValueError) as exc:
+                raise DatasetInvalid("Snapshot corporate actions nejsou konzistentní") from exc
+            if len(corporate_actions) != len(action_entries):
+                raise DatasetInvalid("Snapshot corporate actions nejsou konzistentní")
             times = sorted({item.timestamp for item in observations})
             train_end = int(len(times) * float(request.train_fraction))
             validation_end = train_end + int(len(times) * float(request.validation_fraction))
@@ -212,6 +241,17 @@ class Phase6ExperimentRunner:
                     for row in membership_rows
                 ],
             )
+            instrument_ids = {item.instrument_id for item in observations}
+            instrument_rows = tuple(
+                session.scalars(
+                    select(InstrumentRecord).where(
+                        InstrumentRecord.instrument_id.in_(instrument_ids)
+                    )
+                )
+            )
+            currencies = {row.instrument_id: row.currency for row in instrument_rows}
+            if set(currencies) != instrument_ids:
+                raise DatasetInvalid("Snapshot odkazuje na chybějící instrument metadata")
 
             def evaluate(
                 config: dict[str, object], selected_times: list[datetime]
@@ -219,12 +259,17 @@ class Phase6ExperimentRunner:
                 strategy = strategy_type(**config)
                 if strategy.version != request.strategy_version:
                     raise DatasetInvalid("Implementace strategy version neodpovídá registru")
+                evaluation_start = selected_times[0]
+                evaluation_end = selected_times[-1]
                 result = run_multi_asset(
-                    [item for item in observations if item.timestamp in selected_times],
+                    [item for item in observations if item.timestamp <= evaluation_end],
                     universe,
                     strategy,
                     request.initial_cash,
                     request.commission_bps,
+                    currencies=currencies,
+                    corporate_actions=corporate_actions,
+                    evaluation_start=evaluation_start,
                 )
                 return multi_asset_metrics(result, request.initial_cash)
 
@@ -271,6 +316,7 @@ class Phase6ExperimentRunner:
             )
             session.add(experiment)
             session.flush()
+            session.expunge(experiment)
             return experiment
 
 

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import math
+import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -11,14 +14,23 @@ from sqlalchemy.orm import Session
 
 from quantlab.domain import require_utc
 from quantlab.market_data import DatasetInvalid, Observation, XNYSCalendar
-from quantlab.market_data_service import _observation
-from quantlab.multi_asset import MultiAssetResult
+from quantlab.market_data_service import _lock, _observation
+from quantlab.multi_asset import STRATEGY_REGISTRY, MultiAssetResult, run_multi_asset
 from quantlab.persistence import (
     DatasetSnapshotRecord,
     ExperimentRecord,
     MarketDataIngestionRecord,
     MarketObservationRecord,
     StrategyDeploymentRecord,
+    StrategyRecord,
+    UniverseDefinitionRecord,
+    UniverseMembershipRecord,
+)
+from quantlab.universe import (
+    PointInTimeUniverse,
+    UniverseDefinition,
+    UniverseKind,
+    UniverseMembership,
 )
 
 
@@ -33,6 +45,212 @@ class MultiAssetMetrics:
     time_weighted_exposure: Decimal
     trade_count: int
     total_costs: Decimal
+
+    @property
+    def risk_adjusted_return(self) -> Decimal:
+        return self.sharpe
+
+
+@dataclass(frozen=True)
+class Phase6ExperimentRequest:
+    snapshot_id: str
+    strategy_name: str
+    strategy_version: str
+    parameter_configs: tuple[dict[str, object], ...]
+    train_fraction: Decimal = Decimal("0.6")
+    validation_fraction: Decimal = Decimal("0.2")
+    initial_cash: Decimal = Decimal("100000")
+    commission_bps: Decimal = Decimal("1")
+    seed: int = 42
+    code_sha: str | None = None
+
+
+class Phase6ExperimentRunner:
+    """Snapshot-only Phase 6 runner s persistentní, exactly-once OOS identitou."""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._sessions = session_factory
+
+    @staticmethod
+    def _canonical(value: object) -> str:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+    @staticmethod
+    def _code_sha(explicit: str | None) -> str:
+        value = explicit
+        if value is None:
+            try:
+                value = subprocess.run(
+                    ["git", "rev-parse", "HEAD"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip()
+            except (OSError, subprocess.CalledProcessError) as exc:
+                raise DatasetInvalid("Git SHA nelze zjistit") from exc
+        if len(value) != 40 or any(character not in "0123456789abcdef" for character in value):
+            raise DatasetInvalid("Code SHA musí být plný lowercase Git SHA")
+        return value
+
+    def run(self, request: Phase6ExperimentRequest) -> ExperimentRecord:
+        if not request.parameter_configs:
+            raise ValueError("Parameter space nesmí být prázdný")
+        if not Decimal(0) < request.train_fraction < Decimal(1) or not Decimal(
+            0
+        ) < request.validation_fraction < Decimal(1):
+            raise ValueError("Chronologický split má neplatné poměry")
+        code_sha = self._code_sha(request.code_sha)
+        identity_payload = {
+            "snapshot_id": request.snapshot_id,
+            "strategy": [request.strategy_name, request.strategy_version],
+            "parameters": request.parameter_configs,
+            "train_fraction": request.train_fraction,
+            "validation_fraction": request.validation_fraction,
+            "initial_cash": request.initial_cash,
+            "commission_bps": request.commission_bps,
+            "seed": request.seed,
+            "code_sha": code_sha,
+        }
+        identity = hashlib.sha256(self._canonical(identity_payload).encode()).hexdigest()
+        with self._sessions() as session, session.begin():
+            _lock(session, f"phase6-experiment:{identity}")
+            existing = session.scalar(
+                select(ExperimentRecord).where(ExperimentRecord.idempotency_key == identity)
+            )
+            if existing is not None:
+                return existing
+            snapshot = session.get(DatasetSnapshotRecord, request.snapshot_id)
+            if (
+                snapshot is None
+                or snapshot.status != "VALID"
+                or not snapshot.content_hash
+                or session.get(UniverseDefinitionRecord, snapshot.universe_id) is None
+            ):
+                raise DatasetInvalid("Experiment vyžaduje existující VALID snapshot s universe")
+            strategy_row = session.scalar(
+                select(StrategyRecord).where(
+                    StrategyRecord.strategy_name == request.strategy_name,
+                    StrategyRecord.strategy_version == request.strategy_version,
+                )
+            )
+            strategy_type = STRATEGY_REGISTRY.get(request.strategy_name)
+            if strategy_row is None or strategy_type is None:
+                raise DatasetInvalid("Přesná strategy version není registrována")
+            manifest = json.loads(snapshot.manifest_json)
+            entries = manifest.get("observations")
+            if not isinstance(entries, list) or not entries:
+                raise DatasetInvalid("Snapshot manifest neobsahuje observations")
+            ids = [entry.get("id") for entry in entries if isinstance(entry, dict)]
+            if len(ids) != len(entries) or len(set(ids)) != len(ids):
+                raise DatasetInvalid("Snapshot manifest není interně konzistentní")
+            rows = tuple(
+                session.scalars(
+                    select(MarketObservationRecord).where(
+                        MarketObservationRecord.observation_id.in_(ids)
+                    )
+                )
+            )
+            by_id = {row.observation_id: row for row in rows}
+            if set(by_id) != set(ids) or any(
+                by_id[entry["id"]].revision != entry["revision"]
+                or by_id[entry["id"]].source_hash != entry["hash"]
+                for entry in entries
+            ):
+                raise DatasetInvalid("Snapshot manifest odkazuje na změněná nebo chybějící data")
+            observations = tuple(_observation(by_id[item]) for item in ids)
+            times = sorted({item.timestamp for item in observations})
+            train_end = int(len(times) * float(request.train_fraction))
+            validation_end = train_end + int(len(times) * float(request.validation_fraction))
+            if train_end < 1 or validation_end <= train_end or validation_end >= len(times):
+                raise DatasetInvalid("Každá chronologická část musí obsahovat data")
+            definition_row = session.get(UniverseDefinitionRecord, snapshot.universe_id)
+            assert definition_row is not None
+            membership_rows = tuple(
+                session.scalars(
+                    select(UniverseMembershipRecord).where(
+                        UniverseMembershipRecord.universe_id == snapshot.universe_id,
+                        UniverseMembershipRecord.known_at <= snapshot.as_of,
+                    )
+                )
+            )
+            universe = PointInTimeUniverse(
+                UniverseDefinition(
+                    definition_row.universe_id,
+                    definition_row.name,
+                    UniverseKind(definition_row.kind),
+                    definition_row.created_at,
+                ),
+                [
+                    UniverseMembership(
+                        row.universe_id,
+                        row.instrument_id,
+                        row.valid_from,
+                        row.valid_to,
+                        row.known_at,
+                    )
+                    for row in membership_rows
+                ],
+            )
+
+            def evaluate(
+                config: dict[str, object], selected_times: list[datetime]
+            ) -> MultiAssetMetrics:
+                strategy = strategy_type(**config)
+                if strategy.version != request.strategy_version:
+                    raise DatasetInvalid("Implementace strategy version neodpovídá registru")
+                result = run_multi_asset(
+                    [item for item in observations if item.timestamp in selected_times],
+                    universe,
+                    strategy,
+                    request.initial_cash,
+                    request.commission_bps,
+                )
+                return multi_asset_metrics(result, request.initial_cash)
+
+            scored: list[tuple[Decimal, str, dict[str, object], MultiAssetMetrics]] = []
+            for config in request.parameter_configs:
+                evaluate(config, times[:train_end])
+                validation = evaluate(config, times[train_end:validation_end])
+                scored.append(
+                    (validation.risk_adjusted_return, self._canonical(config), config, validation)
+                )
+            _, _, selected, _ = max(scored, key=lambda item: (item[0], item[1]))
+            oos = evaluate(selected, times[validation_end:])
+            experiment = ExperimentRecord(
+                id=identity,
+                idempotency_key=identity,
+                created_at=datetime.now(UTC),
+                completed_at=datetime.now(UTC),
+                status="COMPLETED",
+                snapshot_id=snapshot.snapshot_id,
+                strategy_identity=strategy_row.strategy_identity,
+                strategy_name=request.strategy_name,
+                strategy_version=request.strategy_version,
+                parameter_space_id=hashlib.sha256(
+                    self._canonical(request.parameter_configs).encode()
+                ).hexdigest(),
+                decision="RESEARCH_ONLY",
+                total_return=float(oos.total_return),
+                annualized_return=float(oos.annualized_return),
+                volatility=float(oos.volatility),
+                sharpe=float(oos.risk_adjusted_return),
+                max_drawdown=float(oos.max_drawdown),
+                turnover=float(oos.turnover),
+                time_weighted_exposure=float(oos.time_weighted_exposure),
+                trade_count=oos.trade_count,
+                total_costs=float(oos.total_costs),
+                code_sha=code_sha,
+                seed=request.seed,
+                cost_model_json=self._canonical(
+                    {"commission_bps": request.commission_bps, "slippage_model": "none"}
+                ),
+                selected_parameters_json=self._canonical(selected),
+                config_json=self._canonical(identity_payload),
+                result_json=self._canonical({"stage": "OOS", "metrics": oos.__dict__}),
+            )
+            session.add(experiment)
+            session.flush()
+            return experiment
 
 
 def multi_asset_metrics(result: MultiAssetResult, initial_cash: Decimal) -> MultiAssetMetrics:

--- a/backend/tests/test_phase6.py
+++ b/backend/tests/test_phase6.py
@@ -437,3 +437,22 @@ def test_runner_uses_adjusted_signals_and_applies_actions():
     )
     assert dict(result.decisions)[CAL.session_close(days[2])].weights == (("a", Decimal("1")),)
     assert result.dividend_income > 0
+
+
+def test_evaluation_window_preserves_lookback_without_pre_window_trades():
+    days = [date(2024, 1, day) for day in (3, 4, 5, 8, 9)]
+    rows = [obs("a", day, str(100 + index)) for index, day in enumerate(days)]
+    evaluation_start = CAL.session_close(days[3])
+
+    result = run_multi_asset(
+        rows,
+        single_asset_universe(),
+        TrendStrategy(2, 3, rebalance_frequency=RebalanceFrequency.DAILY),
+        initial_cash=Decimal("1000"),
+        commission_bps=Decimal("0"),
+        evaluation_start=evaluation_start,
+    )
+
+    assert result.equity[0][0] == evaluation_start
+    assert result.decisions[0][0] == evaluation_start
+    assert all(fill.timestamp > evaluation_start for fill in result.fills)

--- a/docs/database.md
+++ b/docs/database.md
@@ -28,3 +28,10 @@ Phase 4 audit přidal migraci `20260811_02`, která vynucuje kladné order/fill 
 Phase 6 je implementována jako provider → validace/immutable revisions → XNYS calendar/corporate actions → PIT universe → immutable snapshot → multi-asset target portfolio. Detailní invariants jsou v `docs/market-data.md` a `docs/strategy-research.md`. Žádná část nevytváří live execution path; automatický data refresh zatím není allowlistovaný job a refresh se provádí odděleně od trading cycle.
 
 Migrace `20260811_06` je forward změna nad neměnnou `20260811_05`: přidává snapshot FK a multi-asset metriky experimentu a tabulku deployment manifestů. Produkční ingestion a snapshot používají PostgreSQL transaction advisory locks; SQLite není concurrency evidence.
+# Phase 6 experiment lineage
+
+`research_experiments.snapshot_id` je autoritativní FK na immutable evidence. Revision
+`20260812_01` doplňuje unikátní `idempotency_key` a přímé sloupce `code_sha`, `seed`,
+`cost_model_json` a `selected_parameters_json`. Provider, calendar, universe a content hash se
+neduplikují: dohledají se přes snapshot FK. OOS metriky zůstávají v typovaných metrických
+sloupcích experimentu.

--- a/docs/strategy-research.md
+++ b/docs/strategy-research.md
@@ -10,7 +10,25 @@ Universe typu `POINT_IN_TIME_MEMBERSHIP` filtruje `valid_from <= decision < vali
 
 Parametr selection zůstává chronologická IS → validation → OOS pipeline Phase 3; OOS se pouze jednou vyhodnotí a není vstupem výběru. Experiment manifest musí odkazovat na immutable snapshot, coverage, strategy version/parameters, commit a seed. Promotion pouze mění research candidate na schválenou konfiguraci stávající paper pipeline; strategie nikdy neposílá broker order přímo.
 
-## Persistentní lineage a otevřený runner
-Schema experiment registry má FK na Phase 6 snapshot a sloupce multi-asset metrik. Kompletní runner IS → validation → exactly-once OOS nad `run_multi_asset` však dosud není zapojen; není povolen silent fallback na legacy `DatasetRecord` a audit gate zůstává otevřený.
+## Persistentní lineage
+Schema experiment registry má FK na Phase 6 snapshot a sloupce multi-asset metrik. Runner nepovoluje silent fallback na legacy `DatasetRecord`.
 
 `strategy_deployments` je explicitní, ručně schvalovaný manifest strategie/verze, parametrů, universe, paper účtu, experimentu, snapshotu, měny a timeframe. Schválení failne bez `VALID` snapshotu a shodné experiment lineage. Manifest nevytváří nový execution path.
+# Persistentní Phase 6 experimenty
+
+`Phase6ExperimentRunner` přijímá výhradně identitu `VALID` dataset snapshotu. Manifest je
+před spuštěním ověřen proti přesným observation ID, revision a source hash; pozdější provider
+oprava proto nemůže změnit rekonstruovaný experiment. Přesná dvojice jméno/verze strategie
+musí být v registru a bounded parameter set se řadí kanonicky. Train, validation a OOS jsou
+chronologicky disjunktní: všechny konfigurace projdou train a validation, výběr používá pouze
+validation risk-adjusted return a OOS se vyhodnotí právě jednou.
+
+Persistentní OOS metriky jsou total return, anualizovaný výnos, anualizovaná volatilita,
+risk-adjusted return (Sharpe bez risk-free sazby), max drawdown, traded-notional turnover vůči
+počátečnímu kapitálu, časově vážená gross exposure, počet fillů a celkové komise. Exposure je
+integrál stavové portfolio exposure přes čas, nikoli počet nebo stav fillů.
+
+Logická idempotency identita zahrnuje snapshot, přesnou strategii, celý parameter set, split,
+kapitál, cost model, seed a skutečný Git SHA. PostgreSQL runner tuto identitu serializuje
+transaction-scoped advisory lockem; opakování vrací stejný `ResearchExperiment` a nevytváří
+druhé OOS vyhodnocení.

--- a/docs/strategy-research.md
+++ b/docs/strategy-research.md
@@ -23,6 +23,12 @@ musí být v registru a bounded parameter set se řadí kanonicky. Train, valida
 chronologicky disjunktní: všechny konfigurace projdou train a validation, výběr používá pouze
 validation risk-adjusted return a OOS se vyhodnotí právě jednou.
 
+Snapshot manifest verze 3 zahrnuje také kanonické corporate actions známé k `as_of`; jejich
+obsah vstupuje do snapshot content hashe. Validation a OOS dostávají předchozí observations
+pouze jako lookback warm-up, ale portfolio, fills i metriky vznikají až od začátku příslušného
+evaluation okna. Runner před výpočtem načte měny všech instrumentů a mixed-currency universe
+bez explicitní FX konverze odmítne.
+
 Persistentní OOS metriky jsou total return, anualizovaný výnos, anualizovaná volatilita,
 risk-adjusted return (Sharpe bez risk-free sazby), max drawdown, traded-notional turnover vůči
 počátečnímu kapitálu, časově vážená gross exposure, počet fillů a celkové komise. Exposure je


### PR DESCRIPTION
### Motivation
- Dodat persistentní, snapshot-only Phase 6 experiment runner, který garantuje replay přes immutable snapshot, pinuje přesnou strategii/verzi a zajišťuje exactly-once OOS pomocí idempotentní identity a DB advisory-locku.
- Zajistit úplnou experimentální linii v databázi (code SHA, seed, cost model, vybrané parametry) tak, aby každý experiment byl auditovatelný a dohledatelný přes snapshot FK.
- Aktualizovat dokumentaci lineage tak, aby reflektovala nové typované pole a behavior runneru; nasazení produkčního XNYS kalendáře bylo záměrně ponecháno mimo změnu kvůli environmentálním omezením. 

### Description
- Přidán `Phase6ExperimentRunner` do `backend/src/quantlab/phase6_runtime.py` implementující: ověření `snapshot_id` (musí být `VALID`), rekonstrukci přes manifest observation ID/revision/source_hash, pinování strategie name+version, deterministickou idempotency identitu (obsahuje snapshot, strategy, parametry, split, cost model, seed a Git SHA), transaction-scoped advisory lock a persistenci jednoho autoritativního experimentu a jeho OOS metrik. 
- Do `backend/src/quantlab/persistence.py` doplněny sloupce pro experiment lineage: `idempotency_key`, `code_sha`, `seed`, `cost_model_json`, `selected_parameters_json` tak, aby metadata nebyla duplikována v nestrukturovaných polích.
- Přidána forward Alembic migrace `alembic/versions/20260812_01_phase6_experiment_lineage.py`, která vytvoří nové sloupce a unikátní index na `idempotency_key` a obsahuje downgrade cestu.
- Upraveny dokumenty `docs/strategy-research.md` a `docs/database.md`, které popisují behavior runneru, canonical parameter selection, idempotency a uložené metriky (total_return, annualized_return, volatility, risk_adjusted_return (Sharpe), max_drawdown, turnover, time_weighted_exposure, trade_count, total_costs).
- Implementace využívá existující `run_multi_asset` a `STRATEGY_REGISTRY` pro deterministické backtesty; používá `_lock` z market-data service pro PostgreSQL advisory lock.
- Poznámka: produkční exchange-calendar dependency nebyla přidána kvůli chybám v lokálním prostředí (viz Testing), takže stávající calendar abstraction zůstává nezměněná.

### Testing
- Kódové kontroly provedeny: `ruff format --check` a `ruff check` prošly bez chyb na upravených souborech.
- Kompilace zdrojů provedena pomocí `python -m compileall` a nezaznamenala syntaktické chyby pro upravené moduly.
- Statická kontrola `mypy` byla spuštěna lokálně nad upraveným modulem a odhalila a následně byly adresovány drobné typové poznámky; celá strict `mypy` pipeline závisí na plně synchronizovaném locked prostředí a proto není kompletně ověřena zde.
- Běh vybraných testů `pytest` se nepodařilo dokončit, protože závislosti nebyly synchronizovatelné v prostředí (chybí `sqlalchemy` atd.) a environment blokoval `uv sync` a instalaci přidaných závislostí; tedy integrační a PostgreSQL E2E testy (včetně concurrency testů) byly zablokovány.
- Environmentální blokery: lokální `uv` má verzi `0.7.22` zatímco projekt požaduje `==0.12.3`, a síťový přístup na PyPI selhal (tunnel/403), proto nebylo možné uzamknout/addovat `exchange-calendars` ani spustit plnou locked dependency instalaci a následné PostgreSQL testy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c2a5a7cb483328e7c3a44fc09f24f)