### PR TITLE
Stabilizace spuštění v GitHub Codespaces (backend import, dev secrets, Server Actions, standalone dashboard)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .env
 node_modules/
 frontend/dist/
+frontend/next-env.d.ts
 .next/
 .secrets/
 backups/

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ dev:
 api:
 	set -a; . .secrets/dev.env; set +a; cd backend && uv run uvicorn quantlab.api:app --app-dir src --host 127.0.0.1 --port 8000
 dashboard:
-	set -a; . .secrets/dev.env; set +a; cd frontend && npm start
+	set -a; . .secrets/dev.env; set +a; cd frontend && if [ "$${CODESPACES:-}" = "true" ] && [ -n "$${CODESPACE_NAME:-}" ] && [ -n "$${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-}" ]; then npm start; else npm run dev; fi
 dashboard-build:
 	set -a; . .secrets/dev.env; set +a; cd frontend && npm run build
 codespaces-setup: install frontend-install
@@ -30,8 +30,7 @@ codespaces-setup: install frontend-install
 	set -a; . .secrets/dev.env; set +a; cd backend && uv run alembic -c ../alembic.ini upgrade head
 	$(MAKE) dashboard-build
 codespaces-reset-credentials:
-	@rm -f .secrets/dev.env
-	@$(MAKE) generate-dev-secrets
+	@./scripts/reset-dev-secrets.sh
 frontend-test:
 	cd frontend && npm run lint && npm run typecheck && npm test && npm run build
 frontend-install:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install setup check test format lint typecheck dev api dashboard frontend-test frontend-install frontend-check frontend-lock-check generate-dev-secrets security-check frontend-security production-build production-up production-down production-smoke db-backup db-restore db-configure-runtime
+.PHONY: install setup check test format lint typecheck dev api dashboard dashboard-build codespaces-setup codespaces-reset-credentials frontend-test frontend-install frontend-check frontend-lock-check generate-dev-secrets security-check frontend-security production-build production-up production-down production-smoke db-backup db-restore db-configure-runtime
 install:
 	cd backend && uv sync --locked --all-groups
 setup: install
@@ -16,12 +16,22 @@ lint:
 typecheck:
 	cd backend && uv run mypy
 dev:
-	cd backend && uv run uvicorn quantlab.api:app --reload
+	cd backend && uv run uvicorn quantlab.api:app --app-dir src --reload
 
 api:
-	cd backend && uv run uvicorn quantlab.api:app --host 127.0.0.1 --port 8000
+	set -a; . .secrets/dev.env; set +a; cd backend && uv run uvicorn quantlab.api:app --app-dir src --host 127.0.0.1 --port 8000
 dashboard:
-	cd frontend && npm run dev
+	set -a; . .secrets/dev.env; set +a; cd frontend && npm start
+dashboard-build:
+	set -a; . .secrets/dev.env; set +a; cd frontend && npm run build
+codespaces-setup: install frontend-install
+	docker compose up -d --wait postgres
+	@test -f .secrets/dev.env || ./scripts/generate-dev-secrets.sh
+	set -a; . .secrets/dev.env; set +a; cd backend && uv run alembic -c ../alembic.ini upgrade head
+	$(MAKE) dashboard-build
+codespaces-reset-credentials:
+	@rm -f .secrets/dev.env
+	@$(MAKE) generate-dev-secrets
 frontend-test:
 	cd frontend && npm run lint && npm run typecheck && npm test && npm run build
 frontend-install:

--- a/README.md
+++ b/README.md
@@ -82,16 +82,18 @@ Po změně frontend kódu nejprve spusťte `make dashboard-build`. Po změně mi
 
 ### Explicitní reset credentials
 
-Reset zneplatní dosavadní login a API tokeny a znovu vypíše jednorázové heslo:
+Nejprve pomocí `Ctrl+C` zastavte **API i dashboard**. Target odmítne reset, pokud port `8000` nebo `3000` stále naslouchá; tím zabrání souběhu procesů se starými a novými credentials. Potom vygenerujte credentials, znovu sestavte dashboard a oba procesy spusťte:
 
 ```bash
 make codespaces-reset-credentials
 make dashboard-build
+make api        # terminál 1
+make dashboard  # terminál 2
 ```
 
 ### Lokální fallback mimo Codespaces
 
-Stejný postup funguje lokálně; generátor použije `http://localhost:3000` a allowlist `localhost,127.0.0.1`. Lokální `docker-compose.yml` vystavuje PostgreSQL pouze na loopback a používá trust auth výhradně pro development. `make codespaces-setup` existující `.secrets/dev.env` nikdy nepřepíše.
+Stejný postup funguje lokálně; generátor použije `http://localhost:3000` a allowlist `localhost,127.0.0.1`. `make dashboard` mimo Codespaces záměrně spustí vývojový Next.js server, protože produkční standalone validace správně vyžaduje HTTPS. Lokální `docker-compose.yml` vystavuje PostgreSQL pouze na loopback a používá trust auth výhradně pro development. `make codespaces-setup` existující `.secrets/dev.env` nikdy nepřepíše.
 
 ## Automatizovaný paper worker
 

--- a/README.md
+++ b/README.md
@@ -44,51 +44,54 @@ Každý ekonomický příkaz prochází přes `RiskEngine` a `ExecutionEngine`. 
 
 Autoritativní lockfiles jsou `backend/uv.lock` a `frontend/package-lock.json`. Neupravují se ručně.
 
-## Lokální spuštění
+## Doporučené spuštění v GitHub Codespaces
 
-### 1. Instalace a vývojová DB
+Codespaces je doporučené vývojové prostředí. Startup používá PostgreSQL z `docker-compose.yml`, paper-only backend a produkční standalone dashboard se striktním CSP. Forwardovaný port `3000` nastavte v Codespaces jako **Private**; generátor odvodí konkrétní HTTPS URL bez wildcard origins.
+
+### První spuštění
 
 ```bash
-make install
-docker compose up -d postgres
-export DATABASE_URL='postgresql+psycopg://quantlab@127.0.0.1:5432/quantlab'
-cd backend && uv run alembic -c ../alembic.ini upgrade head && cd ..
+make codespaces-setup
 ```
 
-Lokální `docker-compose.yml` vystavuje PostgreSQL pouze na loopback a používá trust auth výhradně pro development.
+Target nainstaluje uzamčené backend/frontend dependency, spustí PostgreSQL, vytvoří `.secrets/dev.env` pouze pokud ještě neexistuje, provede Alembic migrace a sestaví standalone dashboard. Generátor vypíše jednorázové heslo pro uživatele `operator`; bezpečně si je uložte. Soubor `.secrets/dev.env` ani heslo necommitujte.
 
-### 2. Vygenerování lokálních credentials
-
-```bash
-make generate-dev-secrets
-set -a
-. .secrets/dev.env
-set +a
-```
-
-Příkaz vypíše jednorázové heslo. Výchozí uživatel dashboardu je `operator`; heslo ani `.secrets/dev.env` necommitujte.
-
-### 3. Backend
+Potom spusťte dva terminály (Makefile načte uloženou konfiguraci automaticky):
 
 ```bash
+# terminál 1
 make api
-```
 
-API běží na `http://127.0.0.1:8000`.
-
-### 4. Dashboard
-
-V druhém terminálu načtěte stejné secrets a spusťte:
-
-```bash
-set -a
-. .secrets/dev.env
-set +a
-make frontend-install
+# terminál 2
 make dashboard
 ```
 
-Dashboard běží na `http://127.0.0.1:3000`.
+API naslouchá na `127.0.0.1:8000`. Dashboard naslouchá na portu `3000` a otevře se přes privátní Codespaces HTTPS URL.
+
+### Běžné spuštění po restartu Codespace
+
+Není nutné znovu generovat credentials ani ručně exportovat proměnné:
+
+```bash
+docker compose up -d --wait postgres
+make api        # terminál 1
+make dashboard  # terminál 2
+```
+
+Po změně frontend kódu nejprve spusťte `make dashboard-build`. Po změně migrací spusťte `make codespaces-setup`; existující `.secrets/dev.env` zůstane zachován.
+
+### Explicitní reset credentials
+
+Reset zneplatní dosavadní login a API tokeny a znovu vypíše jednorázové heslo:
+
+```bash
+make codespaces-reset-credentials
+make dashboard-build
+```
+
+### Lokální fallback mimo Codespaces
+
+Stejný postup funguje lokálně; generátor použije `http://localhost:3000` a allowlist `localhost,127.0.0.1`. Lokální `docker-compose.yml` vystavuje PostgreSQL pouze na loopback a používá trust auth výhradně pro development. `make codespaces-setup` existující `.secrets/dev.env` nikdy nepřepíše.
 
 ## Automatizovaný paper worker
 

--- a/backend/tests/test_dev_startup.py
+++ b/backend/tests/test_dev_startup.py
@@ -1,9 +1,11 @@
 import os
+import socket
 import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 SECRET_SCRIPT = ROOT / "scripts" / "generate-dev-secrets.sh"
+RESET_SCRIPT = ROOT / "scripts" / "reset-dev-secrets.sh"
 
 
 def generate_environment(tmp_path: Path, environment: dict[str, str]) -> dict[str, str]:
@@ -44,3 +46,27 @@ def test_incomplete_codespaces_environment_uses_localhost(tmp_path: Path) -> Non
     )
     assert values["PUBLIC_BASE_URL"] == "http://localhost:3000"
     assert values["FRONTEND_ALLOWED_HOSTS"] == "localhost,127.0.0.1"
+
+
+def test_credentials_reset_fails_while_dashboard_is_running(tmp_path: Path) -> None:
+    secrets_directory = tmp_path / ".secrets"
+    secrets_directory.mkdir()
+    secret_file = secrets_directory / "dev.env"
+    secret_file.write_text("SENTINEL=unchanged\n")
+    scripts_directory = tmp_path / "scripts"
+    scripts_directory.symlink_to(ROOT / "scripts", target_is_directory=True)
+
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 3000))
+        listener.listen()
+        result = subprocess.run(
+            [str(RESET_SCRIPT)],
+            cwd=tmp_path,
+            env={"PATH": os.environ["PATH"]},
+            capture_output=True,
+            text=True,
+        )
+
+    assert result.returncode != 0
+    assert "zastavte dashboard i API" in result.stderr
+    assert secret_file.read_text() == "SENTINEL=unchanged\n"

--- a/backend/tests/test_dev_startup.py
+++ b/backend/tests/test_dev_startup.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SECRET_SCRIPT = ROOT / "scripts" / "generate-dev-secrets.sh"
+
+
+def generate_environment(tmp_path: Path, environment: dict[str, str]) -> dict[str, str]:
+    result = subprocess.run(
+        [str(SECRET_SCRIPT)],
+        cwd=tmp_path,
+        env={"PATH": os.environ["PATH"], **environment},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "jednorázové heslo" in result.stdout
+    return dict(
+        line.split("=", maxsplit=1)
+        for line in (tmp_path / ".secrets" / "dev.env").read_text().splitlines()
+    )
+
+
+def test_codespaces_urls_are_derived_from_verified_environment(tmp_path: Path) -> None:
+    values = generate_environment(
+        tmp_path,
+        {
+            "CODESPACES": "true",
+            "CODESPACE_NAME": "probable-space",
+            "GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN": "app.github.dev",
+        },
+    )
+    host = "probable-space-3000.app.github.dev"
+    assert values["PUBLIC_BASE_URL"] == f"https://{host}"
+    assert values["FRONTEND_ALLOWED_HOSTS"] == f"{host},localhost,127.0.0.1"
+    assert values["OPERATOR_PASSWORD_SCRYPT"] != ""
+
+
+def test_incomplete_codespaces_environment_uses_localhost(tmp_path: Path) -> None:
+    values = generate_environment(
+        tmp_path,
+        {"CODESPACES": "true", "CODESPACE_NAME": "probable-space"},
+    )
+    assert values["PUBLIC_BASE_URL"] == "http://localhost:3000"
+    assert values["FRONTEND_ALLOWED_HOSTS"] == "localhost,127.0.0.1"

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,2 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,21 @@
 import type { NextConfig } from "next";
-const csp="default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'";
-const securityHeaders=[{key:"Content-Security-Policy",value:csp},{key:"X-Content-Type-Options",value:"nosniff"},{key:"Referrer-Policy",value:"no-referrer"},{key:"Permissions-Policy",value:"camera=(), microphone=(), geolocation=()"},{key:"X-Frame-Options",value:"DENY"},{key:"Cache-Control",value:"no-store"}];
-if(process.env.NODE_ENV==="production"&&process.env.PUBLIC_BASE_URL?.startsWith("https://"))securityHeaders.push({key:"Strict-Transport-Security",value:"max-age=31536000; includeSubDomains"});
-const config: NextConfig = {output:"standalone",poweredByHeader:false,async headers(){return [{source:"/:path*",headers:securityHeaders}]}};
+
+const csp = "default-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'";
+const securityHeaders = [{key:"Content-Security-Policy",value:csp},{key:"X-Content-Type-Options",value:"nosniff"},{key:"Referrer-Policy",value:"no-referrer"},{key:"Permissions-Policy",value:"camera=(), microphone=(), geolocation=()"},{key:"X-Frame-Options",value:"DENY"},{key:"Cache-Control",value:"no-store"}];
+if (process.env.NODE_ENV === "production" && process.env.PUBLIC_BASE_URL?.startsWith("https://")) securityHeaders.push({key:"Strict-Transport-Security",value:"max-age=31536000; includeSubDomains"});
+
+export function codespacesAllowedOrigins(environment: Readonly<Record<string, string | undefined>>): string[] | undefined {
+  if (environment.CODESPACES !== "true" || !environment.CODESPACE_NAME || !environment.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN) return undefined;
+  const host = `${environment.CODESPACE_NAME}-3000.${environment.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/.test(host) || host.includes("..")) throw new Error("Neplatný GitHub Codespaces host pro Server Actions");
+  return [host, "localhost:3000", "127.0.0.1:3000"];
+}
+
+const allowedOrigins = codespacesAllowedOrigins(process.env);
+const config: NextConfig = {
+  output: "standalone",
+  poweredByHeader: false,
+  ...(allowedOrigins ? {experimental: {serverActions: {allowedOrigins}}} : {}),
+  async headers() { return [{source:"/:path*",headers:securityHeaders}]; },
+};
 export default config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quantlab-operator-dashboard", "version": "1.0.0", "private": true,
   "packageManager": "npm@11.17.0",
-  "scripts": {"dev":"next dev --hostname 127.0.0.1", "build":"next build", "start":"VALIDATE_PRODUCTION_STARTUP=true next start --hostname 127.0.0.1", "lint":"eslint .", "typecheck":"tsc --noEmit", "test":"vitest run", "lockfile:check":"node --test scripts/validate-lockfile.node-test.mjs && node scripts/validate-lockfile.mjs"},
+  "scripts": {"dev":"next dev --hostname 127.0.0.1", "build":"next build", "start":"node scripts/start-standalone.mjs", "lint":"eslint .", "typecheck":"tsc --noEmit", "test":"vitest run", "lockfile:check":"node --test scripts/validate-lockfile.node-test.mjs && node scripts/validate-lockfile.mjs"},
   "dependencies": {"@tailwindcss/postcss":"4.1.18", "next":"16.3.2", "react":"19.2.4", "react-dom":"19.2.4", "tailwindcss":"4.1.18"},
   "devDependencies": {"@testing-library/jest-dom":"6.9.1", "@testing-library/react":"16.3.2", "@types/node":"24.10.1", "@types/react":"19.2.14", "@types/react-dom":"19.2.3", "eslint":"9.39.2", "eslint-config-next":"16.3.2", "jsdom":"27.4.0", "typescript":"5.9.3", "vitest":"4.1.11"},
   "engines":{"node":">=24.0.0"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quantlab-operator-dashboard", "version": "1.0.0", "private": true,
   "packageManager": "npm@11.17.0",
-  "scripts": {"dev":"next dev --hostname 127.0.0.1", "build":"next build", "start":"node scripts/start-standalone.mjs", "lint":"eslint .", "typecheck":"tsc --noEmit", "test":"vitest run", "lockfile:check":"node --test scripts/validate-lockfile.node-test.mjs && node scripts/validate-lockfile.mjs"},
+  "scripts": {"dev":"next dev --hostname 127.0.0.1", "build":"next build", "start":"node scripts/start-standalone.mjs", "lint":"eslint .", "typecheck":"next typegen && tsc --noEmit", "test":"vitest run", "lockfile:check":"node --test scripts/validate-lockfile.node-test.mjs && node scripts/validate-lockfile.mjs"},
   "dependencies": {"@tailwindcss/postcss":"4.1.18", "next":"16.3.2", "react":"19.2.4", "react-dom":"19.2.4", "tailwindcss":"4.1.18"},
   "devDependencies": {"@testing-library/jest-dom":"6.9.1", "@testing-library/react":"16.3.2", "@types/node":"24.10.1", "@types/react":"19.2.14", "@types/react-dom":"19.2.3", "eslint":"9.39.2", "eslint-config-next":"16.3.2", "jsdom":"27.4.0", "typescript":"5.9.3", "vitest":"4.1.11"},
   "engines":{"node":">=24.0.0"}

--- a/frontend/scripts/start-standalone.mjs
+++ b/frontend/scripts/start-standalone.mjs
@@ -1,0 +1,24 @@
+import { cpSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const standaloneDirectory = join(process.cwd(), ".next", "standalone");
+const server = join(standaloneDirectory, "server.js");
+
+if (!existsSync(server)) {
+  throw new Error("Standalone build chybí; nejprve spusťte `make dashboard-build`");
+}
+
+cpSync(join(process.cwd(), ".next", "static"), join(standaloneDirectory, ".next", "static"), {
+  recursive: true,
+  force: true,
+});
+const publicDirectory = join(process.cwd(), "public");
+if (existsSync(publicDirectory)) {
+  cpSync(publicDirectory, join(standaloneDirectory, "public"), { recursive: true, force: true });
+}
+
+process.env.NODE_ENV = "production";
+process.env.VALIDATE_PRODUCTION_STARTUP = "true";
+process.env.HOSTNAME = process.env.DASHBOARD_HOSTNAME ?? "0.0.0.0";
+process.env.PORT = process.env.PORT ?? "3000";
+await import(server);

--- a/frontend/tests/codespaces-config.test.ts
+++ b/frontend/tests/codespaces-config.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { codespacesAllowedOrigins } from "../next.config";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GitHub Codespaces Server Actions origins", () => {
+  it("povolí pouze konkrétní proxy host a lokální přístup v Codespaces", () => {
+    const origins = codespacesAllowedOrigins({
+      CODESPACES: "true",
+      CODESPACE_NAME: "probable-space",
+      GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN: "app.github.dev",
+    });
+    expect(origins).toEqual([
+      "probable-space-3000.app.github.dev",
+      "localhost:3000",
+      "127.0.0.1:3000",
+    ]);
+    expect(origins).not.toContain("*");
+  });
+
+  it("mimo Codespaces neaktivuje localhost výjimku", () => {
+    expect(codespacesAllowedOrigins({ CODESPACES: "false" })).toBeUndefined();
+  });
+
+  it("odmítne neplatný proxy host namísto wildcard fallbacku", () => {
+    expect(() => codespacesAllowedOrigins({
+      CODESPACES: "true",
+      CODESPACE_NAME: "space/attacker",
+      GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN: "app.github.dev",
+    })).toThrow("Neplatný GitHub Codespaces host");
+  });
+});

--- a/frontend/tests/security.test.ts
+++ b/frontend/tests/security.test.ts
@@ -36,6 +36,8 @@ describe("Phase 9 security boundary", () => {
   it("produkční responses deklarují obranné headers", () => {
     const config = fs.readFileSync(path.join(process.cwd(), "next.config.ts"), "utf8");
     for (const header of ["Content-Security-Policy", "X-Content-Type-Options", "Referrer-Policy", "Permissions-Policy", "X-Frame-Options"]) expect(config).toContain(header);
+    expect(config).not.toContain("unsafe-eval");
+    expect(config).not.toMatch(/allowedOrigins[^;]*["']\*["']/s);
   });
 
   it("dev helper vytváří obě strany role credentials a login identitu", () => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,13 +26,15 @@
       "@/*": [
         "./*"
       ]
-    }
+    },
+    "incremental": true
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/scripts/generate-dev-secrets.sh
+++ b/scripts/generate-dev-secrets.sh
@@ -4,6 +4,30 @@ umask 077
 mkdir -p .secrets
 python3 - <<'PY'
 import base64, hashlib, os, secrets
+
+codespaces = (
+    os.environ.get("CODESPACES") == "true"
+    and bool(os.environ.get("CODESPACE_NAME"))
+    and bool(os.environ.get("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"))
+)
+if codespaces:
+    codespace_name = os.environ["CODESPACE_NAME"]
+    forwarding_domain = os.environ["GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"]
+    allowed_dns = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-.")
+    if (
+        any(character not in allowed_dns for character in codespace_name + forwarding_domain)
+        or codespace_name.startswith("-")
+        or forwarding_domain.startswith(('-', '.'))
+        or ".." in forwarding_domain
+    ):
+        raise SystemExit("Neplatná GitHub Codespaces hostname konfigurace")
+    frontend_host = f"{codespace_name}-3000.{forwarding_domain}"
+    public_base_url = f"https://{frontend_host}"
+    frontend_allowed_hosts = f"{frontend_host},localhost,127.0.0.1"
+else:
+    public_base_url = "http://localhost:3000"
+    frontend_allowed_hosts = "localhost,127.0.0.1"
+
 password = secrets.token_urlsafe(24)
 salt = os.urandom(16)
 digest = hashlib.scrypt(password.encode(), salt=salt, n=16384, r=8, p=1, dklen=32)
@@ -11,6 +35,7 @@ viewer_token = secrets.token_urlsafe(32)
 operator_token = secrets.token_urlsafe(32)
 admin_token = secrets.token_urlsafe(32)
 values = {
+    "DATABASE_URL": "postgresql+psycopg://quantlab@127.0.0.1:5432/quantlab",
     "SESSION_SECRET": secrets.token_urlsafe(32),
     "API_VIEWER_TOKEN": viewer_token,
     "API_OPERATOR_TOKEN": operator_token,
@@ -21,8 +46,8 @@ values = {
     "OPERATOR_USERNAME": "operator",
     "OPERATOR_ROLE": "ADMIN",
     "SESSION_MAX_AGE_SECONDS": "3600",
-    "PUBLIC_BASE_URL": "http://localhost:3000",
-    "FRONTEND_ALLOWED_HOSTS": "localhost,127.0.0.1",
+    "PUBLIC_BASE_URL": public_base_url,
+    "FRONTEND_ALLOWED_HOSTS": frontend_allowed_hosts,
     "OPERATOR_PASSWORD_SCRYPT": f"{base64.urlsafe_b64encode(salt).decode().rstrip('=')}:{base64.urlsafe_b64encode(digest).decode().rstrip('=')}",
 }
 with open(".secrets/dev.env", "x", encoding="utf-8") as output:

--- a/scripts/reset-dev-secrets.sh
+++ b/scripts/reset-dev-secrets.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+python3 - <<'PY'
+import socket
+
+active_ports = []
+for port in (3000, 8000):
+    with socket.socket() as connection:
+        connection.settimeout(0.2)
+        if connection.connect_ex(("127.0.0.1", port)) == 0:
+            active_ports.append(str(port))
+
+if active_ports:
+    raise SystemExit(
+        "Před resetem zastavte dashboard i API; aktivní porty: "
+        + ", ".join(active_ports)
+    )
+PY
+
+rm -f .secrets/dev.env
+exec ./scripts/generate-dev-secrets.sh


### PR DESCRIPTION
### Motivation
- Opravit běh projektu v GitHub Codespaces bez oslabení bezpečnosti: backend import path selhával, generátor dev secrets neodvozoval bezpečnou Codespaces URL a Next.js Server Actions nebyly explicitně povoleny pro reverzní proxy.  
- Zajistit, aby standalone frontend nevypadal, že používá nepodporovaný `next start` a aby měla produkční runtime deterministický přístup ke statickým assetům.  
- Zlepšit developer UX v Codespaces přidáním bezpečných Makefile targetů a automatického setupu DB/migrací bez přepisování existujících secrets.

### Description
- Makefile: `dev` a `api` nyní spouští `uvicorn ... --app-dir src`, `api` načítá `.secrets/dev.env` automaticky a přidány targety `codespaces-setup`, `dashboard-build` a `codespaces-reset-credentials` pro bezpečný Codespaces workflow.  
- `scripts/generate-dev-secrets.sh`: bezpečná detekce Codespaces přes `CODESPACES`, `CODESPACE_NAME` a `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN`, validace hostnames, odvození `PUBLIC_BASE_URL` jako `https://<codespace>-3000.<forwarding-domain>`, nastavení `FRONTEND_ALLOWED_HOSTS` a přidání `DATABASE_URL`; localhost fallback zůstává.  
- Frontend: `next.config.ts` přidal funkci `codespacesAllowedOrigins(...)` která explicitně povolí jen odvozené origins (žádný wildcard) a aktivuje localhost-only výjimku jen v Codespaces; CSP zůstává striktní a bez `unsafe-eval`.  
- Frontend runtime: `start` script teď spouští `frontend/scripts/start-standalone.mjs` místo `next start`, launcher deterministicky kopíruje `.next/static` a `public` do standalone adresáře a spouští `.next/standalone/server.js` s `VALIDATE_PRODUCTION_STARTUP=true`.  
- Testy a dokumentace: přidán backend test `backend/tests/test_dev_startup.py` pro ověření derivace Codespaces URL a fallbacku, frontend test `frontend/tests/codespaces-config.test.ts` pro allowed origins a aktualizován `README.md` s přesným Codespaces postupem spuštění.

### Testing
- Frontend lint, typecheck, unit tests a production build byly spuštěny lokálně a prošly (`cd frontend && npm run lint`, `npm run typecheck`, `npm test` — 5 souborů, 25 testů prošlo, a `npm run build` úspěšný).  
- Nový frontend unit test `tests/codespaces-config.test.ts` a security assertion o absenci `unsafe-eval` prošly v lokálním test běhu.  
- Backend linter/format check pro nově přidaný test prošel (`ruff format/check`), ale plné backend testy a `mypy` jsou blokovány chybějícími backend dependencies a verzí `uv` v běžném prostředí (projekt požaduje `uv==0.12.3`, v běhu byla dostupná `0.7.22`), takže `pytest` backendu nelze v tomto runneru spolehlivě dokončit.  
- Ověřeny shellové kontroly a `make -n` dry-run pro nové targety, `git diff --check` a změny lockfile nebyly provedeny (lockfiles zůstaly beze změny).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ea560166c83329f9ea44fcd812463)