### PR TITLE
Phase 8: zpřesnění auditních časových filtrů do UTC

### DIFF
--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -233,6 +233,8 @@ def operator_audit(
     start_utc: datetime | None = None,
     end_utc: datetime | None = None,
 ) -> dict[str, object]:
+    start_utc = _normalize_utc_filter(start_utc)
+    end_utc = _normalize_utc_filter(end_utc)
     if start_utc and end_utc and start_utc > end_utc:
         raise HTTPException(422, "start_utc musí být před end_utc")
     return operator_read_model.audit(
@@ -245,6 +247,14 @@ def operator_audit(
         start=start_utc,
         end=end_utc,
     )
+
+
+def _normalize_utc_filter(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 @app.post("/operator/risk/halt", response_model=OperatorDocument)

--- a/backend/tests/test_phase8_api.py
+++ b/backend/tests/test_phase8_api.py
@@ -86,6 +86,21 @@ def test_audit_filters_are_server_side_and_range_is_validated(tmp_path, monkeypa
     )
 
 
+def test_audit_normalizes_mixed_datetime_filters_to_utc(tmp_path, monkeypatch):
+    api = client(tmp_path, monkeypatch)
+    api.post("/operator/risk/halt", json={"confirmation": "HALT", "reason": "UTC audit"})
+
+    response = api.get(
+        "/operator/audit"
+        "?event_type=KILL_SWITCH_MANUAL_HALT"
+        "&start_utc=2020-01-01T00:00:00"
+        "&end_utc=2030-01-01T01:00:00%2B01:00"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+
+
 def test_openapi_exposes_stable_operator_contracts(tmp_path, monkeypatch):
     schema = client(tmp_path, monkeypatch).get("/openapi.json").json()
     required = {

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -28,7 +28,8 @@ formulář. Reconciliation vyžaduje `RECONCILE`. Systém je pouze PAPER a nikde
 Data stránka používá authoritative XNYS latest completed session, nikoli 24h TTL. STARTED,
 FAILED nebo chybějící session se nezobrazí jako healthy. Operations zobrazuje PostgreSQL jobs,
 runs, dead letters a heartbeat freshness. Audit filtry a stránkování probíhají na serveru;
-payload se renderuje escapovaným React textem bez raw HTML.
+payload se renderuje escapovaným React textem bez raw HTML. Časové auditní filtry se před
+porovnáním normalizují do UTC; hodnota bez offsetu z pole označeného UTC se interpretuje jako UTC.
 
 Kontroly: `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`. Při 503 nebo síťové
 chybě stránka zobrazí unavailable stav; prázdná evidence se nikdy nenahrazuje nulami.


### PR DESCRIPTION
### Motivation
- Serverová validační logika a databázové dotazy pro `/operator/audit` mohly porovnávat naive a timezone-aware datetimes, což vedlo k chybným 422 validacím nebo neúplným výsledkům; je potřeba normalizovat filtry na timezone-aware UTC před porovnáním. 
- Změny musí být minimální, bezpečné a nevracet starou implementaci Phase 8 ani nezasahovat do frontendového lockfilu.

### Description
- Přidána pomocná funkce `_normalize_utc_filter` a volána v handleru `operator_audit` pro normalizaci `start_utc` a `end_utc` na timezone-aware UTC před validací a dotazem. 
- Přidán regresní test `test_audit_normalizes_mixed_datetime_filters_to_utc` v `backend/tests/test_phase8_api.py`, který ověřuje kombinaci hodnot bez offsetu a s explicitním offsetem a očekává nalezení auditní události `KILL_SWITCH_MANUAL_HALT`. 
- Aktualizována dokumentace `docs/dashboard.md` o přesnou interpretaci auditních časových filtrů (hodnota bez offsetu z pole označeného UTC se interpretuje jako UTC) a zachovány existující bezpečnostní invariants (paper-only, KILL_SWITCH_MANUAL_HALT atd.).

### Testing
- `ruff format --check .` a `ruff check .` byly spuštěny lokálně a prošly. 
- `python -m compileall -q backend/src/quantlab backend/tests/test_phase8_api.py` a `git diff --check` proběhly a neodhalily chyby. 
- Kontrola závislostí a prostředí je částečně blokovaná: `uv` v prostředí má verzi `0.7.22` zatímco repozitář vyžaduje `uv==0.12.3`, takže `uv lock --check`, `uv sync --locked --all-groups`, `uv run mypy` a `uv run pytest ...` nebyly možné spustit zde pro environmentální omezení. 
- Frontendová fáze (`npm ci`, `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`) nebyla dokončena kvůli omezením sítě/registry v běhovém prostředí, přičemž `frontend/package-lock.json` nebyl změněn a zůstává byte-for-byte zachován.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8d58c879c88332a2f6f7abd11e7315)