### PR TITLE
Uzavření Phase 7 auditu — finální E2E safety důkazy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,5 @@ jobs:
           tests/test_phase7.py
           tests/test_phase7_postgres.py
           tests/test_phase7_e2e_postgres.py
+          tests/test_phase7_automation_postgres.py
+          tests/test_phase7_corporate_actions_postgres.py

--- a/backend/tests/test_phase7_automation_postgres.py
+++ b/backend/tests/test_phase7_automation_postgres.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 from phase6_audit_helpers import CALENDAR, MappingProvider, daily_bar
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session, sessionmaker
 from test_phase7_postgres import _executed_monitoring
 
@@ -16,6 +16,7 @@ from quantlab.automation import (
     JobRun,
     JobType,
     RunStatus,
+    ScheduledJob,
     SchedulerService,
     ScheduleType,
     WorkerService,
@@ -62,10 +63,23 @@ def _counts(factory, account_id: str) -> tuple[int, int, int, int, int]:
         )
 
 
+def _isolate_automation_queue(repository: AutomationRepository, now: datetime) -> None:
+    """Ukončí pouze nevyřízenou evidenci, kterou ve sdílené DB zanechaly starší testy."""
+    with Session(repository.engine) as session:
+        session.execute(update(ScheduledJob).values(enabled=False, updated_at=now))
+        session.execute(
+            update(JobRun)
+            .where(JobRun.status.in_((RunStatus.PENDING, RunStatus.RETRY_SCHEDULED)))
+            .values(status=RunStatus.CANCELLED, finished_at=now, next_attempt_at=None)
+        )
+        session.commit()
+
+
 def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempotent(factory) -> None:
     account_id, _deployment, run, instrument = _executed_monitoring(factory)
     repository = AutomationRepository(str(factory.kw["bind"].url))
     execution_time = datetime.now(UTC)
+    _isolate_automation_queue(repository, execution_time)
     completed_session = CALENDAR.latest_completed_session(execution_time)
     with factory() as session:
         price = Decimal(
@@ -87,7 +101,7 @@ def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempote
         completed_session,
         CALENDAR.session_close(completed_session),
     )
-    due = datetime(2020, 1, 1, tzinfo=UTC)
+    due = execution_time
     job = repository.create_job(
         job_type=JobType.MONITOR_PAPER_DEPLOYMENT,
         account_id=account_id,
@@ -103,7 +117,8 @@ def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempote
         worker_heartbeat_interval=2,
     )
     before = _counts(factory, account_id)
-    run_ids = [SchedulerService(repository).run_now(job.id, "phase7-e2e", due)]
+    run_ids = SchedulerService(repository).tick(due + timedelta(seconds=1))
+    assert len(run_ids) == 1
     assert (
         WorkerService(repository, settings, worker_id="phase7-monitor-1").execute_one()
         == run_ids[0]

--- a/backend/tests/test_phase7_automation_postgres.py
+++ b/backend/tests/test_phase7_automation_postgres.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
 
 import pytest
+from phase6_audit_helpers import CALENDAR, MappingProvider, daily_bar
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, sessionmaker
 from test_phase7_postgres import _executed_monitoring
@@ -18,6 +21,8 @@ from quantlab.automation import (
     WorkerService,
 )
 from quantlab.config import Settings
+from quantlab.market_data_service import PersistentMarketDataService
+from quantlab.persistence import MarketObservationRecord
 from quantlab.phase4 import PaperFillRecord, PaperOrderRecord, TradingCycleRecord
 from quantlab.phase7 import PaperPerformanceEvaluationRecord, PaperPerformanceSnapshotRecord
 
@@ -58,8 +63,30 @@ def _counts(factory, account_id: str) -> tuple[int, int, int, int, int]:
 
 
 def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempotent(factory) -> None:
-    account_id, _deployment, run, _instrument = _executed_monitoring(factory)
+    account_id, _deployment, run, instrument = _executed_monitoring(factory)
     repository = AutomationRepository(str(factory.kw["bind"].url))
+    execution_time = datetime.now(UTC)
+    completed_session = CALENDAR.latest_completed_session(execution_time)
+    with factory() as session:
+        price = Decimal(
+            session.scalar(
+                select(MarketObservationRecord.close)
+                .where(MarketObservationRecord.instrument_id == instrument.instrument_id)
+                .order_by(MarketObservationRecord.session_date.desc())
+                .limit(1)
+            )
+        )
+    PersistentMarketDataService(factory).ingest(
+        MappingProvider(
+            f"automation-{uuid4().hex[:20]}",
+            {instrument.symbol: [daily_bar(completed_session, price, "automation-monitoring")]},
+            {},
+        ),
+        instrument,
+        completed_session,
+        completed_session,
+        CALENDAR.session_close(completed_session),
+    )
     due = datetime(2020, 1, 1, tzinfo=UTC)
     job = repository.create_job(
         job_type=JobType.MONITOR_PAPER_DEPLOYMENT,

--- a/backend/tests/test_phase7_automation_postgres.py
+++ b/backend/tests/test_phase7_automation_postgres.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, sessionmaker
+from test_phase7_postgres import _executed_monitoring
+
+from quantlab.automation import (
+    AutomationRepository,
+    JobRun,
+    JobType,
+    RunStatus,
+    SchedulerService,
+    ScheduleType,
+    WorkerService,
+)
+from quantlab.config import Settings
+from quantlab.phase4 import PaperFillRecord, PaperOrderRecord, TradingCycleRecord
+from quantlab.phase7 import PaperPerformanceEvaluationRecord, PaperPerformanceSnapshotRecord
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_POSTGRES_TESTS") != "1", reason="Vyžaduje PostgreSQL CI service"
+)
+
+
+@pytest.fixture
+def factory():
+    from sqlalchemy import create_engine
+
+    return sessionmaker(create_engine(os.environ["DATABASE_URL"]), expire_on_commit=False)
+
+
+def _counts(factory, account_id: str) -> tuple[int, int, int, int, int]:
+    with factory() as session:
+        return (
+            session.scalar(
+                select(func.count())
+                .select_from(PaperOrderRecord)
+                .where(PaperOrderRecord.account_id == account_id)
+            ),
+            session.scalar(
+                select(func.count())
+                .select_from(PaperFillRecord)
+                .join(PaperOrderRecord)
+                .where(PaperOrderRecord.account_id == account_id)
+            ),
+            session.scalar(
+                select(func.count())
+                .select_from(TradingCycleRecord)
+                .where(TradingCycleRecord.account_id == account_id)
+            ),
+            session.scalar(select(func.count()).select_from(PaperPerformanceSnapshotRecord)),
+            session.scalar(select(func.count()).select_from(PaperPerformanceEvaluationRecord)),
+        )
+
+
+def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempotent(factory) -> None:
+    account_id, _deployment, run, _instrument = _executed_monitoring(factory)
+    repository = AutomationRepository(str(factory.kw["bind"].url))
+    due = datetime.now(UTC)
+    job = repository.create_job(
+        job_type=JobType.MONITOR_PAPER_DEPLOYMENT,
+        account_id=account_id,
+        schedule_type=ScheduleType.INTERVAL,
+        interval_seconds=3600,
+        next_run_at=due,
+        config={"monitoring_id": run.monitoring_id},
+    )
+    settings = Settings(
+        database_url=str(factory.kw["bind"].url),
+        automation_enabled=True,
+        worker_lease_timeout=30,
+        worker_heartbeat_interval=2,
+    )
+    before = _counts(factory, account_id)
+    run_ids = SchedulerService(repository).tick(due + timedelta(seconds=1))
+    assert len(run_ids) == 1
+    assert (
+        WorkerService(repository, settings, worker_id="phase7-monitor-1").execute_one()
+        == run_ids[0]
+    )
+    after_first = _counts(factory, account_id)
+    with Session(repository.engine) as session:
+        stored = session.get(JobRun, run_ids[0])
+        assert stored.status == RunStatus.SUCCEEDED
+        assert stored.trading_cycle_id is None and stored.reconciliation_id is None
+    assert after_first[:3] == before[:3]
+    assert after_first[3:] == (before[3] + 1, before[4] + 1)
+
+    retry_id = SchedulerService(repository).run_now(
+        job.id, "phase7-idempotent-retry", datetime.now(UTC)
+    )
+    assert (
+        WorkerService(repository, settings, worker_id="phase7-monitor-2").execute_one() == retry_id
+    )
+    after_retry = _counts(factory, account_id)
+    assert after_retry == after_first
+    with Session(repository.engine) as session:
+        retried = session.get(JobRun, retry_id)
+        assert retried.status == RunStatus.SUCCEEDED
+        assert retried.trading_cycle_id is None and retried.reconciliation_id is None

--- a/backend/tests/test_phase7_automation_postgres.py
+++ b/backend/tests/test_phase7_automation_postgres.py
@@ -60,7 +60,7 @@ def _counts(factory, account_id: str) -> tuple[int, int, int, int, int]:
 def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempotent(factory) -> None:
     account_id, _deployment, run, _instrument = _executed_monitoring(factory)
     repository = AutomationRepository(str(factory.kw["bind"].url))
-    due = datetime.now(UTC)
+    due = datetime(2020, 1, 1, tzinfo=UTC)
     job = repository.create_job(
         job_type=JobType.MONITOR_PAPER_DEPLOYMENT,
         account_id=account_id,
@@ -76,8 +76,7 @@ def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempote
         worker_heartbeat_interval=2,
     )
     before = _counts(factory, account_id)
-    run_ids = SchedulerService(repository).tick(due + timedelta(seconds=1))
-    assert len(run_ids) == 1
+    run_ids = [SchedulerService(repository).run_now(job.id, "phase7-e2e", due)]
     assert (
         WorkerService(repository, settings, worker_id="phase7-monitor-1").execute_one()
         == run_ids[0]
@@ -91,7 +90,7 @@ def test_monitoring_automation_production_e2e_is_non_economic_and_retry_idempote
     assert after_first[3:] == (before[3] + 1, before[4] + 1)
 
     retry_id = SchedulerService(repository).run_now(
-        job.id, "phase7-idempotent-retry", datetime.now(UTC)
+        job.id, "phase7-idempotent-retry", due + timedelta(seconds=1)
     )
     assert (
         WorkerService(repository, settings, worker_id="phase7-monitor-2").execute_one() == retry_id

--- a/backend/tests/test_phase7_corporate_actions_postgres.py
+++ b/backend/tests/test_phase7_corporate_actions_postgres.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, date, datetime, timedelta
-from decimal import Decimal
+from decimal import ROUND_DOWN, Decimal
 from uuid import uuid4
 
 import pytest
@@ -189,8 +189,12 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
     PaperCorporateActionService(factory).apply(account, effective + timedelta(seconds=1))
     with factory() as session:
         position = session.get(PositionRecord, (account, instrument.instrument_id))
+        split_quantity = position.quantity
         split_basis = position.average_cost
         realized_before = position.realized_pnl
+        account_equity = session.get(PaperAccountRecord, account).equity
+    desired_quantity = (split_quantity / 2).to_integral_value(rounding=ROUND_DOWN)
+    target_weight = (desired_quantity + Decimal("0.000001")) * split_basis / account_equity
     decision = effective + timedelta(days=1)
     executable = decision + timedelta(days=1)
     bars = [
@@ -233,7 +237,7 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
         account,
         "phase7-split-sell",
         bars,
-        {instrument.instrument_id: Decimal("0")},
+        {instrument.instrument_id: target_weight},
         executable.date(),
         decision,
     )
@@ -244,8 +248,10 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
             .join(PaperOrderRecord)
             .where(PaperOrderRecord.trading_cycle_id == cycle_id)
         )
-        assert position.quantity == 0
-        assert position.realized_pnl == realized_before - commission
+        assert position.quantity == desired_quantity
+        assert position.realized_pnl == pytest.approx(
+            realized_before - commission, abs=Decimal("0.0001")
+        )
 
 
 def test_partial_sell_after_split_keeps_remaining_dividend_entitlement(factory) -> None:

--- a/backend/tests/test_phase7_corporate_actions_postgres.py
+++ b/backend/tests/test_phase7_corporate_actions_postgres.py
@@ -243,20 +243,27 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
     )
     with factory() as session:
         position = session.get(PositionRecord, (account, instrument.instrument_id))
-        commission = session.scalar(
-            select(func.sum(PaperFillRecord.commission))
-            .join(PaperOrderRecord)
-            .where(PaperOrderRecord.trading_cycle_id == cycle_id)
+        fills = tuple(
+            session.scalars(
+                select(PaperFillRecord)
+                .join(PaperOrderRecord)
+                .where(PaperOrderRecord.trading_cycle_id == cycle_id)
+                .order_by(PaperFillRecord.sequence)
+            )
         )
-        sold_quantity = session.scalar(
-            select(func.sum(PaperFillRecord.quantity))
-            .join(PaperOrderRecord)
-            .where(PaperOrderRecord.trading_cycle_id == cycle_id)
+        sold_quantity = sum((fill.quantity for fill in fills), Decimal(0))
+        execution_cost = sum(
+            (
+                fill.quantity * (fill.reference_price - fill.price) + fill.commission
+                for fill in fills
+            ),
+            Decimal(0),
         )
+        assert fills
         assert sold_quantity > 0
         assert position.quantity == split_quantity - sold_quantity
         assert position.realized_pnl == pytest.approx(
-            realized_before - commission, abs=Decimal("0.0001")
+            realized_before - execution_cost, abs=Decimal("0.0001")
         )
 
 

--- a/backend/tests/test_phase7_corporate_actions_postgres.py
+++ b/backend/tests/test_phase7_corporate_actions_postgres.py
@@ -16,9 +16,11 @@ from test_phase7_postgres import _completed_as_of, _executed_monitoring
 from quantlab.domain import Bar
 from quantlab.market_data import CorporateActionKind, DatasetInvalid
 from quantlab.market_data_service import PersistentMarketDataService
-from quantlab.persistence import CorporateActionRecord
+from quantlab.persistence import CorporateActionRecord, MarketObservationRecord
 from quantlab.phase4 import (
     PaperAccountRecord,
+    PaperFillRecord,
+    PaperOrderRecord,
     Phase4Repository,
     PositionRecord,
     ProductionRiskConfig,
@@ -66,6 +68,18 @@ def _action(
             )
         )
     return action_id
+
+
+def _snapshot_market_price(factory, snapshot) -> Decimal:
+    observation_id = json.loads(snapshot.observation_lineage_json)[0]["observation_id"]
+    with factory() as session:
+        return Decimal(
+            session.scalar(
+                select(MarketObservationRecord.close).where(
+                    MarketObservationRecord.observation_id == observation_id
+                )
+            )
+        )
 
 
 def test_late_known_corporate_action_is_causal_and_exactly_once(factory) -> None:
@@ -121,27 +135,40 @@ def test_multiple_splits_then_dividend_preserve_entitlement_and_retry(factory) -
         quantity = session.get(PositionRecord, (account, instrument.instrument_id)).quantity
         cash = session.get(PaperAccountRecord, account).cash
     start = datetime.now(UTC) + timedelta(seconds=1)
-    _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, start, start, "2")
-    _action(
-        factory,
-        instrument.instrument_id,
-        CorporateActionKind.SPLIT,
-        start + timedelta(seconds=1),
-        start + timedelta(seconds=1),
-        "1.5",
-    )
-    _action(
-        factory,
-        instrument.instrument_id,
-        CorporateActionKind.CASH_DIVIDEND,
-        start + timedelta(seconds=2),
-        start + timedelta(seconds=2),
-        "1",
-    )
+    action_ids = [
+        _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, start, start, "2"),
+        _action(
+            factory,
+            instrument.instrument_id,
+            CorporateActionKind.SPLIT,
+            start + timedelta(seconds=1),
+            start + timedelta(seconds=1),
+            "1.5",
+        ),
+        _action(
+            factory,
+            instrument.instrument_id,
+            CorporateActionKind.CASH_DIVIDEND,
+            start + timedelta(seconds=2),
+            start + timedelta(seconds=2),
+            "1",
+        ),
+    ]
     service = PaperCorporateActionService(factory)
-    assert len(service.apply(account, start + timedelta(seconds=3))) == 3
-    assert service.apply(account, start + timedelta(seconds=4)) == ()
+    service.apply(account, start + timedelta(seconds=3))
+    service.apply(account, start + timedelta(seconds=4))
     with factory() as session:
+        assert (
+            session.scalar(
+                select(func.count())
+                .select_from(PaperCorporateActionApplicationRecord)
+                .where(
+                    PaperCorporateActionApplicationRecord.account_id == account,
+                    PaperCorporateActionApplicationRecord.action_id.in_(action_ids),
+                )
+            )
+            == 3
+        )
         assert (
             session.get(PositionRecord, (account, instrument.instrument_id)).quantity
             == quantity * 3
@@ -189,10 +216,11 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
             max_position_pct=Decimal("1"),
             max_single_order_pct=Decimal("1"),
             max_single_order_notional=Decimal("1000000"),
+            max_notional_per_day=Decimal("200000"),
             instrument_allowlist=frozenset({instrument.instrument_id}),
         ),
     )
-    service.run(
+    cycle_id = service.run(
         account,
         "phase7-split-sell",
         bars,
@@ -202,9 +230,13 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
     )
     with factory() as session:
         position = session.get(PositionRecord, (account, instrument.instrument_id))
+        commission = session.scalar(
+            select(func.sum(PaperFillRecord.commission))
+            .join(PaperOrderRecord)
+            .where(PaperOrderRecord.trading_cycle_id == cycle_id)
+        )
         assert position.quantity == 0
-        assert position.realized_pnl <= realized_before
-        assert position.realized_pnl == pytest.approx(realized_before, abs=Decimal("1"))
+        assert position.realized_pnl == realized_before - commission
 
 
 def test_partial_sell_after_split_keeps_remaining_dividend_entitlement(factory) -> None:
@@ -249,6 +281,7 @@ def test_partial_sell_after_split_keeps_remaining_dividend_entitlement(factory) 
             max_position_pct=Decimal("1"),
             max_single_order_pct=Decimal("1"),
             max_single_order_notional=Decimal("1000000"),
+            max_notional_per_day=Decimal("200000"),
             instrument_allowlist=frozenset({instrument.instrument_id}),
         ),
     ).run(
@@ -286,14 +319,11 @@ def test_split_performance_continuity_has_no_fake_minus_fifty_percent_return(fac
     next_day = CALENDAR.next_session(before.session_date)
     effective = CALENDAR.session_open(next_day)
     _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, effective, effective, "2")
-    with factory() as session:
-        pre_split_price = session.get(
-            PositionRecord, (account, instrument.instrument_id)
-        ).average_cost
+    pre_split_price = _snapshot_market_price(factory, before)
     observed = CALENDAR.session_close(next_day)
     PersistentMarketDataService(factory).ingest(
         MappingProvider(
-            f"split-continuity-{uuid4().hex}",
+            f"split-{uuid4().hex[:24]}",
             {instrument.symbol: [daily_bar(next_day, pre_split_price / 2, "post-split")]},
             {},
         ),
@@ -324,12 +354,12 @@ def test_dividend_performance_continuity_credits_equity_once_on_retry(factory) -
         "1",
     )
     with factory() as session:
-        price = session.get(PositionRecord, (account, instrument.instrument_id)).average_cost
         quantity = session.get(PositionRecord, (account, instrument.instrument_id)).quantity
+    price = _snapshot_market_price(factory, before)
     observed = CALENDAR.session_close(next_day)
     PersistentMarketDataService(factory).ingest(
         MappingProvider(
-            f"dividend-continuity-{uuid4().hex}",
+            f"dividend-{uuid4().hex[:21]}",
             {instrument.symbol: [daily_bar(next_day, price, "ex-dividend-equivalent")]},
             {},
         ),

--- a/backend/tests/test_phase7_corporate_actions_postgres.py
+++ b/backend/tests/test_phase7_corporate_actions_postgres.py
@@ -248,7 +248,13 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
             .join(PaperOrderRecord)
             .where(PaperOrderRecord.trading_cycle_id == cycle_id)
         )
-        assert position.quantity == desired_quantity
+        sold_quantity = session.scalar(
+            select(func.sum(PaperFillRecord.quantity))
+            .join(PaperOrderRecord)
+            .where(PaperOrderRecord.trading_cycle_id == cycle_id)
+        )
+        assert sold_quantity > 0
+        assert position.quantity == split_quantity - sold_quantity
         assert position.realized_pnl == pytest.approx(
             realized_before - commission, abs=Decimal("0.0001")
         )

--- a/backend/tests/test_phase7_corporate_actions_postgres.py
+++ b/backend/tests/test_phase7_corporate_actions_postgres.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from uuid import uuid4
 
@@ -80,6 +80,12 @@ def _snapshot_market_price(factory, snapshot) -> Decimal:
                 )
             )
         )
+
+
+def _next_account_session(factory, account_id: str, after: date) -> date:
+    with factory() as session:
+        created_day = session.get(PaperAccountRecord, account_id).created_at.date()
+    return CALENDAR.next_session(max(after, created_day))
 
 
 def test_late_known_corporate_action_is_causal_and_exactly_once(factory) -> None:
@@ -214,9 +220,12 @@ def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
         repository,
         ProductionRiskConfig(
             max_position_pct=Decimal("1"),
-            max_single_order_pct=Decimal("1"),
+            max_single_order_pct=Decimal("2"),
             max_single_order_notional=Decimal("1000000"),
             max_notional_per_day=Decimal("200000"),
+            max_gross_exposure=Decimal("2"),
+            max_net_exposure=Decimal("2"),
+            max_leverage=Decimal("2"),
             instrument_allowlist=frozenset({instrument.instrument_id}),
         ),
     )
@@ -316,7 +325,7 @@ def test_split_performance_continuity_has_no_fake_minus_fifty_percent_return(fac
     before = performance.capture(
         run.monitoring_id, _completed_as_of(factory, instrument.instrument_id)
     )
-    next_day = CALENDAR.next_session(before.session_date)
+    next_day = _next_account_session(factory, account, before.session_date)
     effective = CALENDAR.session_open(next_day)
     _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, effective, effective, "2")
     pre_split_price = _snapshot_market_price(factory, before)
@@ -343,7 +352,7 @@ def test_dividend_performance_continuity_credits_equity_once_on_retry(factory) -
     before = performance.capture(
         run.monitoring_id, _completed_as_of(factory, instrument.instrument_id)
     )
-    next_day = CALENDAR.next_session(before.session_date)
+    next_day = _next_account_session(factory, account, before.session_date)
     effective = CALENDAR.session_open(next_day)
     _action(
         factory,

--- a/backend/tests/test_phase7_corporate_actions_postgres.py
+++ b/backend/tests/test_phase7_corporate_actions_postgres.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from phase6_audit_helpers import CALENDAR, MappingProvider, daily_bar
+from sqlalchemy import func, select
+from sqlalchemy.orm import sessionmaker
+from test_phase7_e2e_postgres import _economic_counts, _execution_service
+from test_phase7_postgres import _completed_as_of, _executed_monitoring
+
+from quantlab.domain import Bar
+from quantlab.market_data import CorporateActionKind, DatasetInvalid
+from quantlab.market_data_service import PersistentMarketDataService
+from quantlab.persistence import CorporateActionRecord
+from quantlab.phase4 import (
+    PaperAccountRecord,
+    Phase4Repository,
+    PositionRecord,
+    ProductionRiskConfig,
+    TradingCycleService,
+)
+from quantlab.phase6_runtime import ValidatedCurrentDataAccessor
+from quantlab.phase7 import (
+    PaperCorporateActionApplicationRecord,
+    PaperCorporateActionService,
+    PaperMonitoringRunRecord,
+    PaperPerformanceService,
+)
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_POSTGRES_TESTS") != "1", reason="Vyžaduje PostgreSQL CI service"
+)
+
+
+@pytest.fixture
+def factory():
+    from sqlalchemy import create_engine
+
+    return sessionmaker(create_engine(os.environ["DATABASE_URL"]), expire_on_commit=False)
+
+
+def _action(
+    factory,
+    instrument_id: str,
+    kind: CorporateActionKind,
+    effective: datetime,
+    known: datetime,
+    value: str | None,
+) -> str:
+    action_id = f"phase7-{kind}-{uuid4().hex}"
+    with factory() as session, session.begin():
+        session.add(
+            CorporateActionRecord(
+                action_id=action_id,
+                instrument_id=instrument_id,
+                kind=kind,
+                effective_at=effective,
+                known_at=known,
+                value=value,
+                new_symbol=None,
+            )
+        )
+    return action_id
+
+
+def test_late_known_corporate_action_is_causal_and_exactly_once(factory) -> None:
+    account, _deployment, _run, instrument = _executed_monitoring(factory)
+    with factory() as session:
+        before = session.get(PositionRecord, (account, instrument.instrument_id)).quantity
+    effective = datetime.now(UTC) + timedelta(seconds=1)
+    known = effective + timedelta(days=2)
+    action_id = _action(
+        factory, instrument.instrument_id, CorporateActionKind.SPLIT, effective, known, "2"
+    )
+    assert PaperCorporateActionService(factory).apply(account, effective + timedelta(days=1)) == ()
+    with factory() as session:
+        assert session.get(PositionRecord, (account, instrument.instrument_id)).quantity == before
+        assert (
+            session.scalar(
+                select(func.count())
+                .select_from(PaperCorporateActionApplicationRecord)
+                .where(PaperCorporateActionApplicationRecord.action_id == action_id)
+            )
+            == 0
+        )
+    first = PaperCorporateActionService(factory).apply(account, known + timedelta(seconds=1))
+    assert len(first) == 1
+    assert PaperCorporateActionService(factory).apply(account, known + timedelta(seconds=2)) == ()
+    with factory() as session:
+        assert (
+            session.get(PositionRecord, (account, instrument.instrument_id)).quantity == before * 2
+        )
+
+
+def test_delisting_suspends_without_synthetic_economics_and_blocks_execution(factory) -> None:
+    account, deployment, run, instrument = _executed_monitoring(factory)
+    cutoff = datetime.now(UTC) + timedelta(seconds=1)
+    _action(factory, instrument.instrument_id, CorporateActionKind.DELISTING, cutoff, cutoff, None)
+    before = _economic_counts(factory, account)
+    applied = PaperCorporateActionService(factory).apply(account, cutoff + timedelta(seconds=1))
+    assert json.loads(applied[0].effect_json)["resolution"] == "SUSPENDED_NO_SYNTHETIC_FILL"
+    with factory() as session:
+        stored = session.get(PaperMonitoringRunRecord, run.monitoring_id)
+        assert stored.state == "SUSPENDED" and stored.state_reason == "DELISTING_UNSUPPORTED"
+    assert _economic_counts(factory, account) == before
+    with pytest.raises(DatasetInvalid):
+        _execution_service(factory, instrument.instrument_id).run(
+            deployment.deployment_id, cutoff + timedelta(days=1)
+        )
+    assert _economic_counts(factory, account) == before
+
+
+def test_multiple_splits_then_dividend_preserve_entitlement_and_retry(factory) -> None:
+    account, _deployment, _run, instrument = _executed_monitoring(factory)
+    with factory() as session:
+        quantity = session.get(PositionRecord, (account, instrument.instrument_id)).quantity
+        cash = session.get(PaperAccountRecord, account).cash
+    start = datetime.now(UTC) + timedelta(seconds=1)
+    _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, start, start, "2")
+    _action(
+        factory,
+        instrument.instrument_id,
+        CorporateActionKind.SPLIT,
+        start + timedelta(seconds=1),
+        start + timedelta(seconds=1),
+        "1.5",
+    )
+    _action(
+        factory,
+        instrument.instrument_id,
+        CorporateActionKind.CASH_DIVIDEND,
+        start + timedelta(seconds=2),
+        start + timedelta(seconds=2),
+        "1",
+    )
+    service = PaperCorporateActionService(factory)
+    assert len(service.apply(account, start + timedelta(seconds=3))) == 3
+    assert service.apply(account, start + timedelta(seconds=4)) == ()
+    with factory() as session:
+        assert (
+            session.get(PositionRecord, (account, instrument.instrument_id)).quantity
+            == quantity * 3
+        )
+        assert session.get(PaperAccountRecord, account).cash == cash + quantity * 3
+
+
+def test_sell_after_split_preserves_basis_and_realized_pnl(factory) -> None:
+    account, _deployment, _run, instrument = _executed_monitoring(factory)
+    effective = datetime.now(UTC) + timedelta(seconds=1)
+    _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, effective, effective, "2")
+    PaperCorporateActionService(factory).apply(account, effective + timedelta(seconds=1))
+    with factory() as session:
+        position = session.get(PositionRecord, (account, instrument.instrument_id))
+        split_basis = position.average_cost
+        realized_before = position.realized_pnl
+    decision = effective + timedelta(days=1)
+    executable = decision + timedelta(days=1)
+    bars = [
+        Bar(
+            instrument.instrument_id,
+            decision,
+            split_basis,
+            split_basis,
+            split_basis,
+            split_basis,
+            Decimal("1000000"),
+            split_basis,
+        ),
+        Bar(
+            instrument.instrument_id,
+            executable,
+            split_basis,
+            split_basis,
+            split_basis,
+            split_basis,
+            Decimal("1000000"),
+            split_basis,
+        ),
+    ]
+    repository = Phase4Repository(str(factory.kw["bind"].url), bootstrap_test_schema=False)
+    service = TradingCycleService(
+        repository,
+        ProductionRiskConfig(
+            max_position_pct=Decimal("1"),
+            max_single_order_pct=Decimal("1"),
+            max_single_order_notional=Decimal("1000000"),
+            instrument_allowlist=frozenset({instrument.instrument_id}),
+        ),
+    )
+    service.run(
+        account,
+        "phase7-split-sell",
+        bars,
+        {instrument.instrument_id: Decimal("0")},
+        executable.date(),
+        decision,
+    )
+    with factory() as session:
+        position = session.get(PositionRecord, (account, instrument.instrument_id))
+        assert position.quantity == 0
+        assert position.realized_pnl <= realized_before
+        assert position.realized_pnl == pytest.approx(realized_before, abs=Decimal("1"))
+
+
+def test_partial_sell_after_split_keeps_remaining_dividend_entitlement(factory) -> None:
+    account, _deployment, _run, instrument = _executed_monitoring(factory)
+    effective = datetime.now(UTC) + timedelta(seconds=1)
+    _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, effective, effective, "2")
+    PaperCorporateActionService(factory).apply(account, effective + timedelta(seconds=1))
+    with factory() as session:
+        position = session.get(PositionRecord, (account, instrument.instrument_id))
+        split_quantity, price = position.quantity, position.average_cost
+        ledger_equity = session.get(PaperAccountRecord, account).cash + split_quantity * price
+    desired_quantity = split_quantity * Decimal("0.75")
+    target_weight = desired_quantity * price / ledger_equity
+    decision = effective + timedelta(days=1)
+    executable = decision + timedelta(days=1)
+    bars = [
+        Bar(
+            instrument.instrument_id,
+            decision,
+            price,
+            price,
+            price,
+            price,
+            Decimal("1000000"),
+            price,
+        ),
+        Bar(
+            instrument.instrument_id,
+            executable,
+            price,
+            price,
+            price,
+            price,
+            Decimal("1000000"),
+            price,
+        ),
+    ]
+    repository = Phase4Repository(str(factory.kw["bind"].url), bootstrap_test_schema=False)
+    TradingCycleService(
+        repository,
+        ProductionRiskConfig(
+            max_position_pct=Decimal("1"),
+            max_single_order_pct=Decimal("1"),
+            max_single_order_notional=Decimal("1000000"),
+            instrument_allowlist=frozenset({instrument.instrument_id}),
+        ),
+    ).run(
+        account,
+        "phase7-partial-split-sell",
+        bars,
+        {instrument.instrument_id: target_weight},
+        executable.date(),
+        decision,
+    )
+    with factory() as session:
+        remaining = session.get(PositionRecord, (account, instrument.instrument_id)).quantity
+        cash_before = session.get(PaperAccountRecord, account).cash
+    assert remaining < split_quantity
+    dividend_at = effective + timedelta(days=2)
+    _action(
+        factory,
+        instrument.instrument_id,
+        CorporateActionKind.CASH_DIVIDEND,
+        dividend_at,
+        dividend_at,
+        "1",
+    )
+    PaperCorporateActionService(factory).apply(account, dividend_at + timedelta(seconds=1))
+    with factory() as session:
+        assert session.get(PaperAccountRecord, account).cash == cash_before + remaining
+
+
+def test_split_performance_continuity_has_no_fake_minus_fifty_percent_return(factory) -> None:
+    account, _deployment, run, instrument = _executed_monitoring(factory)
+    performance = PaperPerformanceService(factory, ValidatedCurrentDataAccessor(factory))
+    before = performance.capture(
+        run.monitoring_id, _completed_as_of(factory, instrument.instrument_id)
+    )
+    next_day = CALENDAR.next_session(before.session_date)
+    effective = CALENDAR.session_open(next_day)
+    _action(factory, instrument.instrument_id, CorporateActionKind.SPLIT, effective, effective, "2")
+    with factory() as session:
+        pre_split_price = session.get(
+            PositionRecord, (account, instrument.instrument_id)
+        ).average_cost
+    observed = CALENDAR.session_close(next_day)
+    PersistentMarketDataService(factory).ingest(
+        MappingProvider(
+            f"split-continuity-{uuid4().hex}",
+            {instrument.symbol: [daily_bar(next_day, pre_split_price / 2, "post-split")]},
+            {},
+        ),
+        instrument,
+        next_day,
+        next_day,
+        observed,
+    )
+    after = performance.capture(run.monitoring_id, observed + timedelta(minutes=1))
+    assert after.daily_return is not None
+    assert after.daily_return == pytest.approx(Decimal("0"), abs=Decimal("0.0001"))
+
+
+def test_dividend_performance_continuity_credits_equity_once_on_retry(factory) -> None:
+    account, _deployment, run, instrument = _executed_monitoring(factory)
+    performance = PaperPerformanceService(factory, ValidatedCurrentDataAccessor(factory))
+    before = performance.capture(
+        run.monitoring_id, _completed_as_of(factory, instrument.instrument_id)
+    )
+    next_day = CALENDAR.next_session(before.session_date)
+    effective = CALENDAR.session_open(next_day)
+    _action(
+        factory,
+        instrument.instrument_id,
+        CorporateActionKind.CASH_DIVIDEND,
+        effective,
+        effective,
+        "1",
+    )
+    with factory() as session:
+        price = session.get(PositionRecord, (account, instrument.instrument_id)).average_cost
+        quantity = session.get(PositionRecord, (account, instrument.instrument_id)).quantity
+    observed = CALENDAR.session_close(next_day)
+    PersistentMarketDataService(factory).ingest(
+        MappingProvider(
+            f"dividend-continuity-{uuid4().hex}",
+            {instrument.symbol: [daily_bar(next_day, price, "ex-dividend-equivalent")]},
+            {},
+        ),
+        instrument,
+        next_day,
+        next_day,
+        observed,
+    )
+    after = performance.capture(run.monitoring_id, observed + timedelta(minutes=1))
+    retry = performance.capture(run.monitoring_id, observed + timedelta(minutes=2))
+    assert after.marked_equity == before.marked_equity + quantity
+    assert retry.snapshot_id == after.snapshot_id
+    assert retry.marked_equity == after.marked_equity

--- a/backend/tests/test_phase7_e2e_postgres.py
+++ b/backend/tests/test_phase7_e2e_postgres.py
@@ -24,6 +24,7 @@ from quantlab.phase4 import (
     PaperFillRecord,
     PaperOrderRecord,
     Phase4Repository,
+    PositionRecord,
     ProductionRiskConfig,
     ReconciliationService,
     TradingCycleRecord,
@@ -44,6 +45,7 @@ from quantlab.phase7 import (
     PaperPerformanceEvaluationService,
     PaperPerformanceService,
     PaperPerformanceSnapshotRecord,
+    deterministic_block_bootstrap,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -58,7 +60,11 @@ def factory():
     return sessionmaker(create_engine(os.environ["DATABASE_URL"]), expire_on_commit=False)
 
 
-def _full_multi_session_flow(factory, prices: tuple[Decimal, ...]):
+def _full_multi_session_flow(
+    factory,
+    prices: tuple[Decimal, ...],
+    expected_verdict: EvaluationVerdict | None = None,
+):
     """Naváže na production research→promotion→approval→enrollment→execution flow."""
     engine = factory.kw["bind"]
     account_id, deployment, experiment, source_snapshot, _cycle, instrument, _ = _research_to_paper(
@@ -76,6 +82,11 @@ def _full_multi_session_flow(factory, prices: tuple[Decimal, ...]):
     )
     policy_config = DEFAULT_POLICY.copy()
     policy_config["minimum_sessions"] = 3
+    if expected_verdict is EvaluationVerdict.WATCH:
+        policy_config["watch_return_percentile"] = 50
+    elif expected_verdict is EvaluationVerdict.REVIEW_REQUIRED:
+        policy_config["watch_return_percentile"] = 50
+        policy_config["review_return_percentile"] = 40
     policy = monitoring.create_policy(
         f"phase7-e2e-{deployment.deployment_id}", policy_config, datetime.now(UTC)
     )
@@ -230,14 +241,67 @@ def test_drawdown_uses_only_historical_peak(factory) -> None:
     assert snapshots[-1].drawdown == expected
 
 
+def _append_controlled_verdict(factory, flow, expected):
+    account, _deployment, _experiment, _source, run, snapshots, _evaluations = flow
+    with factory() as session:
+        baseline = session.get(PaperExpectationBaselineRecord, run.baseline_id)
+        returns = [Decimal(value) for value in json.loads(baseline.oos_returns_json)]
+        position = session.scalar(
+            select(PositionRecord).where(PositionRecord.account_id == account)
+        )
+        account_row = session.get(PaperAccountRecord, account)
+        instrument = _instrument(factory, position.instrument_id)
+    horizon = len(snapshots) + 1
+    distribution = sorted(
+        deterministic_block_bootstrap(
+            returns,
+            horizon,
+            1000,
+            5,
+            f"{run.monitoring_id}:{run.policy_id}:{horizon}:paper-monitoring-v1",
+        )
+    )
+    if expected is EvaluationVerdict.WATCH:
+        target_return = next(
+            value
+            for value in dict.fromkeys(distribution)
+            if 2 < sum(outcome <= value for outcome in distribution) * 100 / len(distribution) <= 50
+        )
+    else:
+        target_return = distribution[0] - Decimal("0.01")
+    target_equity = run.starting_equity * (Decimal(1) + target_return)
+    target_price = (target_equity - account_row.cash) / position.quantity
+    session_day = CALENDAR.next_session(snapshots[-1].session_date)
+    observed_at = CALENDAR.session_close(session_day)
+    decision_time = observed_at + timedelta(minutes=1)
+    provider = MappingProvider(
+        f"verdict-{instrument.symbol}",
+        {instrument.symbol: [daily_bar(session_day, target_price, f"verdict-{session_day}")]},
+        {},
+    )
+    assert (
+        PersistentMarketDataService(factory)
+        .ingest(provider, instrument, session_day, session_day, observed_at)
+        .status
+        == "SUCCEEDED"
+    )
+    snapshot = PaperPerformanceService(factory, ValidatedCurrentDataAccessor(factory)).capture(
+        run.monitoring_id, decision_time
+    )
+    evaluation = PaperPerformanceEvaluationService(factory).evaluate(
+        run.monitoring_id, snapshot.snapshot_id, decision_time
+    )
+    return evaluation
+
+
 @pytest.mark.parametrize(
     ("name", "prices", "expected"),
     [
         ("HEALTHY", (Decimal("180"), Decimal("220")), EvaluationVerdict.HEALTHY),
-        ("WATCH", (Decimal("121"), Decimal("123.2")), EvaluationVerdict.WATCH),
+        ("WATCH", (Decimal("121"),), EvaluationVerdict.WATCH),
         (
             "REVIEW_REQUIRED",
-            (Decimal("121"), Decimal("122.5")),
+            (Decimal("121"),),
             EvaluationVerdict.REVIEW_REQUIRED,
         ),
     ],
@@ -250,10 +314,14 @@ def test_controlled_paper_series_proves_healthy_watch_and_review_without_auto_re
         deployments_before = session.scalar(
             select(func.count()).select_from(StrategyDeploymentRecord)
         )
-    _account, deployment, experiment, _source, run, _snapshots, evaluations = (
-        _full_multi_session_flow(factory, prices)
+    flow = _full_multi_session_flow(factory, prices, expected)
+    _account, deployment, experiment, _source, run, _snapshots, evaluations = flow
+    evaluation = (
+        evaluations[-1]
+        if expected is EvaluationVerdict.HEALTHY
+        else _append_controlled_verdict(factory, flow, expected)
     )
-    assert evaluations[-1].verdict == expected, name
+    assert evaluation.verdict == expected, name
     with factory() as session:
         stored_run = session.get(PaperMonitoringRunRecord, run.monitoring_id)
         stored_experiment = session.get(ExperimentRecord, experiment.id)
@@ -362,7 +430,11 @@ def test_baseline_is_immutable_after_provider_correction(factory) -> None:
             baseline.oos_metrics_json,
         )
         lineage = json.loads(snapshots[-1].observation_lineage_json)
-        observation = session.get(MarketObservationRecord, lineage[0]["observation_id"])
+        observation = session.scalar(
+            select(MarketObservationRecord).where(
+                MarketObservationRecord.observation_id == lineage[0]["observation_id"]
+            )
+        )
         instrument = _instrument(factory, observation.instrument_id)
     corrected_day = observation.session_date.date()
     provider = MappingProvider(
@@ -410,7 +482,11 @@ def test_historical_paper_snapshot_and_evaluation_survive_real_provider_correcti
     before_evaluation = (evaluation.evaluation_id, evaluation.content_hash, evaluation.verdict)
     with factory() as session:
         lineage = json.loads(snapshot.observation_lineage_json)
-        observation = session.get(MarketObservationRecord, lineage[0]["observation_id"])
+        observation = session.scalar(
+            select(MarketObservationRecord).where(
+                MarketObservationRecord.observation_id == lineage[0]["observation_id"]
+            )
+        )
         instrument = _instrument(factory, observation.instrument_id)
     day = observation.session_date.date()
     correction = PersistentMarketDataService(factory).ingest(

--- a/backend/tests/test_phase7_e2e_postgres.py
+++ b/backend/tests/test_phase7_e2e_postgres.py
@@ -83,8 +83,10 @@ def _full_multi_session_flow(
     policy_config = DEFAULT_POLICY.copy()
     policy_config["minimum_sessions"] = 3
     if expected_verdict is EvaluationVerdict.WATCH:
+        policy_config["bootstrap_block_size"] = 1
         policy_config["watch_return_percentile"] = 50
     elif expected_verdict is EvaluationVerdict.REVIEW_REQUIRED:
+        policy_config["bootstrap_block_size"] = 1
         policy_config["watch_return_percentile"] = 50
         policy_config["review_return_percentile"] = 40
     policy = monitoring.create_policy(
@@ -257,7 +259,7 @@ def _append_controlled_verdict(factory, flow, expected):
             returns,
             horizon,
             1000,
-            5,
+            1,
             f"{run.monitoring_id}:{run.policy_id}:{horizon}:paper-monitoring-v1",
         )
     )

--- a/backend/tests/test_phase7_e2e_postgres.py
+++ b/backend/tests/test_phase7_e2e_postgres.py
@@ -266,7 +266,7 @@ def _append_controlled_verdict(factory, flow, expected):
             value
             for value in dict.fromkeys(distribution)
             if 2 < sum(outcome <= value for outcome in distribution) * 100 / len(distribution) <= 50
-        )
+        ) + Decimal("0.000000001")
     else:
         target_return = distribution[0] - Decimal("0.01")
     target_equity = run.starting_equity * (Decimal(1) + target_return)
@@ -471,16 +471,24 @@ def test_historical_paper_snapshot_and_evaluation_survive_real_provider_correcti
         _full_multi_session_flow(factory, (Decimal("121"),))
     )
     snapshot, evaluation = snapshots[-1], evaluations[-1]
-    before_snapshot = (
-        snapshot.snapshot_id,
-        snapshot.content_hash,
-        snapshot.observation_lineage_json,
-        snapshot.daily_return,
-        snapshot.cumulative_return,
-        snapshot.drawdown,
-    )
-    before_evaluation = (evaluation.evaluation_id, evaluation.content_hash, evaluation.verdict)
     with factory() as session:
+        persisted_snapshot = session.get(PaperPerformanceSnapshotRecord, snapshot.snapshot_id)
+        persisted_evaluation = session.get(
+            PaperPerformanceEvaluationRecord, evaluation.evaluation_id
+        )
+        before_snapshot = (
+            persisted_snapshot.snapshot_id,
+            persisted_snapshot.content_hash,
+            persisted_snapshot.observation_lineage_json,
+            persisted_snapshot.daily_return,
+            persisted_snapshot.cumulative_return,
+            persisted_snapshot.drawdown,
+        )
+        before_evaluation = (
+            persisted_evaluation.evaluation_id,
+            persisted_evaluation.content_hash,
+            persisted_evaluation.verdict,
+        )
         lineage = json.loads(snapshot.observation_lineage_json)
         observation = session.scalar(
             select(MarketObservationRecord).where(

--- a/backend/tests/test_phase7_e2e_postgres.py
+++ b/backend/tests/test_phase7_e2e_postgres.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
@@ -10,13 +11,22 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import sessionmaker
 from test_phase6_e2e_postgres import CALENDAR, _research_to_paper
 
+from quantlab.market_data import AssetType, DatasetInvalid, Instrument
 from quantlab.market_data_service import PersistentMarketDataService
-from quantlab.persistence import ExperimentRecord, MarketObservationRecord, StrategyDeploymentRecord
+from quantlab.persistence import (
+    ExperimentRecord,
+    InstrumentRecord,
+    MarketObservationRecord,
+    StrategyDeploymentRecord,
+)
 from quantlab.phase4 import (
+    PaperAccountRecord,
     PaperFillRecord,
     PaperOrderRecord,
     Phase4Repository,
     ProductionRiskConfig,
+    ReconciliationService,
+    TradingCycleRecord,
     TradingCycleService,
 )
 from quantlab.phase6_runtime import (
@@ -33,6 +43,7 @@ from quantlab.phase7 import (
     PaperPerformanceEvaluationRecord,
     PaperPerformanceEvaluationService,
     PaperPerformanceService,
+    PaperPerformanceSnapshotRecord,
 )
 
 pytestmark = pytest.mark.skipif(
@@ -114,6 +125,56 @@ def _full_multi_session_flow(factory, prices: tuple[Decimal, ...]):
     return account_id, deployment, experiment, source_snapshot, run, snapshots, evaluations
 
 
+def _execution_service(factory, instrument_id: str) -> Phase6PaperExecutionService:
+    repository = Phase4Repository(str(factory.kw["bind"].url), bootstrap_test_schema=False)
+    risk = ProductionRiskConfig(
+        max_position_pct=Decimal("1"),
+        max_single_order_pct=Decimal("1"),
+        max_single_order_notional=Decimal("200000"),
+        instrument_allowlist=frozenset({instrument_id}),
+    )
+    return Phase6PaperExecutionService(
+        factory, ValidatedCurrentDataAccessor(factory), TradingCycleService(repository, risk)
+    )
+
+
+def _economic_counts(factory, account_id: str) -> tuple[int, int, int]:
+    with factory() as session:
+        return (
+            session.scalar(
+                select(func.count())
+                .select_from(PaperOrderRecord)
+                .where(PaperOrderRecord.account_id == account_id)
+            ),
+            session.scalar(
+                select(func.count())
+                .select_from(PaperFillRecord)
+                .join(PaperOrderRecord)
+                .where(PaperOrderRecord.account_id == account_id)
+            ),
+            session.scalar(
+                select(func.count())
+                .select_from(TradingCycleRecord)
+                .where(TradingCycleRecord.account_id == account_id)
+            ),
+        )
+
+
+def _instrument(factory, instrument_id: str) -> Instrument:
+    with factory() as session:
+        row = session.get(InstrumentRecord, instrument_id)
+        return Instrument(
+            row.instrument_id,
+            row.symbol,
+            row.exchange,
+            row.calendar,
+            row.currency,
+            AssetType(row.asset_type),
+            row.active_from.date(),
+            row.active_to.date() if row.active_to else None,
+        )
+
+
 def test_true_phase7_production_flow_persists_ordered_multi_session_evidence(factory) -> None:
     account, deployment, experiment, _source, run, snapshots, evaluations = (
         _full_multi_session_flow(
@@ -169,6 +230,73 @@ def test_drawdown_uses_only_historical_peak(factory) -> None:
     assert snapshots[-1].drawdown == expected
 
 
+@pytest.mark.parametrize(
+    ("name", "prices", "expected"),
+    [
+        ("HEALTHY", (Decimal("180"), Decimal("220")), EvaluationVerdict.HEALTHY),
+        ("WATCH", (Decimal("121"), Decimal("123.2")), EvaluationVerdict.WATCH),
+        (
+            "REVIEW_REQUIRED",
+            (Decimal("121"), Decimal("122.5")),
+            EvaluationVerdict.REVIEW_REQUIRED,
+        ),
+    ],
+)
+def test_controlled_paper_series_proves_healthy_watch_and_review_without_auto_retune(
+    factory, name, prices, expected
+) -> None:
+    with factory() as session:
+        experiments_before = session.scalar(select(func.count()).select_from(ExperimentRecord))
+        deployments_before = session.scalar(
+            select(func.count()).select_from(StrategyDeploymentRecord)
+        )
+    _account, deployment, experiment, _source, run, _snapshots, evaluations = (
+        _full_multi_session_flow(factory, prices)
+    )
+    assert evaluations[-1].verdict == expected, name
+    with factory() as session:
+        stored_run = session.get(PaperMonitoringRunRecord, run.monitoring_id)
+        stored_experiment = session.get(ExperimentRecord, experiment.id)
+        stored_deployment = session.get(StrategyDeploymentRecord, deployment.deployment_id)
+        assert stored_run.state == MonitoringState.ACTIVE
+        assert (
+            session.scalar(select(func.count()).select_from(ExperimentRecord))
+            == experiments_before + 1
+        )
+        assert (
+            session.scalar(select(func.count()).select_from(StrategyDeploymentRecord))
+            == deployments_before + 1
+        )
+        assert stored_experiment.selected_parameters_json == experiment.selected_parameters_json
+        assert stored_deployment.parameters_json == deployment.parameters_json
+        assert stored_deployment.strategy_version == deployment.strategy_version
+
+
+def test_suspended_monitoring_requires_safe_explicit_operator_resume(factory) -> None:
+    account, _deployment, _experiment, _source, run, _snapshots, _evaluations = (
+        _full_multi_session_flow(factory, ())
+    )
+    monitoring = PaperMonitoringService(factory)
+    monitoring.transition(
+        run.monitoring_id, MonitoringState.SUSPENDED, "reconciliation incident", datetime.now(UTC)
+    )
+    with factory() as session, session.begin():
+        session.get(PaperAccountRecord, account).reconciliation_safe = False
+    with pytest.raises(DatasetInvalid):
+        monitoring.transition(
+            run.monitoring_id, MonitoringState.ACTIVE, "unsafe resume", datetime.now(UTC)
+        )
+    repository = Phase4Repository(str(factory.kw["bind"].url), bootstrap_test_schema=False)
+    assert ReconciliationService(repository).reconcile(account).status == "SUCCEEDED"
+    resumed = monitoring.transition(
+        run.monitoring_id,
+        MonitoringState.ACTIVE,
+        "operator verified reconciliation",
+        datetime.now(UTC),
+    )
+    assert resumed.state == MonitoringState.ACTIVE
+
+
 def test_hard_suspension_blocks_execution_and_resume_until_safe(factory) -> None:
     account, deployment, experiment, _source, run, snapshots, _ = _full_multi_session_flow(
         factory, (Decimal("1"),)
@@ -178,30 +306,50 @@ def test_hard_suspension_blocks_execution_and_resume_until_safe(factory) -> None
     )
     assert evaluation.verdict == EvaluationVerdict.SUSPENDED
     with factory() as session:
-        before_orders = session.scalar(
-            select(func.count())
-            .select_from(PaperOrderRecord)
-            .where(PaperOrderRecord.account_id == account)
+        instrument_id = session.scalar(
+            select(MarketObservationRecord.instrument_id).order_by(
+                MarketObservationRecord.session_date.desc()
+            )
+        )
+    before = _economic_counts(factory, account)
+    with pytest.raises(DatasetInvalid):
+        _execution_service(factory, instrument_id).run(
+            deployment.deployment_id, datetime.now(UTC) + timedelta(days=1)
         )
     service = PaperMonitoringService(factory)
     with pytest.raises(ValueError):
         service.transition(run.monitoring_id, MonitoringState.ACTIVE, "unsafe", datetime.now(UTC))
     with factory() as session:
         assert session.get(PaperMonitoringRunRecord, run.monitoring_id).state == "SUSPENDED"
-        assert (
-            session.scalar(
-                select(func.count())
-                .select_from(PaperOrderRecord)
-                .where(PaperOrderRecord.account_id == account)
-            )
-            == before_orders
-        )
         assert session.get(ExperimentRecord, experiment.id).decision == "PAPER_CANDIDATE"
         assert session.get(StrategyDeploymentRecord, deployment.deployment_id).status == "APPROVED"
+    assert _economic_counts(factory, account) == before
+
+
+@pytest.mark.parametrize("blocked_state", [MonitoringState.PAUSED, MonitoringState.RETIRED])
+def test_paused_and_retired_monitoring_block_actual_execution(factory, blocked_state) -> None:
+    account, deployment, _experiment, _source, run, _snapshots, _ = _full_multi_session_flow(
+        factory, ()
+    )
+    with factory() as session:
+        instrument_id = session.scalar(
+            select(MarketObservationRecord.instrument_id).order_by(
+                MarketObservationRecord.session_date.desc()
+            )
+        )
+    PaperMonitoringService(factory).transition(
+        run.monitoring_id, blocked_state, f"audit {blocked_state}", datetime.now(UTC)
+    )
+    before = _economic_counts(factory, account)
+    with pytest.raises(DatasetInvalid):
+        _execution_service(factory, instrument_id).run(
+            deployment.deployment_id, datetime.now(UTC) + timedelta(days=1)
+        )
+    assert _economic_counts(factory, account) == before
 
 
 def test_baseline_is_immutable_after_provider_correction(factory) -> None:
-    _account, _deployment, _experiment, _source, run, _snapshots, _ = _full_multi_session_flow(
+    _account, _deployment, _experiment, _source, run, snapshots, _ = _full_multi_session_flow(
         factory, (Decimal("121"),)
     )
     with factory() as session:
@@ -213,7 +361,28 @@ def test_baseline_is_immutable_after_provider_correction(factory) -> None:
             baseline.oos_equity_json,
             baseline.oos_metrics_json,
         )
-    # Baseline je immutable artefakt navázaný na snapshot; opakované enrollment jej neregeneruje.
+        lineage = json.loads(snapshots[-1].observation_lineage_json)
+        observation = session.get(MarketObservationRecord, lineage[0]["observation_id"])
+        instrument = _instrument(factory, observation.instrument_id)
+    corrected_day = observation.session_date.date()
+    provider = MappingProvider(
+        observation.provider,
+        {
+            instrument.symbol: [
+                daily_bar(corrected_day, Decimal(observation.close) + Decimal("7"), "correction")
+            ]
+        },
+        {},
+    )
+    correction = PersistentMarketDataService(factory).ingest(
+        provider,
+        instrument,
+        corrected_day,
+        corrected_day,
+        snapshots[-1].as_of + timedelta(days=1),
+    )
+    assert correction.status == "SUCCEEDED"
+    assert correction.observations[0].revision == observation.revision + 1
     with factory() as session:
         baseline = session.get(PaperExpectationBaselineRecord, run.baseline_id)
         assert before == (
@@ -222,4 +391,65 @@ def test_baseline_is_immutable_after_provider_correction(factory) -> None:
             baseline.oos_returns_json,
             baseline.oos_equity_json,
             baseline.oos_metrics_json,
+        )
+
+
+def test_historical_paper_snapshot_and_evaluation_survive_real_provider_correction(factory) -> None:
+    _account, _deployment, _experiment, _source, run, snapshots, evaluations = (
+        _full_multi_session_flow(factory, (Decimal("121"),))
+    )
+    snapshot, evaluation = snapshots[-1], evaluations[-1]
+    before_snapshot = (
+        snapshot.snapshot_id,
+        snapshot.content_hash,
+        snapshot.observation_lineage_json,
+        snapshot.daily_return,
+        snapshot.cumulative_return,
+        snapshot.drawdown,
+    )
+    before_evaluation = (evaluation.evaluation_id, evaluation.content_hash, evaluation.verdict)
+    with factory() as session:
+        lineage = json.loads(snapshot.observation_lineage_json)
+        observation = session.get(MarketObservationRecord, lineage[0]["observation_id"])
+        instrument = _instrument(factory, observation.instrument_id)
+    day = observation.session_date.date()
+    correction = PersistentMarketDataService(factory).ingest(
+        MappingProvider(
+            observation.provider,
+            {instrument.symbol: [daily_bar(day, Decimal(observation.close) + 9, "correction")]},
+            {},
+        ),
+        instrument,
+        day,
+        day,
+        snapshot.as_of + timedelta(days=1),
+    )
+    assert correction.observations[0].revision == observation.revision + 1
+    assert (
+        PaperPerformanceService(factory, ValidatedCurrentDataAccessor(factory))
+        .capture(run.monitoring_id, snapshot.as_of)
+        .snapshot_id
+        == snapshot.snapshot_id
+    )
+    assert (
+        PaperPerformanceEvaluationService(factory)
+        .evaluate(run.monitoring_id, snapshot.snapshot_id, snapshot.as_of)
+        .evaluation_id
+        == evaluation.evaluation_id
+    )
+    with factory() as session:
+        stored_snapshot = session.get(PaperPerformanceSnapshotRecord, snapshot.snapshot_id)
+        stored_evaluation = session.get(PaperPerformanceEvaluationRecord, evaluation.evaluation_id)
+        assert before_snapshot == (
+            stored_snapshot.snapshot_id,
+            stored_snapshot.content_hash,
+            stored_snapshot.observation_lineage_json,
+            stored_snapshot.daily_return,
+            stored_snapshot.cumulative_return,
+            stored_snapshot.drawdown,
+        )
+        assert before_evaluation == (
+            stored_evaluation.evaluation_id,
+            stored_evaluation.content_hash,
+            stored_evaluation.verdict,
         )

--- a/docs/codex/phase7-complete.md
+++ b/docs/codex/phase7-complete.md
@@ -1,5 +1,14 @@
 # Phase 7 — Paper Performance Monitoring and Strategy Lifecycle
 
+## Uzavření finálního audit gate
+
+PostgreSQL auditní sada provádí skutečné execution pokusy pro blokované lifecycle stavy,
+skutečné provider corrections pro baseline i historickou paper evidenci a produkční Phase 5
+monitorovací job včetně idempotentního retry. Samostatné corporate-action E2E důkazy ověřují
+kauzalitu pozdě známé akce, fail-closed delisting a složené splity s dividendou bez dvojího
+zaúčtování. Controlled paper série současně dokazují verdict větve bez automatického retune,
+nového experimentu nebo deploymentu.
+
 ## Finální auditní opravy
 
 Validní enrollment deterministicky přehrává immutable Phase 6 snapshot stejnou authoritative


### PR DESCRIPTION
### Motivation
- Doplnit a zafixovat chybějící Phase 7 auditní důkazy (blokovaná execution pro PAUSED/SUSPENDED/RETIRED, immutable baseline a historická paper evidence při provider correction, HEALTHY/WATCH/REVIEW_REQUIRED větve, explicitní safe resume, automation E2E a corporate-action edge-cases). 
- Testy musí být „false‑green“: každé tvrzení v názvu testu provede skutečnou akci (reálný ingest correction, volání `Phase6PaperExecutionService.run()`, Scheduler→Worker path, apod.).

### Description
- Přidány nové integrační testy a rozšířeny stávající: upraven `backend/tests/test_phase7_e2e_postgres.py`, přidány `backend/tests/test_phase7_automation_postgres.py` a `backend/tests/test_phase7_corporate_actions_postgres.py` pro kompletní Phase 7 proof‑set; testy pokrývají suspend/pause/retire execution‑gate, real provider correction immutability, historickou paper snapshot immutability, HEALTHY/WATCH/REVIEW_REQUIRED verdicty, explicitní safe resume, monitoring automation non‑economic E2E + idempotent retry, late‑known corporate actions, delisting, více splitů a sell/partial‑sell scénáře.
- Aktualizována CI definice `.github/workflows/ci.yml` tak, aby PostgreSQL job spouštěl nové Phase7 testy; doplněna drobná dokumentace `docs/codex/phase7-complete.md` shrnující finální auditní korekce.
- V testech explicitně použit `PersistentMarketDataService` a `Phase6PaperExecutionService` pro environment‑level důkazy, přidány pomocné funkce pro kontrolu ekonomických ledger‑counts a znovupoužitelné execution helpery; dodržen fail‑closed princip (testy očekávají a asertují `DatasetInvalid` tam, kde má run být zablokován).

### Testing
- Spuštěné statické/formatovací kontroly: `ruff format` / `ruff check` a `python -m compileall` prošly bez chyb pro upravené testy a zdroj; výsledky: PASS.
- Pokusy o dependency/quality gates: `uv --version` ukázal běžící `uv 0.7.22` zatímco repo vyžaduje `uv == 0.12.3`, takže `uv lock --check` a `uv sync --locked --all-groups` nebyly úspěšné v tomto prostředí a synchronizace balíčků selhala kvůli chybějícím síťovým/registry zdrojům; výsledek: BLOCKED BY ENVIRONMENT.
- Běh testů: spouštěné `pytest` cíleně proti novým souborům skončilo collection chybami způsobenými chybějícími runtime závislostmi (`ModuleNotFoundError: No module named 'sqlalchemy'`), což je vedlejší efekt nemožnosti dokončit `uv sync` v sandboxu; výsledky: TEST COLLECTION ERROR (není selhání logiky testů, ale chybějící závislosti v prostředí).
- Shrnutí automatických výsledků: lint/format/compile = PASS; dependency sync / locked quality / pytest PostgreSQL runs = BLOCKED (uv verze + offline/registry omezení a chybějící PostgreSQL v sandboxu).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c3a9869888332b1a8fa119449213a)