### PR TITLE
Aplikace splitu: inkluzivní boundary pro fills v čase splitu

### DIFF
--- a/backend/src/quantlab/phase7.py
+++ b/backend/src/quantlab/phase7.py
@@ -249,7 +249,7 @@ def _entitled_quantity(
     for filled_at, filled_quantity, side in fills:
         adjusted = filled_quantity
         for split_at, value in applied_splits:
-            if _database_utc(split_at) > _database_utc(filled_at):
+            if _database_utc(split_at) >= _database_utc(filled_at):
                 ratio = Decimal(value or "0")
                 if ratio <= 0:
                     raise DatasetInvalid("Split ratio musí být kladné")

--- a/backend/tests/test_phase7.py
+++ b/backend/tests/test_phase7.py
@@ -78,6 +78,17 @@ def test_entitlement_applies_split_to_older_fills_only() -> None:
     assert quantity == Decimal("15")
 
 
+def test_entitlement_applies_split_to_fill_at_effective_timestamp() -> None:
+    effective_at = datetime(2026, 1, 7, tzinfo=UTC)
+
+    quantity = _entitled_quantity(
+        [(effective_at, Decimal("10"), "BUY")],
+        [(effective_at, "2")],
+    )
+
+    assert quantity == Decimal("20")
+
+
 def test_entitlement_compounds_multiple_splits_without_drift() -> None:
     bought_at = datetime(2026, 1, 2, tzinfo=UTC)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,8 @@ hranice; selection smí používat train/validation, nikoli test. Monte Carlo bo
 opakováním trade returns a explicitním seedem. Parameter stability přímo reportuje medián,
 populační varianci a podíl profitabilních sousedů. Cost stress obsahuje nenulový base model.
 
-Split násobí počet akcií a cash dividend připíše držené množství krát dividend na ex-date.
+Split násobí počet akcií včetně lotů a fillů se shodným effective timestampem; cash dividend
+připíše držené množství krát dividend na ex-date.
 Adjusted signalová řada se znovu účetně nepřipisuje. Corporate actions musí být dodány explicitně.
 
 ## Známá omezení research vrstvy


### PR DESCRIPTION
### Motivation
- Rekonstrukce entitlementu používala přísné porovnání timestampů (`>`), takže fill provedený přesně v `effective_at` splitu nebyl upraven, což mohlo vést k nesprávnému spočítání nároku na dividendy a nekompatibilitě s úpravou lotů.

### Description
- Změněna kontrola v `quantlab.phase7._entitled_quantity` z `if _database_utc(split_at) > _database_utc(filled_at):` na inkluzivní `>=`, doplněn regresní test `test_entitlement_applies_split_to_fill_at_effective_timestamp` v `backend/tests/test_phase7.py` a upravena dokumentace v `docs/architecture.md` aby explicitně uváděla inkluzivní hranici; změny jsou commitnuty.

### Testing
- `ruff format --check backend/src backend/tests` a `ruff check backend/src backend/tests` proběhly a prošly úspěšně.
- `git diff --check` prošel bez chyb.
- `pytest -c backend/pyproject.toml backend/tests/test_phase7.py` selhal během kolekce kvůli chybějící dependency `sqlalchemy` v běhovém prostředí, takže úplné spuštění testů v uzamčeném prostředí nebylo možné.
- `mypy` a další kroky vyžadující synchronizaci závislostí (`uv lock` / `uv sync`) nelze dokončit v tomto prostředí kvůli neodpovídající verzi `uv` a omezenému síťovému přístupu (viz logy).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c2796c8608332b8d485d7ca524e1f)