### PR TITLE
Zapojení Phase 6 runtime testů do CI a oprava cache globu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           version: ${{ env.UV_VERSION }}
           working-directory: backend
           cache-dependency-glob: |
-            backend/pyproject.toml
-            backend/uv.lock
+            pyproject.toml
+            uv.lock
       - run: uv --version
       - run: uv lock --check
       - run: uv sync --locked --all-groups
@@ -45,10 +45,15 @@ jobs:
           version: ${{ env.UV_VERSION }}
           working-directory: backend
           cache-dependency-glob: |
-            backend/pyproject.toml
-            backend/uv.lock
+            pyproject.toml
+            uv.lock
       - run: uv sync --locked --all-groups
-      - run: uv run pytest -q tests/test_research.py tests/test_research_engine.py tests/test_phase6.py
+      - run: >-
+          uv run pytest -q
+          tests/test_research.py
+          tests/test_research_engine.py
+          tests/test_phase6.py
+          tests/test_phase6_runtime.py
 
   api:
     runs-on: ubuntu-latest
@@ -64,8 +69,8 @@ jobs:
           version: ${{ env.UV_VERSION }}
           working-directory: backend
           cache-dependency-glob: |
-            backend/pyproject.toml
-            backend/uv.lock
+            pyproject.toml
+            uv.lock
       - run: uv sync --locked --all-groups
       - run: uv run pytest -q tests/test_vertical_slice.py
 
@@ -94,8 +99,8 @@ jobs:
           version: ${{ env.UV_VERSION }}
           working-directory: backend
           cache-dependency-glob: |
-            backend/pyproject.toml
-            backend/uv.lock
+            pyproject.toml
+            uv.lock
       - run: uv sync --locked --all-groups
       - run: uv run alembic -c ../alembic.ini upgrade head
       - name: PostgreSQL Phase 3–6, concurrency a recovery
@@ -105,4 +110,6 @@ jobs:
           tests/test_phase4.py
           tests/test_phase5.py
           tests/test_phase5_postgres.py
+          tests/test_phase6.py
+          tests/test_phase6_runtime.py
           tests/test_phase6_postgres.py


### PR DESCRIPTION
### Motivation
- Zajistit, aby nové Phase 6 runtime testy byly skutečně spouštěny v CI a aby cache globy `setup-uv` fungovaly korektně s `working-directory: backend`.
- Opravit falešnou bezpečnost CI, kde některé důležité Phase6 testy nebyly v unit/research ani v PostgreSQL jobu zahrnuty.

### Description
- Upraveno `.github/workflows/ci.yml` tak, aby `unit-research` job explicitně spouštěl `tests/test_research.py`, `tests/test_research_engine.py`, `tests/test_phase6.py` a `tests/test_phase6_runtime.py`.
- Upraven `integration-postgres` job tak, aby zahrnoval `tests/test_phase6.py` a `tests/test_phase6_runtime.py` mezi spouštěné PostgreSQL testy.
- Opraveny `cache-dependency-glob` položky použitím relativních cest `pyproject.toml` a `uv.lock` (relativně vůči `working-directory: backend`) aby se zabránilo chybné cache cestě typu `backend/backend/...`.
- Neprováděny žádné změny aplikační logiky, kalendáře ani migrací v tomto PR (záměrně minimalní zásah). Commit: `02ec7754dad915076db354fd972244c8b304daba`.

### Testing
- Zkontrolováno prostředí a repozitář: `git status` čistý, aktuální branch `work`, commit výše.
- Spuštěné lokální unit Phase 6 testy: `python -m pytest -q tests/test_phase6.py` → `14 passed` (OK).
- Spuštění rozšířených testů selhalo při collection kvůli chybějícím závislostem a prostředí: `python -m pytest -q tests/test_research.py tests/test_research_engine.py tests/test_phase6.py tests/test_phase6_runtime.py` → collection selhala s `ModuleNotFoundError: No module named 'sqlalchemy'` (BLOCKED BY ENVIRONMENT / dependency sync).
- Pokus o použití `uv` pro locked workflow byl omezen: lokální `uv` je `0.7.22`, repo vyžaduje `==0.12.3`, instalace/upgrade `uv==0.12.3` selhala z prostředí (síť/registry přístup blokován) a proto nebylo možné bezpečně spustit `uv lock --check`, `uv sync --locked --all-groups` ani plnou locked verifikaci (BLOCKED BY ENVIRONMENT).
- Docker/PostgreSQL běh není dostupný v aktuálním prostředí (`docker: command not found`), tudíž integraci PostgreSQL a concurrency E2E nelze zde ověřit (BLOCKED BY ENVIRONMENT).

Poznámka: tento PR provádí pouze CI/metadata úpravu, která je bezpečná a nezmění aplikační chování; klíčové body Phase 6 DoD (produkční exchange-calendar, plné PostgreSQL concurrency E2E, research→paper E2E, HALTED regression) zůstávají nezavršeny a vyžadují další změny a environmentální ověření.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c30c6090c8332bda0014dbc1ce842)