### PR TITLE
Phase 7: replayable Phase‑6 OOS baseline + paper corporate‑action runtime + baseline persistence

### DIFF
--- a/alembic/versions/20260824_02_phase7_oos_equity.py
+++ b/alembic/versions/20260824_02_phase7_oos_equity.py
@@ -1,0 +1,35 @@
+"""Přidá immutable Phase 6 OOS equity evidenci.
+
+Revision ID: 20260824_02
+Revises: 20260824_01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260824_02"
+down_revision = "20260824_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    columns = {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns("paper_expectation_baselines")
+    }
+    if "oos_equity_json" not in columns:
+        op.add_column(
+            "paper_expectation_baselines",
+            sa.Column("oos_equity_json", sa.Text(), nullable=False, server_default="[]"),
+        )
+        op.alter_column("paper_expectation_baselines", "oos_equity_json", server_default=None)
+
+
+def downgrade() -> None:
+    columns = {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns("paper_expectation_baselines")
+    }
+    if "oos_equity_json" in columns:
+        op.drop_column("paper_expectation_baselines", "oos_equity_json")

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -811,7 +811,11 @@ class PersistentPaperBroker:
             realized = Decimal(0)
             if side is Side.BUY:
                 lots.append(
-                    {"quantity": str(quantity), "unit_basis": str(price + commission / quantity)}
+                    {
+                        "quantity": str(quantity),
+                        "unit_basis": str(price + commission / quantity),
+                        "acquired_at": bar.timestamp.isoformat(),
+                    }
                 )
                 position.quantity += quantity
             else:

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -850,6 +850,13 @@ class Phase6PaperExecutionService:
                 or snapshot.timeframe != "1d"
             ):
                 raise DatasetInvalid("Approved deployment evidence se od schválení změnila")
+            from quantlab.phase7 import PaperCorporateActionService
+
+            PaperCorporateActionService(self._sessions).apply(account.id, decision_time)
+            session.expire_all()
+            monitoring = session.get(PaperMonitoringRunRecord, monitoring.monitoring_id)
+            if monitoring is None or monitoring.state != "ACTIVE":
+                raise DatasetInvalid("Corporate action zablokovala paper execution")
             definition = session.get(UniverseDefinitionRecord, deployment.universe_id)
             if definition is None or definition.kind != UniverseKind.POINT_IN_TIME_MEMBERSHIP:
                 raise DatasetInvalid("Paper execution vyžaduje podporovaný PIT universe")

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -85,6 +85,19 @@ class Phase6ExperimentRequest:
     code_sha: str | None = None
 
 
+@dataclass(frozen=True)
+class Phase6ExperimentReplay:
+    """Deterministický výsledek společné Phase 6 research evaluace."""
+
+    selected_parameters: dict[str, object]
+    train: MultiAssetMetrics
+    validation: MultiAssetMetrics
+    oos: MultiAssetMetrics
+    oos_equity: tuple[tuple[datetime, Decimal], ...]
+    oos_returns: tuple[Decimal, ...]
+    oos_sessions: tuple[datetime, ...]
+
+
 class Phase6ExperimentRunner:
     """Snapshot-only Phase 6 runner s persistentní, exactly-once OOS identitou."""
 
@@ -113,6 +126,18 @@ class Phase6ExperimentRunner:
         return value
 
     def run(self, request: Phase6ExperimentRequest) -> ExperimentRecord:
+        result = self._execute(request, persist=True)
+        assert isinstance(result, ExperimentRecord)
+        return result
+
+    def replay(self, request: Phase6ExperimentRequest) -> Phase6ExperimentReplay:
+        result = self._execute(request, persist=False)
+        assert isinstance(result, Phase6ExperimentReplay)
+        return result
+
+    def _execute(
+        self, request: Phase6ExperimentRequest, *, persist: bool
+    ) -> ExperimentRecord | Phase6ExperimentReplay:
         if not request.parameter_configs:
             raise ValueError("Parameter space nesmí být prázdný")
         if not Decimal(0) < request.train_fraction < Decimal(1) or not Decimal(
@@ -134,12 +159,13 @@ class Phase6ExperimentRunner:
         identity = hashlib.sha256(self._canonical(identity_payload).encode()).hexdigest()
         with self._sessions() as session, session.begin():
             _lock(session, f"phase6-experiment:{identity}")
-            existing = session.scalar(
-                select(ExperimentRecord).where(ExperimentRecord.idempotency_key == identity)
-            )
-            if existing is not None:
-                session.expunge(existing)
-                return existing
+            if persist:
+                existing = session.scalar(
+                    select(ExperimentRecord).where(ExperimentRecord.idempotency_key == identity)
+                )
+                if existing is not None:
+                    session.expunge(existing)
+                    return existing
             snapshot = session.get(DatasetSnapshotRecord, request.snapshot_id)
             if (
                 snapshot is None
@@ -298,7 +324,7 @@ class Phase6ExperimentRunner:
 
             def evaluate(
                 config: dict[str, object], selected_times: list[datetime]
-            ) -> MultiAssetMetrics:
+            ) -> tuple[MultiAssetMetrics, MultiAssetResult]:
                 strategy = strategy_type(**config)
                 if strategy.version != request.strategy_version:
                     raise DatasetInvalid("Implementace strategy version neodpovídá registru")
@@ -314,17 +340,35 @@ class Phase6ExperimentRunner:
                     corporate_actions=corporate_actions,
                     evaluation_start=evaluation_start,
                 )
-                return multi_asset_metrics(result, request.initial_cash)
+                return multi_asset_metrics(result, request.initial_cash), result
 
             scored: list[tuple[Decimal, str, dict[str, object], MultiAssetMetrics]] = []
             for config in request.parameter_configs:
                 evaluate(config, times[:train_end])
-                validation = evaluate(config, times[train_end:validation_end])
+                validation, _ = evaluate(config, times[train_end:validation_end])
                 scored.append(
                     (validation.risk_adjusted_return, self._canonical(config), config, validation)
                 )
             _, _, selected, _ = max(scored, key=lambda item: (item[0], item[1]))
-            oos = evaluate(selected, times[validation_end:])
+            train, _ = evaluate(selected, times[:train_end])
+            validation, _ = evaluate(selected, times[train_end:validation_end])
+            oos, oos_result = evaluate(selected, times[validation_end:])
+            oos_equity = tuple(oos_result.equity)
+            oos_returns = tuple(
+                oos_equity[index][1] / oos_equity[index - 1][1] - 1
+                for index in range(1, len(oos_equity))
+            )
+            replay = Phase6ExperimentReplay(
+                selected,
+                train,
+                validation,
+                oos,
+                oos_equity,
+                oos_returns,
+                tuple(when for when, _ in oos_equity),
+            )
+            if not persist:
+                return replay
             experiment = ExperimentRecord(
                 id=identity,
                 idempotency_key=identity,
@@ -355,12 +399,30 @@ class Phase6ExperimentRunner:
                 ),
                 selected_parameters_json=self._canonical(selected),
                 config_json=self._canonical(identity_payload),
-                result_json=self._canonical({"stage": "OOS", "metrics": oos.__dict__}),
+                result_json=self._canonical(
+                    {
+                        "stage": "OOS",
+                        "metrics": oos.__dict__,
+                        "equity": oos_equity,
+                        "returns": oos_returns,
+                        "sessions": replay.oos_sessions,
+                    }
+                ),
             )
             session.add(experiment)
             session.flush()
             session.expunge(experiment)
             return experiment
+
+
+class Phase6ExperimentReplayService:
+    """Replay používající tutéž authoritative implementaci jako experiment runner."""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._runner = Phase6ExperimentRunner(session_factory)
+
+    def replay(self, request: Phase6ExperimentRequest) -> Phase6ExperimentReplay:
+        return self._runner.replay(request)
 
 
 def multi_asset_metrics(result: MultiAssetResult, initial_cash: Decimal) -> MultiAssetMetrics:

--- a/backend/src/quantlab/phase7.py
+++ b/backend/src/quantlab/phase7.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from quantlab.domain import SystemTradingState, require_utc
 from quantlab.market_data import CorporateActionKind, DatasetInvalid, XNYSCalendar
+from quantlab.market_data_service import _database_utc
 from quantlab.persistence import (
     Base,
     CorporateActionRecord,
@@ -264,6 +265,7 @@ class PaperCorporateActionService:
                     .where(
                         CorporateActionRecord.known_at <= cutoff,
                         CorporateActionRecord.effective_at <= cutoff,
+                        CorporateActionRecord.effective_at >= account.created_at,
                     )
                     .order_by(CorporateActionRecord.effective_at, CorporateActionRecord.action_id)
                 )
@@ -285,15 +287,62 @@ class PaperCorporateActionService:
                     )
                     .with_for_update()
                 )
-                quantity = position.quantity if position is not None else Decimal(0)
+                fill_rows = tuple(
+                    session.execute(
+                        select(PaperFillRecord.quantity, PaperOrderRecord.side)
+                        .join(PaperOrderRecord, PaperOrderRecord.id == PaperFillRecord.order_id)
+                        .where(
+                            PaperOrderRecord.account_id == account_id,
+                            PaperOrderRecord.instrument_id == action.instrument_id,
+                            PaperFillRecord.timestamp <= action.effective_at,
+                        )
+                    )
+                )
+                historical_quantity = sum(
+                    (quantity if side == "BUY" else -quantity for quantity, side in fill_rows),
+                    Decimal(0),
+                )
+                if (
+                    not fill_rows
+                    and position is not None
+                    and position.updated_at <= action.effective_at
+                ):
+                    historical_quantity = position.quantity
+                quantity = max(historical_quantity, Decimal(0))
                 kind = CorporateActionKind(action.kind)
                 effect: dict[str, object] = {"kind": kind, "eligible_quantity": quantity}
                 if kind is CorporateActionKind.SPLIT and position is not None:
                     ratio = Decimal(action.value or "0")
                     if ratio <= 0:
                         raise DatasetInvalid("Split ratio musí být kladné")
-                    position.quantity *= ratio
-                    position.average_cost /= ratio
+                    lots: object = json.loads(position.lots_json)
+                    if not isinstance(lots, list) or any(not isinstance(lot, dict) for lot in lots):
+                        raise DatasetInvalid("Paper position lots nejsou validní")
+                    adjusted_quantity = Decimal(0)
+                    for lot in cast(list[dict[str, object]], lots):
+                        lot_quantity = Decimal(str(lot["quantity"]))
+                        unit_basis = Decimal(str(lot["unit_basis"]))
+                        acquired_at = lot.get("acquired_at")
+                        eligible = acquired_at is None or require_utc(
+                            datetime.fromisoformat(str(acquired_at))
+                        ) <= _database_utc(action.effective_at)
+                        if eligible:
+                            lot_quantity *= ratio
+                            unit_basis /= ratio
+                            lot["quantity"] = str(lot_quantity)
+                            lot["unit_basis"] = str(unit_basis)
+                        adjusted_quantity += lot_quantity
+                    position.quantity = adjusted_quantity
+                    position.lots_json = canonical(lots)
+                    position.average_cost = (
+                        sum(
+                            Decimal(str(lot["quantity"])) * Decimal(str(lot["unit_basis"]))
+                            for lot in cast(list[dict[str, object]], lots)
+                        )
+                        / adjusted_quantity
+                        if adjusted_quantity
+                        else Decimal(0)
+                    )
                     position.updated_at = cutoff
                     effect.update({"ratio": ratio, "quantity_after": position.quantity})
                 elif kind is CorporateActionKind.CASH_DIVIDEND:
@@ -305,7 +354,11 @@ class PaperCorporateActionService:
                     account.equity += credit
                     account.updated_at = cutoff
                     effect.update({"per_share": dividend, "cash_credit": credit})
-                elif kind is CorporateActionKind.DELISTING and quantity:
+                elif (
+                    kind is CorporateActionKind.DELISTING
+                    and position is not None
+                    and position.quantity
+                ):
                     run = session.scalar(
                         select(PaperMonitoringRunRecord)
                         .where(

--- a/backend/src/quantlab/phase7.py
+++ b/backend/src/quantlab/phase7.py
@@ -26,9 +26,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Mapped, Session, mapped_column
 
 from quantlab.domain import SystemTradingState, require_utc
-from quantlab.market_data import DatasetInvalid, XNYSCalendar
+from quantlab.market_data import CorporateActionKind, DatasetInvalid, XNYSCalendar
 from quantlab.persistence import (
     Base,
+    CorporateActionRecord,
     ExperimentRecord,
     StrategyDeploymentRecord,
 )
@@ -41,7 +42,12 @@ from quantlab.phase4 import (
     RiskDecisionRecord,
     TradingCycleRecord,
 )
-from quantlab.phase6_runtime import DeploymentService, ValidatedCurrentDataAccessor
+from quantlab.phase6_runtime import (
+    DeploymentService,
+    Phase6ExperimentReplayService,
+    Phase6ExperimentRequest,
+    ValidatedCurrentDataAccessor,
+)
 
 ALGORITHM_VERSION = "paper-monitoring-v1"
 OPEN_STATES = ("ACTIVE", "PAUSED", "SUSPENDED")
@@ -94,6 +100,7 @@ class PaperExpectationBaselineRecord(Base):
     cost_model_json: Mapped[str] = mapped_column(Text, nullable=False)
     oos_metrics_json: Mapped[str] = mapped_column(Text, nullable=False)
     oos_returns_json: Mapped[str] = mapped_column(Text, nullable=False)
+    oos_equity_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]")
     oos_session_count: Mapped[int] = mapped_column(Integer, nullable=False)
     algorithm_version: Mapped[str] = mapped_column(String(40), nullable=False)
     content_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
@@ -232,6 +239,108 @@ class PaperCorporateActionApplicationRecord(Base):
     __table_args__ = (UniqueConstraint("account_id", "action_id"),)
 
 
+class PaperCorporateActionService:
+    """Aplikuje kauzální corporate actions přímo na paper ledger, bez order/fill cesty."""
+
+    def __init__(self, sessions: Callable[[], Session]) -> None:
+        self.sessions = sessions
+
+    def apply(
+        self, account_id: str, as_of: datetime
+    ) -> tuple[PaperCorporateActionApplicationRecord, ...]:
+        cutoff = require_utc(as_of)
+        applied: list[PaperCorporateActionApplicationRecord] = []
+        with self.sessions() as session, session.begin():
+            account = session.scalar(
+                select(PaperAccountRecord)
+                .where(PaperAccountRecord.id == account_id)
+                .with_for_update()
+            )
+            if account is None:
+                raise DatasetInvalid("Paper účet neexistuje")
+            actions = tuple(
+                session.scalars(
+                    select(CorporateActionRecord)
+                    .where(
+                        CorporateActionRecord.known_at <= cutoff,
+                        CorporateActionRecord.effective_at <= cutoff,
+                    )
+                    .order_by(CorporateActionRecord.effective_at, CorporateActionRecord.action_id)
+                )
+            )
+            for action in actions:
+                existing = session.scalar(
+                    select(PaperCorporateActionApplicationRecord).where(
+                        PaperCorporateActionApplicationRecord.account_id == account_id,
+                        PaperCorporateActionApplicationRecord.action_id == action.action_id,
+                    )
+                )
+                if existing is not None:
+                    continue
+                position = session.scalar(
+                    select(PositionRecord)
+                    .where(
+                        PositionRecord.account_id == account_id,
+                        PositionRecord.instrument_id == action.instrument_id,
+                    )
+                    .with_for_update()
+                )
+                quantity = position.quantity if position is not None else Decimal(0)
+                kind = CorporateActionKind(action.kind)
+                effect: dict[str, object] = {"kind": kind, "eligible_quantity": quantity}
+                if kind is CorporateActionKind.SPLIT and position is not None:
+                    ratio = Decimal(action.value or "0")
+                    if ratio <= 0:
+                        raise DatasetInvalid("Split ratio musí být kladné")
+                    position.quantity *= ratio
+                    position.average_cost /= ratio
+                    position.updated_at = cutoff
+                    effect.update({"ratio": ratio, "quantity_after": position.quantity})
+                elif kind is CorporateActionKind.CASH_DIVIDEND:
+                    dividend = Decimal(action.value or "0")
+                    if dividend <= 0:
+                        raise DatasetInvalid("Dividend amount musí být kladný")
+                    credit = quantity * dividend
+                    account.cash += credit
+                    account.equity += credit
+                    account.updated_at = cutoff
+                    effect.update({"per_share": dividend, "cash_credit": credit})
+                elif kind is CorporateActionKind.DELISTING and quantity:
+                    run = session.scalar(
+                        select(PaperMonitoringRunRecord)
+                        .where(
+                            PaperMonitoringRunRecord.paper_account_id == account_id,
+                            PaperMonitoringRunRecord.state.in_(OPEN_STATES),
+                        )
+                        .with_for_update()
+                    )
+                    if run is not None:
+                        run.state = MonitoringState.SUSPENDED
+                        run.state_reason = "DELISTING_UNSUPPORTED"
+                        run.state_changed_at = cutoff
+                    effect["resolution"] = "SUSPENDED_NO_SYNTHETIC_FILL"
+                elif kind is CorporateActionKind.SYMBOL_CHANGE:
+                    effect.update(
+                        {"canonical_instrument_unchanged": True, "new_symbol": action.new_symbol}
+                    )
+                row = PaperCorporateActionApplicationRecord(
+                    application_id=identity(
+                        {"account_id": account_id, "action_id": action.action_id}
+                    ),
+                    action_id=action.action_id,
+                    account_id=account_id,
+                    instrument_id=action.instrument_id,
+                    applied_at=cutoff,
+                    effect_json=canonical(effect),
+                )
+                session.add(row)
+                session.flush()
+                applied.append(row)
+            for row in applied:
+                session.expunge(row)
+        return tuple(applied)
+
+
 def canonical(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
 
@@ -368,12 +477,39 @@ class PaperMonitoringService:
                     "sharpe",
                     "max_drawdown",
                     "turnover",
+                    "time_weighted_exposure",
                     "trade_count",
                     "total_costs",
                 )
             }
-            # Phase 6 v1 ukládá agregovanou OOS evidenci. Prázdná série je explicitní NOT_AVAILABLE,
-            # nikoli syntetická řada odvozená z agregátů.
+            config = json.loads(experiment.config_json)
+            replay = Phase6ExperimentReplayService(self.sessions).replay(
+                Phase6ExperimentRequest(
+                    snapshot_id=experiment.snapshot_id,
+                    strategy_name=experiment.strategy_name,
+                    strategy_version=experiment.strategy_version,
+                    parameter_configs=tuple(config["parameters"]),
+                    train_fraction=Decimal(str(config["train_fraction"])),
+                    validation_fraction=Decimal(str(config["validation_fraction"])),
+                    initial_cash=Decimal(str(config["initial_cash"])),
+                    commission_bps=Decimal(str(config["commission_bps"])),
+                    seed=int(config["seed"]),
+                    code_sha=experiment.code_sha,
+                )
+            )
+            if canonical(replay.selected_parameters) != canonical(selected):
+                raise DatasetInvalid("Phase 6 replay vybral jiné parametry")
+            for key, persisted in metrics.items():
+                replayed = getattr(replay.oos, key)
+                if abs(Decimal(str(persisted)) - Decimal(str(replayed))) > Decimal("1e-10"):
+                    raise DatasetInvalid(f"Phase 6 replay metric mismatch: {key}")
+            if not replay.oos_returns:
+                raise DatasetInvalid("Validní Phase 6 replay nemá denní OOS returns")
+            returns = list(replay.oos_returns)
+            equity = [
+                {"timestamp": when.isoformat(), "equity": str(value)}
+                for when, value in replay.oos_equity
+            ]
             baseline_payload = {
                 "deployment_id": deployment_id,
                 "experiment_id": experiment.id,
@@ -384,8 +520,9 @@ class PaperMonitoringService:
                 "code_sha": experiment.code_sha,
                 "cost_model": json.loads(experiment.cost_model_json or "{}"),
                 "metrics": metrics,
-                "returns": [],
-                "algorithm_version": "phase6-oos-evidence-v1",
+                "returns": returns,
+                "equity": equity,
+                "algorithm_version": "phase6-oos-replay-v2",
             }
             baseline_hash = identity(baseline_payload)
             baseline = session.scalar(
@@ -406,9 +543,10 @@ class PaperMonitoringService:
                     code_sha=experiment.code_sha or "",
                     cost_model_json=experiment.cost_model_json or "{}",
                     oos_metrics_json=canonical(metrics),
-                    oos_returns_json="[]",
-                    oos_session_count=0,
-                    algorithm_version="phase6-oos-evidence-v1",
+                    oos_returns_json=canonical(returns),
+                    oos_equity_json=canonical(equity),
+                    oos_session_count=len(replay.oos_sessions),
+                    algorithm_version="phase6-oos-replay-v2",
                     content_hash=baseline_hash,
                     created_at=started,
                 )
@@ -547,6 +685,14 @@ class PaperPerformanceService:
     def capture(self, monitoring_id: str, as_of: datetime) -> PaperPerformanceSnapshotRecord:
         captured = require_utc(as_of)
         session_date = self.calendar.latest_completed_session(captured)
+        with self.sessions() as lookup:
+            account_id = lookup.scalar(
+                select(PaperMonitoringRunRecord.paper_account_id).where(
+                    PaperMonitoringRunRecord.monitoring_id == monitoring_id
+                )
+            )
+        if account_id is not None:
+            PaperCorporateActionService(self.sessions).apply(account_id, captured)
         with self.sessions() as session, session.begin():
             run = session.get(PaperMonitoringRunRecord, monitoring_id)
             if run is None or run.state == MonitoringState.RETIRED:

--- a/backend/src/quantlab/phase7.py
+++ b/backend/src/quantlab/phase7.py
@@ -482,6 +482,12 @@ class PaperMonitoringService:
                     "total_costs",
                 )
             }
+            if (
+                experiment.snapshot_id is None
+                or experiment.strategy_name is None
+                or experiment.strategy_version is None
+            ):
+                raise DatasetInvalid("Experiment nemá úplnou Phase 6 replay lineage")
             config = json.loads(experiment.config_json)
             replay = Phase6ExperimentReplayService(self.sessions).replay(
                 Phase6ExperimentRequest(

--- a/backend/tests/test_phase7.py
+++ b/backend/tests/test_phase7.py
@@ -30,3 +30,27 @@ def test_block_bootstrap_is_deterministic_and_horizon_aware() -> None:
 
 def test_no_synthetic_bootstrap_without_baseline_series() -> None:
     assert deterministic_block_bootstrap([], 20, 100, 5, "seed") == []
+
+
+@pytest.mark.parametrize(
+    ("returns", "horizon", "block_size"),
+    [
+        ([Decimal("0")], 1, 10),
+        ([Decimal("0")], 20, 50),
+        ([Decimal("0.01")], 25, 3),
+        ([Decimal("0.01"), Decimal("-0.01")], 40, 20),
+    ],
+)
+def test_bootstrap_handles_short_and_zero_series_without_non_finite_values(
+    returns: list[Decimal], horizon: int, block_size: int
+) -> None:
+    distribution = deterministic_block_bootstrap(returns, horizon, 50, block_size, "safe")
+    assert len(distribution) == 50
+    assert all(value.is_finite() for value in distribution)
+
+
+def test_bootstrap_distribution_changes_with_paper_horizon() -> None:
+    returns = [Decimal("0.01"), Decimal("-0.02"), Decimal("0.03")]
+    short = deterministic_block_bootstrap(returns, 3, 100, 2, "monitor:3")
+    long = deterministic_block_bootstrap(returns, 8, 100, 2, "monitor:8")
+    assert short != long

--- a/docs/codex/phase7-complete.md
+++ b/docs/codex/phase7-complete.md
@@ -1,5 +1,23 @@
 # Phase 7 — Paper Performance Monitoring and Strategy Lifecycle
 
+## Finální auditní opravy
+
+Validní enrollment deterministicky přehrává immutable Phase 6 snapshot stejnou authoritative
+evaluací jako `Phase6ExperimentRunner`. Před vytvořením monitoringu ověří přesnou shodu
+vybraných parametrů a uložených OOS metrik. Baseline ukládá denní OOS returns, session
+timestamps a equity curve; prázdná série je pro nový enrollment fail-closed. Provider correction
+proto nemůže přepsat již hashovanou baseline evidenci.
+
+Paper ledger má produkční `PaperCorporateActionService`. Kauzálně (`effective_at` i `known_at`)
+a exactly-once aplikuje split a cash dividend bez orderu, fillu nebo syntetického P&L. Symbol
+change zachovává canonical `instrument_id`; delisting otevřené pozice bez authoritative ceny
+suspenduje monitoring s důvodem `DELISTING_UNSUPPORTED` a nevytváří syntetickou likvidaci.
+Authoritative orchestration probíhá před performance valuation dokončené session.
+
+Expected-vs-realized evaluace používá uložené skutečné OOS returns v horizon-aware
+deterministickém block bootstrapu. WATCH, REVIEW_REQUIRED ani SUSPENDED nikdy nemění parametry,
+nevytvářejí experiment/deployment a neprovádějí ekonomickou nebo live operaci.
+
 ## Verdict
 
 Implementace je dokončena; auditní verdict závisí na locked quality a PostgreSQL CI gate.


### PR DESCRIPTION
### Motivation
- Opravit zásadní Phase 7 blokery: validní enrollment bez skutečné denní OOS řady a chybějící produkční runtime pro paper corporate actions, aby evaluace očekávaného vs. realizovaného mohla fungovat deterministicky.
- Zachovat autoritativní Phase 6 research logiku a zabránit duplikaci výpočtů při replay baseline evidence.

### Description
- Přidáno replay API k Phase 6: `Phase6ExperimentReplay` + `Phase6ExperimentReplayService` a refaktor `Phase6ExperimentRunner` tak, aby sdílel `_execute()` pro persistované runy i replay; replay vrací vybrané parametry, TRAIN/VALIDATION/OOS metriky, OOS equity curve, denní returns a session timestamps. (`backend/src/quantlab/phase6_runtime.py`)
- Enrollment v `PaperMonitoringService.enroll` nyní spouští deterministický Phase‑6 replay, ověřuje shodu `selected_parameters` a porovnává replayované metriky s persistentními hodnotami; nový validní enrollment fail‑closes pokud nejsou dostupné denní OOS returns. Baseline payload nyní persistuje returns, equity a session count. (`backend/src/quantlab/phase7.py`)
- Přidána produkční `PaperCorporateActionService` s idempotentní, kauzální a auditable aplikací akcí (split, cash dividend, symbol change, delisting → suspend) přímo na paper ledger bez vytváření orderů/fillů; evidence aplikací je persistovaná a unikátní na `account_id + action_id`. Service je volána před performance valuation. (`backend/src/quantlab/phase7.py`)
- Schéma: nová Alembic migrace `20260824_02` přidává `oos_equity_json` a logiku bezpečného upgrade; existující `20260824_01` nebyla měněna. (`alembic/versions/20260824_02_phase7_oos_equity.py`)
- Testy a dokumentace: doplněny deterministické bootstrap unit testy a aktualizace dokumentace `docs/codex/phase7-complete.md` popisující replay, baseline evidence a corporate‑action runtime. (`backend/tests/test_phase7.py`, `docs/codex/phase7-complete.md`)

### Testing
- Formátování a lint: spustil jsem `ruff format` a `ruff check` nad upravenými soubory a kontroly prošly (files reformatted as needed, linters OK).
- Syntaktická kontrola: `python -m compileall` nad zdrojovými moduly proběhla bez chyb.
- Statická kontrola `mypy`: spuštěno, ale produkční type‑check selhal v sandboxu kvůli chybějícím projektovým závislostem/stubům (SQLAlchemy, Pydantic apod.), proto nelze ověřit úplné typování v tomto prostředí.
- Jednotkové testy: přidány nové unit testy pro deterministic block bootstrap v `backend/tests/test_phase7.py`; v sandboxu nebylo možné spustit `pytest` / PostgreSQL E2E kvůli omezením prostředí a chybějícím službám, proto výsledky PyTest/PGCI nejsou ověřeny lokálně.
- Migrace: nová migrace `20260824_02` byla přidána a soubor vytvořen; upgrade/downgrade v cílové PostgreSQL instanci musí být ověřeno v CI (fresh DB a upgrade z `20260824_01`).

Poznámka: implementace řeší klíčové blokery (skutečné immutable OOS series, reuse Phase‑6 logic, baseline persistence, corporate action runtime) ale rozsáhlé PostgreSQL service‑level concurrency testy, multi‑session E2E a kompletní adversariální sadě regresních testů z původního DoD budou vyžadovat spuštění v CI/Codespace (PostgreSQL) a nejsou v tomto sandboxu plně ověřeny.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c10e3a5548332b91ea512d85aa45f)