### PR TITLE
Oprava entitlementu po splitech (dividend) a doplnění testů

### DIFF
--- a/backend/src/quantlab/phase7.py
+++ b/backend/src/quantlab/phase7.py
@@ -240,6 +240,24 @@ class PaperCorporateActionApplicationRecord(Base):
     __table_args__ = (UniqueConstraint("account_id", "action_id"),)
 
 
+def _entitled_quantity(
+    fills: Sequence[tuple[datetime, Decimal, str]],
+    applied_splits: Sequence[tuple[datetime, str | None]],
+) -> Decimal:
+    """Vrátí ekonomické držení v čase entitlementu z neměnné ledger historie."""
+    quantity = Decimal(0)
+    for filled_at, filled_quantity, side in fills:
+        adjusted = filled_quantity
+        for split_at, value in applied_splits:
+            if _database_utc(split_at) > _database_utc(filled_at):
+                ratio = Decimal(value or "0")
+                if ratio <= 0:
+                    raise DatasetInvalid("Split ratio musí být kladné")
+                adjusted *= ratio
+        quantity += adjusted if side == "BUY" else -adjusted
+    return quantity
+
+
 class PaperCorporateActionService:
     """Aplikuje kauzální corporate actions přímo na paper ledger, bez order/fill cesty."""
 
@@ -289,7 +307,11 @@ class PaperCorporateActionService:
                 )
                 fill_rows = tuple(
                     session.execute(
-                        select(PaperFillRecord.quantity, PaperOrderRecord.side)
+                        select(
+                            PaperFillRecord.timestamp,
+                            PaperFillRecord.quantity,
+                            PaperOrderRecord.side,
+                        )
                         .join(PaperOrderRecord, PaperOrderRecord.id == PaperFillRecord.order_id)
                         .where(
                             PaperOrderRecord.account_id == account_id,
@@ -298,9 +320,25 @@ class PaperCorporateActionService:
                         )
                     )
                 )
-                historical_quantity = sum(
-                    (quantity if side == "BUY" else -quantity for quantity, side in fill_rows),
-                    Decimal(0),
+                applied_splits = tuple(
+                    session.execute(
+                        select(CorporateActionRecord.effective_at, CorporateActionRecord.value)
+                        .join(
+                            PaperCorporateActionApplicationRecord,
+                            PaperCorporateActionApplicationRecord.action_id
+                            == CorporateActionRecord.action_id,
+                        )
+                        .where(
+                            PaperCorporateActionApplicationRecord.account_id == account_id,
+                            CorporateActionRecord.instrument_id == action.instrument_id,
+                            CorporateActionRecord.kind == CorporateActionKind.SPLIT,
+                            CorporateActionRecord.effective_at <= action.effective_at,
+                        )
+                    )
+                )
+                historical_quantity = _entitled_quantity(
+                    [(timestamp, quantity, side) for timestamp, quantity, side in fill_rows],
+                    [(effective_at, value) for effective_at, value in applied_splits],
                 )
                 if (
                     not fill_rows

--- a/backend/tests/test_phase7.py
+++ b/backend/tests/test_phase7.py
@@ -1,8 +1,14 @@
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
 
-from quantlab.phase7 import DEFAULT_POLICY, deterministic_block_bootstrap, validate_policy
+from quantlab.phase7 import (
+    DEFAULT_POLICY,
+    _entitled_quantity,
+    deterministic_block_bootstrap,
+    validate_policy,
+)
 
 
 def test_default_policy_is_fail_closed_and_valid() -> None:
@@ -54,3 +60,43 @@ def test_bootstrap_distribution_changes_with_paper_horizon() -> None:
     short = deterministic_block_bootstrap(returns, 3, 100, 2, "monitor:3")
     long = deterministic_block_bootstrap(returns, 8, 100, 2, "monitor:8")
     assert short != long
+
+
+def test_entitlement_applies_split_to_older_fills_only() -> None:
+    bought_at = datetime(2026, 1, 2, tzinfo=UTC)
+    split_at = bought_at + timedelta(days=5)
+    sold_at = split_at + timedelta(days=1)
+
+    quantity = _entitled_quantity(
+        [
+            (bought_at, Decimal("10"), "BUY"),
+            (sold_at, Decimal("5"), "SELL"),
+        ],
+        [(split_at, "2")],
+    )
+
+    assert quantity == Decimal("15")
+
+
+def test_entitlement_compounds_multiple_splits_without_drift() -> None:
+    bought_at = datetime(2026, 1, 2, tzinfo=UTC)
+
+    quantity = _entitled_quantity(
+        [(bought_at, Decimal("10"), "BUY")],
+        [
+            (bought_at + timedelta(days=2), "2"),
+            (bought_at + timedelta(days=4), "1.5"),
+        ],
+    )
+
+    assert quantity == Decimal("30")
+
+
+def test_entitlement_rejects_invalid_applied_split_evidence() -> None:
+    bought_at = datetime(2026, 1, 2, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match="Split ratio"):
+        _entitled_quantity(
+            [(bought_at, Decimal("10"), "BUY")],
+            [(bought_at + timedelta(days=1), "0")],
+        )

--- a/docs/codex/phase7-complete.md
+++ b/docs/codex/phase7-complete.md
@@ -13,6 +13,11 @@ a exactly-once aplikuje split a cash dividend bez orderu, fillu nebo syntetické
 change zachovává canonical `instrument_id`; delisting otevřené pozice bez authoritative ceny
 suspenduje monitoring s důvodem `DELISTING_UNSUPPORTED` a nevytváří syntetickou likvidaci.
 Authoritative orchestration probíhá před performance valuation dokončené session.
+Dividendový entitlement se rekonstruuje z immutable fillů a pouze z dříve aplikovaných splitů.
+Každý split násobí jen fill, který mu časově předcházel; post-split prodej proto zůstává v nové
+jednotce. To zachovává správné držení pro split→dividend, vícenásobné splity i částečný prodej.
+Legacy lot bez `acquired_at` zůstává při přímé úpravě aktuální pozice zpětně kompatibilně
+způsobilý, místo aby byl nesprávně označen za future data.
 
 Expected-vs-realized evaluace používá uložené skutečné OOS returns v horizon-aware
 deterministickém block bootstrapu. WATCH, REVIEW_REQUIRED ani SUSPENDED nikdy nemění parametry,
@@ -97,8 +102,10 @@ Neexistuje auto-tune, auto-experiment, auto-deployment ani live promotion.
 
 ## Tests a CI
 
-`test_phase7.py` pokrývá policy safety a deterministic bootstrap. PostgreSQL soubory ověřují
-migration/schema a partial index; Phase 6 PostgreSQL E2E zůstává autoritativní pro předcházející
+`test_phase7.py` pokrývá policy safety, deterministic bootstrap a regresní výpočet entitlementu
+pro split→dividend, více splitů a post-split částečný prodej. PostgreSQL soubory aktuálně ověřují
+migration/schema a partial index; nejde o náhradu požadovaného service-level concurrency a
+multi-session E2E důkazu. Phase 6 PostgreSQL E2E zůstává autoritativní pouze pro předcházející
 research→paper tok. CI explicitně spouští Phase 7 unit i PostgreSQL soubory, locked Ruff/mypy a
 fresh Alembic upgrade.
 


### PR DESCRIPTION
### Motivation
- Opravit P0 chybu, kdy cash dividendy rekonstruované z raw fillů ignorovaly dřívější splity a tím podhodnocovaly nárok (např. BUY 10 → 2:1 split → dividend 1 USD → mělo být 20 USD). 

### Description
- Přidána funkce `_entitled_quantity` která z immutable historie fillů a evidence již aplikovaných splitů vypočítá ekonomické držení v čase entitlementu tak, že každý split násobí pouze filly, které mu časově předcházejí. 
- Upraven `PaperCorporateActionService.apply` pro načítání `PaperFillRecord.timestamp, quantity, side` a pro dotaz na již aplikované splity a následné použití `_entitled_quantity` při výpočtu `eligible_quantity`, přičemž zachován existující idempotentní zápis `PaperCorporateActionApplicationRecord`. 
- Přidány regresní unit testy v `backend/tests/test_phase7.py` pokrývající scénáře: split→post-split-sell→dividend, vícenásobné splity bez driftu a odmítnutí neplatného split ratio, a aktualizována dokumentace `docs/codex/phase7-complete.md` s popisem nové semantics entitlementu. 

### Testing
- ✅ `python -m compileall -q backend/src/quantlab backend/tests/test_phase7.py` — kompilace modulů projetá bez syntaktických chyb. 
- ✅ `git diff --check` — žádné whitespace/merge konflikty v diffu. 
- ❌ Pokus spustit unit testy `cd backend && python -m pytest -q tests/test_phase7.py` selhal při kolekci testů kvůli chybějící závislosti `sqlalchemy` v sandboxu, což brání lokálnímu vykonání PostgreSQL/DB závislých testů. 
- ⚠️ Locked-quality kroky a CI lokální validace (`uv --version`, `uv lock --check`, `uv sync --locked --all-groups`, `uv run ruff/mypy`) nelze dokončit v tomto sandboxu kvůli nainstalované `uv` verzi a blokované instalaci přes síť; tyto kroky jsou vyžadovány ve workflow a proběhnou v GitHub CI. 

Změněné soubory: `backend/src/quantlab/phase7.py`, `backend/tests/test_phase7.py`, `docs/codex/phase7-complete.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c2507d3a08332a0b99bfcedebf12e)