### PR TITLE
Oprava přenositelnosti DB záloh: relativní checksum a ověření restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,16 @@ jobs:
         with: {persist-credentials: false}
       - run: docker build -f backend/Dockerfile -t quantlab-backend .
       - run: docker build -f frontend/Dockerfile -t quantlab-frontend .
-      - run: test "$(docker run --rm --entrypoint id quantlab-backend -u)" != 0
-      - run: test "$(docker run --rm --entrypoint id quantlab-frontend -u)" != 0
+      - run: test "$(docker run --rm --entrypoint /app/backend/.venv/bin/python quantlab-backend -c 'import os; print(os.getuid())')" != 0
+      - run: test "$(docker run --rm --entrypoint /nodejs/bin/node quantlab-frontend -e 'console.log(process.getuid())')" != 0
+      - name: Verify minimal production runtimes
+        run: |
+          docker run --rm --entrypoint /app/backend/.venv/bin/python quantlab-backend -c \
+            "import pathlib,sys; assert sys.version_info[:2] == (3,12); assert not any(pathlib.Path('/usr/local/bin').glob('pip*'))"
+          docker run --rm --entrypoint /nodejs/bin/node quantlab-frontend -e \
+            "const fs=require('node:fs'); if(process.versions.node.split('.')[0] !== '24' || ['/usr/local/bin/npm','/usr/local/bin/yarn','/bin/sh'].some(fs.existsSync)) process.exit(1)"
+          test "$(docker inspect --format '{{json .Config.Healthcheck.Test}}' quantlab-backend)" != null
+          test "$(docker inspect --format '{{json .Config.Healthcheck.Test}}' quantlab-frontend)" != null
       - run: docker save quantlab-backend --output "$RUNNER_TEMP/backend-image.tar"
       - run: docker save quantlab-frontend --output "$RUNNER_TEMP/frontend-image.tar"
       - run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Verify minimal production runtimes
         run: |
           docker run --rm --entrypoint /app/backend/.venv/bin/python quantlab-backend -c \
-            "import pathlib,sys; assert sys.version_info[:2] == (3,12); assert not any(pathlib.Path('/usr/local/bin').glob('pip*')); assert not pathlib.Path('/usr/local/bin/uv').exists()"
+            "import ctypes,numpy,pandas,pathlib,psycopg,pydantic_core,pyarrow,sys; ctypes.CDLL('libgcc_s.so.1'); assert sys.version_info[:2] == (3,12); assert not any(pathlib.Path('/usr/local/bin').glob('pip*')); assert not pathlib.Path('/usr/local/bin/uv').exists()"
           docker run --rm --entrypoint /usr/local/bin/node quantlab-frontend -e \
             "const fs=require('node:fs'); if(process.versions.node.split('.')[0] !== '24' || ['/usr/local/bin/npm','/usr/local/bin/yarn','/bin/sh'].some(fs.existsSync)) process.exit(1)"
           test "$(docker inspect --format '{{json .Config.Healthcheck.Test}}' quantlab-backend)" != null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,12 +201,12 @@ jobs:
       - run: docker build -f backend/Dockerfile -t quantlab-backend .
       - run: docker build -f frontend/Dockerfile -t quantlab-frontend .
       - run: test "$(docker run --rm --entrypoint /app/backend/.venv/bin/python quantlab-backend -c 'import os; print(os.getuid())')" != 0
-      - run: test "$(docker run --rm --entrypoint /nodejs/bin/node quantlab-frontend -e 'console.log(process.getuid())')" != 0
+      - run: test "$(docker run --rm --entrypoint /usr/local/bin/node quantlab-frontend -e 'console.log(process.getuid())')" != 0
       - name: Verify minimal production runtimes
         run: |
           docker run --rm --entrypoint /app/backend/.venv/bin/python quantlab-backend -c \
-            "import pathlib,sys; assert sys.version_info[:2] == (3,12); assert not any(pathlib.Path('/usr/local/bin').glob('pip*'))"
-          docker run --rm --entrypoint /nodejs/bin/node quantlab-frontend -e \
+            "import pathlib,sys; assert sys.version_info[:2] == (3,12); assert not any(pathlib.Path('/usr/local/bin').glob('pip*')); assert not pathlib.Path('/usr/local/bin/uv').exists()"
+          docker run --rm --entrypoint /usr/local/bin/node quantlab-frontend -e \
             "const fs=require('node:fs'); if(process.versions.node.split('.')[0] !== '24' || ['/usr/local/bin/npm','/usr/local/bin/yarn','/bin/sh'].some(fs.existsSync)) process.exit(1)"
           test "$(docker inspect --format '{{json .Config.Healthcheck.Test}}' quantlab-backend)" != null
           test "$(docker inspect --format '{{json .Config.Healthcheck.Test}}' quantlab-frontend)" != null

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,13 +17,17 @@ RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
       | sort -u > /tmp/runtime-libs \
     && test -s /tmp/runtime-libs \
     && while IFS= read -r library; do \
-      mkdir -p "/runtime-libs$(dirname "$library")"; \
-      cp -L "$library" "/runtime-libs$library"; \
+      case "$library" in \
+        /lib/*|/lib64/*) destination="/runtime-libs/usr$library" ;; \
+        *) destination="/runtime-libs$library" ;; \
+      esac; \
+      mkdir -p "$(dirname "$destination")"; \
+      cp -L "$library" "$destination"; \
     done < /tmp/runtime-libs
 
 FROM gcr.io/distroless/static-debian13:nonroot
 WORKDIR /app
-COPY --from=build /runtime-libs/ /
+COPY --from=build /runtime-libs/usr/ /usr/
 COPY --from=build /usr/local /usr/local
 COPY --from=build --chown=65532:65532 /app/backend /app/backend
 COPY --chown=65532:65532 alembic.ini /app/alembic.ini

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,10 +7,23 @@ RUN uv sync --locked --no-dev --no-install-project
 COPY backend/src ./src
 RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
     /usr/local/lib/python3.12/ensurepip \
-    /usr/local/bin/pip*
+    /usr/local/lib/python3.12/lib-dynload/_curses*.so \
+    /usr/local/lib/python3.12/lib-dynload/readline*.so \
+    /usr/local/bin/pip* \
+    /usr/local/bin/uv \
+    && mkdir /runtime-libs \
+    && find /usr/local -type f -exec ldd {} \; 2>/dev/null \
+      | awk '{ for (i = 1; i <= NF; i++) if ($i ~ "^/") print $i }' \
+      | sort -u > /tmp/runtime-libs \
+    && test -s /tmp/runtime-libs \
+    && while IFS= read -r library; do \
+      mkdir -p "/runtime-libs$(dirname "$library")"; \
+      cp -L "$library" "/runtime-libs$library"; \
+    done < /tmp/runtime-libs
 
-FROM gcr.io/distroless/python3-debian13:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 WORKDIR /app
+COPY --from=build /runtime-libs/ /
 COPY --from=build /usr/local /usr/local
 COPY --from=build --chown=65532:65532 /app/backend /app/backend
 COPY --chown=65532:65532 alembic.ini /app/alembic.ini

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,19 +5,19 @@ WORKDIR /app/backend
 COPY backend/pyproject.toml backend/uv.lock ./
 RUN uv sync --locked --no-dev --no-install-project
 COPY backend/src ./src
+RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
+    /usr/local/lib/python3.12/ensurepip \
+    /usr/local/bin/pip*
 
-FROM python:3.12.14-slim-trixie
-RUN apt-get update \
-    && apt-get upgrade --yes \
-    && groupadd --system quantlab \
-    && useradd --system --gid quantlab --home /app quantlab \
-    && rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/python3-debian13:nonroot
 WORKDIR /app
-COPY --from=build --chown=quantlab:quantlab /app/backend /app/backend
-COPY --chown=quantlab:quantlab alembic.ini /app/alembic.ini
-COPY --chown=quantlab:quantlab alembic /app/alembic
+COPY --from=build /usr/local /usr/local
+COPY --from=build --chown=65532:65532 /app/backend /app/backend
+COPY --chown=65532:65532 alembic.ini /app/alembic.ini
+COPY --chown=65532:65532 alembic /app/alembic
 ENV PATH=/app/backend/.venv/bin:$PATH PYTHONPATH=/app/backend/src
-USER quantlab
+USER 65532:65532
 EXPOSE 8000
-HEALTHCHECK CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2)"
-CMD ["uvicorn","quantlab.api:app","--host","0.0.0.0","--port","8000","--workers","1","--no-proxy-headers"]
+HEALTHCHECK CMD ["/app/backend/.venv/bin/python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2)"]
+ENTRYPOINT []
+CMD ["/app/backend/.venv/bin/python","-m","uvicorn","quantlab.api:app","--host","0.0.0.0","--port","8000","--workers","1","--no-proxy-headers"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
     /usr/local/bin/pip* \
     /usr/local/bin/uv \
     && mkdir /runtime-libs \
-    && find /usr/local -type f -exec ldd {} \; 2>/dev/null \
+    && find /usr/local /app/backend/.venv -type f -exec ldd {} \; 2>/dev/null \
       | awk '{ for (i = 1; i <= NF; i++) if ($i ~ "^/") print $i }' \
       | sort -u > /tmp/runtime-libs \
     && test -s /tmp/runtime-libs \

--- a/backend/tests/test_phase9_postgres.py
+++ b/backend/tests/test_phase9_postgres.py
@@ -80,7 +80,12 @@ def test_production_repository_does_not_create_schema_implicitly() -> None:
             connection.execute(f'DROP DATABASE "{database}" WITH (FORCE)')
 
 
-def _run_postgres_tool(script: str, arguments: list[str], environment: dict[str, str]):
+def _run_postgres_tool(
+    script: str,
+    arguments: list[str],
+    environment: dict[str, str],
+    backup_path: str = "/backup/phase9.dump",
+):
     repository = Path(__file__).parents[2]
     docker_environment = [item for key in environment for item in ("-e", key)]
     return subprocess.run(
@@ -98,7 +103,7 @@ def _run_postgres_tool(script: str, arguments: list[str], environment: dict[str,
             *docker_environment,
             "postgres:17-alpine",
             f"/scripts/{script}",
-            "/backup/phase9.dump",
+            backup_path,
         ],
         check=False,
         capture_output=True,
@@ -115,6 +120,14 @@ def test_backup_checksum_restore_and_fail_closed_inputs(tmp_path: Path) -> None:
     assert (tmp_path / "phase9.dump").is_file()
     assert (tmp_path / "phase9.dump.sha256").is_file()
 
+    relocated = tmp_path / "off-site" / "recovery"
+    relocated.mkdir(parents=True)
+    backup_path = relocated / "phase9.dump"
+    checksum_path = relocated / "phase9.dump.sha256"
+    (tmp_path / "phase9.dump").rename(backup_path)
+    (tmp_path / "phase9.dump.sha256").rename(checksum_path)
+    assert checksum_path.read_text().endswith("  phase9.dump\n")
+
     missing = subprocess.run(
         [str(repository / "scripts/db-restore.sh"), str(tmp_path / "missing.dump")],
         env={
@@ -130,9 +143,9 @@ def test_backup_checksum_restore_and_fail_closed_inputs(tmp_path: Path) -> None:
     )
     assert unconfirmed.returncode != 0
 
-    checksum = tmp_path / "phase9.dump.sha256"
+    checksum = checksum_path
     valid_checksum = checksum.read_text()
-    checksum.write_text("0" * 64 + "  /backup/phase9.dump\n")
+    checksum.write_text("0" * 64 + "  phase9.dump\n")
     corrupt = _run_postgres_tool(
         "db-restore.sh",
         volume,
@@ -140,9 +153,10 @@ def test_backup_checksum_restore_and_fail_closed_inputs(tmp_path: Path) -> None:
             "RESTORE_DATABASE_URL": _dsn("missing"),
             "RESTORE_CONFIRMATION": "RESTORE_EPHEMERAL_DATABASE",
         },
+        "/backup/off-site/recovery/phase9.dump",
     )
     assert corrupt.returncode != 0
-    checksum.write_text(valid_checksum.replace(str(tmp_path), "/backup"))
+    checksum.write_text(valid_checksum)
 
     restored_database = f"phase9_restore_{uuid4().hex[:12]}"
     with psycopg.connect(_dsn(), autocommit=True) as connection:
@@ -155,6 +169,7 @@ def test_backup_checksum_restore_and_fail_closed_inputs(tmp_path: Path) -> None:
                 "RESTORE_DATABASE_URL": _dsn(restored_database),
                 "RESTORE_CONFIRMATION": "RESTORE_EPHEMERAL_DATABASE",
             },
+            "/backup/off-site/recovery/phase9.dump",
         )
         assert restored.returncode == 0, restored.stderr
         with psycopg.connect(_dsn(restored_database)) as connection:

--- a/backend/tests/test_phase9_security.py
+++ b/backend/tests/test_phase9_security.py
@@ -1,10 +1,43 @@
 import json
+import os
+import subprocess
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 
 from quantlab import api
 from quantlab.config import Settings
 from quantlab.security import limiter
+
+
+def test_backup_fails_when_checksum_cannot_be_computed(tmp_path: Path) -> None:
+    repository = Path(__file__).parents[2]
+    tools = tmp_path / "tools"
+    tools.mkdir()
+    pg_dump = tools / "pg_dump"
+    pg_dump.write_text('#!/bin/sh\nprintf "valid dump" > "${4#--file=}"\n')
+    pg_dump.chmod(0o700)
+    sha256sum = tools / "sha256sum"
+    sha256sum.write_text("#!/bin/sh\nexit 74\n")
+    sha256sum.chmod(0o700)
+    backup = tmp_path / "backup.dump"
+
+    result = subprocess.run(
+        [str(repository / "scripts/db-backup.sh"), str(backup)],
+        env={
+            **os.environ,
+            "DATABASE_URL": "postgresql://synthetic.invalid/quantlab",
+            "PATH": f"{tools}:{os.environ['PATH']}",
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "Výpočet checksumu backupu selhal" in result.stderr
+    assert backup.is_file()
+    assert not backup.with_suffix(".dump.sha256").exists()
 
 
 def client(role: str = "admin") -> TestClient:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -10,6 +10,10 @@ Production-like PAPER provoz vyžaduje explicitní migration step, strong secret
 
 Diagnostika používá risk events/decisions, orders, audit a reconciliation status. Po crashi spusťte stejný logical cycle: DB identity obnoví existující stav namísto nového obchodu. Testy: `uv run pytest -q`.
 
+Backup skript ukládá vedle dumpu SHA-256 manifest s relativním názvem souboru. Dump a jeho
+`.sha256` proto lze společně přesunout do off-site úložiště nebo recovery adresáře; restore vždy
+přepočítá a porovná obsah skutečně předaného dumpu před prvním destruktivním databázovým krokem.
+
 PostgreSQL Phase 5 acceptance suite je v `tests/test_phase5_postgres.py` a používá oddělené
 enginy, sessions a souběžná vlákna. Ověřuje race schedulerů, race worker claimů včetně lease a
 fencing tokenu, restart po ekonomickém commitu Phase 4 a account lock mezi paper cycle a

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,5 +1,9 @@
 # Production-like PAPER deployment
 
+Produkční backend a frontend používají distroless Debian 13 runtime bez shellu a systémového
+package manageru. Diagnostiku a non-root kontroly proto provádějte přes aplikační Python nebo
+Node runtime, nikoli pomocí `sh`, `id`, `apt` či `npm` uvnitř běžícího kontejneru.
+
 1. `make generate-dev-secrets` použijte jen pro lokální credentials a bezpečně provisionujte
    ekvivalentní production secrets. Veřejný ingress musí ukončovat HTTPS.
 2. Vytvořte oddělené PostgreSQL migration/runtime role; migration credential použijte pouze pro

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,8 +1,9 @@
 # Production-like PAPER deployment
 
-Produkční backend a frontend používají distroless Debian 13 runtime bez shellu a systémového
-package manageru. Diagnostiku a non-root kontroly proto provádějte přes aplikační Python nebo
-Node runtime, nikoli pomocí `sh`, `id`, `apt` či `npm` uvnitř běžícího kontejneru.
+Produkční backend a frontend používají distroless `static` Debian 13 runtime, do kterého build
+kopíruje jen aplikační interpreter a jeho dynamické knihovny. Runtime neobsahuje shell ani
+systémový package manager. Diagnostiku a non-root kontroly proto provádějte přes aplikační Python
+nebo Node runtime, nikoli pomocí `sh`, `id`, `apt` či `npm` uvnitř běžícího kontejneru.
 
 1. `make generate-dev-secrets` použijte jen pro lokální credentials a bezpečně provisionujte
    ekvivalentní production secrets. Veřejný ingress musí ukončovat HTTPS.

--- a/docs/security-exceptions.md
+++ b/docs/security-exceptions.md
@@ -1,0 +1,14 @@
+# Časově omezené security výjimky
+
+Tento registr neřídí ani neoslabuje Trivy. Blocking scan nadále kontroluje všechny HIGH a
+CRITICAL nálezy bez `--ignore-unfixed`; záznamy pouze auditují upstream komponenty, pro které
+2026-08-26 není publikovaná opravená Debian 13 verze.
+
+| Advisory | Vlastník | Platnost | Expozice a mitigace |
+|---|---|---|---|
+| CVE-2026-14456 | Platform Security | 2026-09-30 | OpenSSL QUIC server může neomezeně alokovat paměť. Quant Lab nespouští QUIC server; OpenSSL slouží pouze klientskému HTTPS/PostgreSQL TLS. Runtime je non-root, read-only a bez capabilities. |
+| CVE-2026-7210 | Platform Security | 2026-09-30 | Upstream CPython/Expat může při zpracování škodlivého XML spotřebovat CPU. Produkční API XML nepřijímá ani neparsuje a runtime nemá obecný upload endpoint. |
+
+Vlastník při vydání opraveného upstream runtime odstraní výjimku a ověří oba produkční images
+blocking Trivy scanem. Po datu platnosti je výjimka neplatná a musí být před deploymentem znovu
+triagována; nesmí být automaticky prodloužena.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,8 @@
 # Phase 9 threat model a bezpečnostní architektura
 
+Časově omezené upstream výjimky a jejich mitigace eviduje
+[`security-exceptions.md`](security-exceptions.md); tento registr nemění blocking scanner policy.
+
 Single operator ≠ no authentication. Systém není multi-tenant SaaS, ale production-like PAPER
 control plane je vždy autentizovaný a backend autorizuje každou operaci.
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,14 +12,18 @@ RUN npm run build \
       | sort -u > /tmp/runtime-libs \
     && test -s /tmp/runtime-libs \
     && while IFS= read -r library; do \
-      mkdir -p "/runtime-libs$(dirname "$library")"; \
-      cp -L "$library" "/runtime-libs$library"; \
+      case "$library" in \
+        /lib/*|/lib64/*) destination="/runtime-libs/usr$library" ;; \
+        *) destination="/runtime-libs$library" ;; \
+      esac; \
+      mkdir -p "$(dirname "$destination")"; \
+      cp -L "$library" "$destination"; \
     done < /tmp/runtime-libs
 
 FROM gcr.io/distroless/static-debian13:nonroot
 ENV NODE_ENV=production HOSTNAME=0.0.0.0 PORT=3000 VALIDATE_PRODUCTION_STARTUP=true
 WORKDIR /app
-COPY --from=build /runtime-libs/ /
+COPY --from=build /runtime-libs/usr/ /usr/
 COPY --from=build /usr/local/bin/node /usr/local/bin/node
 COPY --from=build --chown=65532:65532 /app/.next/standalone ./
 COPY --from=build --chown=65532:65532 /app/.next/static ./.next/static

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,28 +7,14 @@ ARG PUBLIC_BASE_URL=https://localhost
 ENV PUBLIC_BASE_URL=$PUBLIC_BASE_URL
 RUN npm run build
 
-FROM node:24.18.1-trixie-slim
+FROM gcr.io/distroless/nodejs24-debian13:nonroot
 ENV NODE_ENV=production HOSTNAME=0.0.0.0 PORT=3000 VALIDATE_PRODUCTION_STARTUP=true
-RUN apt-get update \
-    && apt-get upgrade --yes \
-    && rm -rf /usr/local/lib/node_modules/npm \
-        /usr/local/lib/node_modules/corepack \
-        /usr/local/bin/corepack \
-        /usr/local/bin/npm \
-        /usr/local/bin/npx \
-        /usr/local/bin/pnpm \
-        /usr/local/bin/pnpx \
-        /usr/local/bin/yarn \
-        /usr/local/bin/yarnpkg \
-    && groupadd --system quantlab \
-    && useradd --system --gid quantlab --home /app quantlab \
-    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY --from=build --chown=quantlab:quantlab /app/.next/standalone ./
-COPY --from=build --chown=quantlab:quantlab /app/.next/static ./.next/static
-COPY --from=build --chown=quantlab:quantlab /app/public ./public
-USER quantlab
+COPY --from=build --chown=65532:65532 /app/.next/standalone ./
+COPY --from=build --chown=65532:65532 /app/.next/static ./.next/static
+COPY --from=build --chown=65532:65532 /app/public ./public
+USER 65532:65532
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:3000/login').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
-CMD ["node","server.js"]
+  CMD ["/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:3000/login').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+CMD ["server.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,16 +5,28 @@ RUN npm install --global npm@11.17.0 && npm ci --ignore-scripts
 COPY frontend/ ./
 ARG PUBLIC_BASE_URL=https://localhost
 ENV PUBLIC_BASE_URL=$PUBLIC_BASE_URL
-RUN npm run build
+RUN npm run build \
+    && mkdir /runtime-libs \
+    && ldd /usr/local/bin/node \
+      | awk '{ for (i = 1; i <= NF; i++) if ($i ~ "^/") print $i }' \
+      | sort -u > /tmp/runtime-libs \
+    && test -s /tmp/runtime-libs \
+    && while IFS= read -r library; do \
+      mkdir -p "/runtime-libs$(dirname "$library")"; \
+      cp -L "$library" "/runtime-libs$library"; \
+    done < /tmp/runtime-libs
 
-FROM gcr.io/distroless/nodejs24-debian13:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot
 ENV NODE_ENV=production HOSTNAME=0.0.0.0 PORT=3000 VALIDATE_PRODUCTION_STARTUP=true
 WORKDIR /app
+COPY --from=build /runtime-libs/ /
+COPY --from=build /usr/local/bin/node /usr/local/bin/node
 COPY --from=build --chown=65532:65532 /app/.next/standalone ./
 COPY --from=build --chown=65532:65532 /app/.next/static ./.next/static
 COPY --from=build --chown=65532:65532 /app/public ./public
 USER 65532:65532
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD ["/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:3000/login').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
-CMD ["server.js"]
+  CMD ["/usr/local/bin/node", "-e", "fetch('http://127.0.0.1:3000/login').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
+ENTRYPOINT []
+CMD ["/usr/local/bin/node","server.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG PUBLIC_BASE_URL=https://localhost
 ENV PUBLIC_BASE_URL=$PUBLIC_BASE_URL
 RUN npm run build \
     && mkdir /runtime-libs \
-    && ldd /usr/local/bin/node \
+    && find /usr/local/bin/node /app/.next/standalone -type f -exec ldd {} \; 2>/dev/null \
       | awk '{ for (i = 1; i <= NF; i++) if ($i ~ "^/") print $i }' \
       | sort -u > /tmp/runtime-libs \
     && test -s /tmp/runtime-libs \

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -10,4 +10,5 @@ case "$DATABASE_URL" in
   *) database_url=$DATABASE_URL ;;
 esac
 pg_dump --format=custom --no-owner --no-acl --file="$target" "$database_url"
-sha256sum "$target" > "$target.sha256"
+checksum=$(sha256sum "$target" | awk '{print $1}')
+printf '%s  %s\n' "$checksum" "$(basename "$target")" > "$target.sha256"

--- a/scripts/db-backup.sh
+++ b/scripts/db-backup.sh
@@ -10,5 +10,9 @@ case "$DATABASE_URL" in
   *) database_url=$DATABASE_URL ;;
 esac
 pg_dump --format=custom --no-owner --no-acl --file="$target" "$database_url"
-checksum=$(sha256sum "$target" | awk '{print $1}')
+if ! checksum_output=$(sha256sum "$target"); then
+  echo "Výpočet checksumu backupu selhal" >&2
+  exit 1
+fi
+checksum=${checksum_output%% *}
 printf '%s  %s\n' "$checksum" "$(basename "$target")" > "$target.sha256"

--- a/scripts/db-restore.sh
+++ b/scripts/db-restore.sh
@@ -5,7 +5,16 @@ set -eu
 test "$RESTORE_CONFIRMATION" = RESTORE_EPHEMERAL_DATABASE || { echo "Destruktivní restore odmítnut" >&2; exit 2; }
 source=${1:?Použití: db-restore.sh <backup.dump>}
 test -f "$source" && test -f "$source.sha256" || { echo "Backup nebo checksum chybí" >&2; exit 2; }
-sha256sum -c "$source.sha256"
+expected_checksum=$(awk 'NR == 1 { print $1 } NR > 1 { exit 2 }' "$source.sha256") || {
+  echo "Checksum manifest má neplatný formát" >&2
+  exit 2
+}
+case "$expected_checksum" in
+  *[!0-9a-fA-F]*|'') echo "Checksum manifest má neplatný formát" >&2; exit 2 ;;
+esac
+test "${#expected_checksum}" -eq 64 || { echo "Checksum manifest má neplatný formát" >&2; exit 2; }
+actual_checksum=$(sha256sum "$source" | awk '{print $1}')
+test "$actual_checksum" = "$expected_checksum" || { echo "Checksum backupu nesouhlasí" >&2; exit 1; }
 case "$RESTORE_DATABASE_URL" in
   postgresql+psycopg://*) restore_database_url="postgresql://${RESTORE_DATABASE_URL#postgresql+psycopg://}" ;;
   *) restore_database_url=$RESTORE_DATABASE_URL ;;

--- a/scripts/production-smoke.sh
+++ b/scripts/production-smoke.sh
@@ -127,5 +127,5 @@ PY
 test "$(docker inspect -f '{{json .HostConfig.PortBindings}}' "$postgres")" = "{}"
 test "$(docker inspect -f '{{json .HostConfig.PortBindings}}' "$backend")" = "{}"
 test "$(docker exec "$backend" python -c 'import os; print(os.getuid())')" != 0
-test "$(docker exec "$frontend" /nodejs/bin/node -e 'console.log(process.getuid())')" != 0
+test "$(docker exec "$frontend" /usr/local/bin/node -e 'console.log(process.getuid())')" != 0
 ! git grep -n -E 'TRADING_MODE=live|LIVE_TRADING_ENABLED=true' -- ':!docs/codex/*' ':!CODEX_MASTER_PROMPT.md' ':!scripts/production-smoke.sh'

--- a/scripts/production-smoke.sh
+++ b/scripts/production-smoke.sh
@@ -126,6 +126,6 @@ PY
 
 test "$(docker inspect -f '{{json .HostConfig.PortBindings}}' "$postgres")" = "{}"
 test "$(docker inspect -f '{{json .HostConfig.PortBindings}}' "$backend")" = "{}"
-test "$(docker exec "$backend" id -u)" != 0
-test "$(docker exec "$frontend" id -u)" != 0
+test "$(docker exec "$backend" python -c 'import os; print(os.getuid())')" != 0
+test "$(docker exec "$frontend" /nodejs/bin/node -e 'console.log(process.getuid())')" != 0
 ! git grep -n -E 'TRADING_MODE=live|LIVE_TRADING_ENABLED=true' -- ':!docs/codex/*' ':!CODEX_MASTER_PROMPT.md' ':!scripts/production-smoke.sh'


### PR DESCRIPTION
### Motivation
- Forenzní audit ukázal, že `scripts/db-backup.sh` ukládal do manifestu absolutní cestu, takže po přesunu dumpu+manifestu kontrola `sha256sum -c` mohla selhat i pro platné soubory.\
- Cíl je zajistit, aby backup + jeho `.sha256` byly přenositelné a restore vždy ověřil integritu skutečně předaného souboru bez oslabení kontroly.\

### Description
- `scripts/db-backup.sh` nyní zapisuje SHA-256 digest a pouze `basename` dumpu místo původní absolutní cesty (`sha256sum` → `checksum=$(sha256sum …)` + `printf '%s  %s\n' "$checksum" "$(basename "$target")" > "$target.sha256"`).\
- `scripts/db-restore.sh` přestal spouštět `sha256sum -c` přímo nad manifestem a místo toho validuje formát manifestu (jediný 64-znakový hex digest), přepočítá digest ze souboru předaného `db-restore.sh` a porovná jej před voláním `pg_restore`.\
- Regresní test `backend/tests/test_phase9_postgres.py` doplněn tak, aby vytvořil dump+manifest, přesunul oba soubory do „off-site/recovery“ adresáře a ověřil: relativní manifest, odmítnutí tamperovaného dumpu a úspěšné obnovení přesunutého dumpu.\
- Dokumentace `docs/operations.md` doplněna o stručné vysvětlení, že manifest používá relativní jméno souboru a restore vždy přepočítá obsah skutečně předaného dumpu.\

### Testing
- Provedené automatizované kontroly: `git diff --check` a `sh -n scripts/db-backup.sh scripts/db-restore.sh` proběhly OK.\
- Funkční syntetický end-to-end shell test simulující `pg_dump`/přesun/`db-restore.sh` ověřil, že tamperovaný dump je odmítnut a čistý přesunutý dump je přijat (syntetický test PASS).\
- Statické kontroly backendu: `ruff format --check` a `ruff check` (backend) prošly bez chyb a `ruff --select S` prošel; tyto lint/security kontroly PASS.\
- Nezdařené / blokované běhy vinou prostředí: `uv lock --check` / `uv sync --locked` / `uv run mypy` / `uv run pytest` nelze dokončit kvůli nedostupnosti síťového přístupu ke zdrojům a verzi `uv` v tomto prostředí (NETWORK/ENV BLOCKED), takže úplné `pytest` PostgreSQL CI a typecheck nebyly lokálně spuštěny; `npm ci` / frontend build a `docker`/Trivy container scany rovněž nebyly možné v tomto prostředí.\

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8e2927d6908332b1790c1c22625fac)