### PR TITLE
Remediation B1 — přidat podporovaný Phase 6 control‑plane (/operator)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
           tests/test_phase7_corporate_actions_postgres.py
           tests/test_phase8_postgres.py
           tests/test_phase9_postgres.py
+      - name: B1 control-plane end-to-end acceptance
+        run: uv run pytest -q tests/test_b1_control_plane_postgres.py
 
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
           tests/test_phase7_corporate_actions_postgres.py
           tests/test_phase8_postgres.py
           tests/test_phase9_postgres.py
+      - name: Recreate clean application schema for B1 acceptance
+        run: |
+          uv run alembic -c ../alembic.ini downgrade base
+          uv run alembic -c ../alembic.ini upgrade head
       - name: B1 control-plane end-to-end acceptance
         run: uv run pytest -q tests/test_b1_control_plane_postgres.py
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ market data
 
 Každý ekonomický příkaz prochází přes `RiskEngine` a `ExecutionEngine`. Strategie nikdy nevolá broker přímo. Signál z close T se může realizovat nejdříve na raw open následující session. Research snapshoty a current paper feed jsou oddělené.
 
+Podporovaný Phase 6 bootstrap je dostupný v autentizovaném ADMIN namespace `/operator`: instrument,
+PIT universe/membership, provider ingest, validovaný snapshot, allowlisted experiment, promotion,
+deployment create/approve a monitoring enrollment. Připraví pouze schválený PAPER deployment;
+worker integration a automatický market-data refresh zatím nejsou součástí této cesty.
+
 ## Požadavky
 
 - Python **3.12+**

--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -679,6 +679,7 @@ def approve_deployment(
             actor=_actor(request),
             reason=body.reason,
             correlation_id=_correlation(request),
+            allow_already_approved=True,
         )
         return {"deployment_id": deployment_id, "status": "APPROVED"}
     except (ValueError, DatasetInvalid) as exc:

--- a/backend/src/quantlab/api.py
+++ b/backend/src/quantlab/api.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
@@ -24,9 +26,11 @@ from quantlab.automation import (
 )
 from quantlab.backtest import serialize_result
 from quantlab.config import get_settings
+from quantlab.control_plane import ControlPlaneRegistryService
 from quantlab.demo import load_fixture, run_demo
 from quantlab.domain import AuditEventType
-from quantlab.market_data import StooqProvider, XNYSCalendar
+from quantlab.market_data import AssetType, DatasetInvalid, Instrument, StooqProvider, XNYSCalendar
+from quantlab.market_data_service import DatasetSnapshotService, PersistentMarketDataService
 from quantlab.multi_asset import STRATEGY_REGISTRY
 from quantlab.operator_read_model import OperatorReadModel
 from quantlab.persistence import (
@@ -48,6 +52,12 @@ from quantlab.phase4 import (
     TradingCycleRecord,
     TradingCycleService,
 )
+from quantlab.phase6_runtime import (
+    DeploymentService,
+    Phase6EligibilityService,
+    Phase6ExperimentRequest,
+    Phase6ExperimentRunner,
+)
 from quantlab.phase7 import (
     DEFAULT_POLICY,
     MonitoringState,
@@ -58,6 +68,7 @@ from quantlab.phase7 import (
 )
 from quantlab.research_service import ResearchService
 from quantlab.security import current_principal, security_boundary
+from quantlab.universe import UniverseDefinition, UniverseKind, UniverseMembership
 
 settings = get_settings()
 app = FastAPI(
@@ -91,6 +102,18 @@ monitoring_service = PaperMonitoringService(lambda: Session(paper_repository.eng
 operator_read_model = OperatorReadModel(lambda: Session(paper_repository.engine), settings)
 
 
+def session_factory() -> Session:
+    return Session(paper_repository.engine)
+
+
+control_plane_registry = ControlPlaneRegistryService(session_factory)
+market_data_service = PersistentMarketDataService(session_factory)
+dataset_snapshot_service = DatasetSnapshotService(session_factory)
+phase6_runner = Phase6ExperimentRunner(session_factory)
+eligibility_service = Phase6EligibilityService(session_factory)
+deployment_service = DeploymentService(session_factory)
+
+
 class JobCreate(BaseModel):
     job_type: JobType
     account_id: str = "paper-main"
@@ -116,8 +139,87 @@ class MonitoringPolicyCreate(BaseModel):
     config: dict[str, object] = DEFAULT_POLICY.copy()
 
 
+class OperatorMonitoringPolicyCreate(MonitoringPolicyCreate):
+    reason: str = Field(min_length=3, max_length=1000)
+
+
 class MonitoringTransition(BaseModel):
     reason: str = Field(min_length=1, max_length=1000)
+
+
+class ReasonedMutation(BaseModel):
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class InstrumentCreate(BaseModel):
+    instrument_id: str = Field(min_length=1, max_length=64)
+    symbol: str = Field(min_length=1, max_length=32)
+    exchange: str = "XNYS"
+    calendar: str = "XNYS"
+    currency: str = "USD"
+    asset_type: AssetType = AssetType.EQUITY
+    active_from: date
+    active_to: date | None = None
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class UniverseCreate(BaseModel):
+    universe_id: str = Field(min_length=1, max_length=64)
+    name: str = Field(min_length=1, max_length=100)
+    kind: UniverseKind = UniverseKind.POINT_IN_TIME_MEMBERSHIP
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class MembershipCreate(BaseModel):
+    instrument_id: str = Field(min_length=1, max_length=64)
+    valid_from: datetime
+    valid_to: datetime | None = None
+    known_at: datetime
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class IngestionCreate(BaseModel):
+    provider: str = "stooq"
+    instrument_id: str = Field(min_length=1, max_length=64)
+    start: date
+    end: date
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class SnapshotCreate(BaseModel):
+    provider: str = Field(min_length=1, max_length=40)
+    universe_id: str = Field(min_length=1, max_length=64)
+    start: date
+    end: date
+    as_of: datetime
+    minimum_coverage: Decimal = Field(Decimal("0.8"), ge=0, le=1)
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class ExperimentCreate(BaseModel):
+    snapshot_id: str = Field(min_length=1, max_length=64)
+    strategy_name: str = Field(min_length=1, max_length=100)
+    strategy_version: str = Field(min_length=1, max_length=50)
+    parameter_configs: list[dict[str, object]] = Field(min_length=1, max_length=50)
+    train_fraction: Decimal = Decimal("0.6")
+    validation_fraction: Decimal = Decimal("0.2")
+    initial_cash: Decimal = Field(Decimal("100000"), gt=0)
+    commission_bps: Decimal = Field(Decimal("1"), ge=0)
+    seed: int = 42
+    code_sha: str = Field(min_length=40, max_length=40)
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class DeploymentCreate(BaseModel):
+    experiment_id: str = Field(min_length=1, max_length=64)
+    paper_account_id: str = "paper-main"
+    reason: str = Field(min_length=3, max_length=1000)
+
+
+class MonitoringEnrollment(BaseModel):
+    deployment_id: str = Field(min_length=1, max_length=64)
+    policy_id: str = Field(min_length=1, max_length=64)
+    reason: str = Field(min_length=3, max_length=1000)
 
 
 class OperatorAction(BaseModel):
@@ -316,12 +418,317 @@ def _row(row: object) -> dict[str, object]:
     return {key: value for key, value in vars(row).items() if not key.startswith("_")}
 
 
+def _actor(request: Request) -> dict[str, str]:
+    principal = current_principal(request)
+    return {
+        "actor_id": principal.actor_id,
+        "actor_role": principal.role.name,
+        "authentication": "bearer",
+    }
+
+
+def _correlation(request: Request) -> str:
+    return request.headers.get("x-correlation-id", str(uuid4()))[:64]
+
+
+def _audit_control_mutation(
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    actor: dict[str, str],
+    reason: str,
+    correlation_id: str,
+) -> None:
+    identity = hashlib.sha256(
+        json.dumps(
+            [event_type, entity_type, entity_id, actor["actor_id"], reason],
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()
+    with session_factory() as session, session.begin():
+        if session.get(AuditEventRecord, identity) is None:
+            session.add(
+                AuditEventRecord(
+                    id=identity,
+                    timestamp=datetime.now(UTC),
+                    event_type=event_type,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    trading_cycle_id=None,
+                    correlation_id=correlation_id,
+                    payload_json=json.dumps({"actor": actor, "reason": reason}, sort_keys=True),
+                )
+            )
+
+
+@app.post("/operator/instruments")
+def create_instrument(body: InstrumentCreate, request: Request) -> dict[str, object]:
+    try:
+        row = control_plane_registry.register_instrument(
+            Instrument(
+                body.instrument_id,
+                body.symbol.strip().upper(),
+                body.exchange,
+                body.calendar,
+                body.currency,
+                body.asset_type,
+                body.active_from,
+                body.active_to,
+                datetime.now(UTC),
+            )
+        )
+        _audit_control_mutation(
+            "CONTROL_INSTRUMENT_REGISTERED",
+            "instrument",
+            row.instrument_id,
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        return _row(row)
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/universes")
+def create_universe(body: UniverseCreate, request: Request) -> dict[str, object]:
+    try:
+        row = control_plane_registry.create_universe(
+            UniverseDefinition(body.universe_id, body.name, body.kind, datetime.now(UTC))
+        )
+        _audit_control_mutation(
+            "CONTROL_UNIVERSE_CREATED",
+            "universe",
+            row.universe_id,
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        return _row(row)
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/universes/{universe_id}/memberships")
+def add_universe_membership(
+    universe_id: str, body: MembershipCreate, request: Request
+) -> dict[str, object]:
+    try:
+        row = control_plane_registry.add_membership(
+            UniverseMembership(
+                universe_id, body.instrument_id, body.valid_from, body.valid_to, body.known_at
+            )
+        )
+        evidence_id = f"{universe_id}:{body.instrument_id}:{body.valid_from.isoformat()}"
+        _audit_control_mutation(
+            "CONTROL_MEMBERSHIP_ADDED",
+            "universe_membership",
+            evidence_id[:64],
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        return _row(row)
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/market-data/ingestions")
+def ingest_market_data(body: IngestionCreate, request: Request) -> dict[str, object]:
+    if body.provider != "stooq":
+        raise HTTPException(422, "Provider není v production allowlistu")
+    with session_factory() as session:
+        persisted = session.get(InstrumentRecord, body.instrument_id)
+        if persisted is None:
+            raise HTTPException(404, "Instrument neexistuje")
+        instrument = Instrument(
+            persisted.instrument_id,
+            persisted.symbol,
+            persisted.exchange,
+            persisted.calendar,
+            persisted.currency,
+            AssetType(persisted.asset_type),
+            persisted.active_from.date(),
+            persisted.active_to.date() if persisted.active_to else None,
+            persisted.created_at,
+        )
+    result = market_data_service.ingest(
+        StooqProvider(), instrument, body.start, body.end, datetime.now(UTC)
+    )
+    _audit_control_mutation(
+        "CONTROL_MARKET_DATA_INGESTED",
+        "market_data_ingestion",
+        result.ingestion_id,
+        _actor(request),
+        body.reason,
+        _correlation(request),
+    )
+    payload = vars(result)
+    if result.status != "SUCCEEDED":
+        raise HTTPException(502, payload)
+    return payload
+
+
+@app.post("/operator/datasets")
+def build_dataset(body: SnapshotCreate, request: Request) -> dict[str, object]:
+    try:
+        snapshot = dataset_snapshot_service.build(
+            as_of=body.as_of,
+            provider=body.provider,
+            universe_id=body.universe_id,
+            start=body.start,
+            end=body.end,
+            minimum_coverage=body.minimum_coverage,
+        )
+        _audit_control_mutation(
+            "CONTROL_DATASET_BUILT",
+            "dataset_snapshot",
+            snapshot.snapshot_id,
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        if snapshot.status != "VALID":
+            raise HTTPException(
+                409,
+                {
+                    "snapshot_id": snapshot.snapshot_id,
+                    "status": snapshot.status,
+                    "coverage": str(snapshot.coverage),
+                },
+            )
+        return vars(snapshot)
+    except DatasetInvalid as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/research/experiments")
+def run_phase6_experiment(body: ExperimentCreate, request: Request) -> dict[str, object]:
+    try:
+        control_plane_registry.ensure_strategy(
+            body.strategy_name, body.strategy_version, datetime.now(UTC)
+        )
+        row = phase6_runner.run(
+            Phase6ExperimentRequest(
+                body.snapshot_id,
+                body.strategy_name,
+                body.strategy_version,
+                tuple(body.parameter_configs),
+                body.train_fraction,
+                body.validation_fraction,
+                body.initial_cash,
+                body.commission_bps,
+                body.seed,
+                body.code_sha,
+            )
+        )
+        _audit_control_mutation(
+            "CONTROL_PHASE6_EXPERIMENT_COMPLETED",
+            "experiment",
+            row.id,
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        return _row(row)
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/research/experiments/{experiment_id}/promote")
+def promote_phase6_experiment(
+    experiment_id: str, body: ReasonedMutation, request: Request
+) -> dict[str, object]:
+    try:
+        return _row(
+            eligibility_service.promote(
+                experiment_id,
+                actor=_actor(request),
+                reason=body.reason,
+                correlation_id=_correlation(request),
+            )
+        )
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/deployments")
+def create_deployment(body: DeploymentCreate, request: Request) -> dict[str, object]:
+    try:
+        return _row(
+            deployment_service.create(
+                body.experiment_id,
+                body.paper_account_id,
+                actor=_actor(request),
+                reason=body.reason,
+                correlation_id=_correlation(request),
+            )
+        )
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/deployments/{deployment_id}/approve")
+def approve_deployment(
+    deployment_id: str, body: ReasonedMutation, request: Request
+) -> dict[str, str]:
+    try:
+        deployment_service.approve(
+            deployment_id,
+            datetime.now(UTC),
+            actor=_actor(request),
+            reason=body.reason,
+            correlation_id=_correlation(request),
+        )
+        return {"deployment_id": deployment_id, "status": "APPROVED"}
+    except (ValueError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
+@app.post("/operator/monitoring/enrollments")
+def operator_monitoring_enrollment(
+    body: MonitoringEnrollment, request: Request
+) -> dict[str, object]:
+    try:
+        row = monitoring_service.enroll(body.deployment_id, body.policy_id, datetime.now(UTC))
+        _audit_control_mutation(
+            "CONTROL_MONITORING_ENROLLED",
+            "monitoring",
+            row.monitoring_id,
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        return _row(row)
+    except (ValueError, RuntimeError, DatasetInvalid) as exc:
+        raise HTTPException(409, str(exc)) from exc
+
+
 @app.post("/paper/monitoring/policies")
 def create_monitoring_policy(request: MonitoringPolicyCreate) -> dict[str, object]:
     try:
         return _row(
             monitoring_service.create_policy(request.name, request.config, datetime.now(UTC))
         )
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+
+
+@app.post("/operator/monitoring/policies")
+def create_operator_monitoring_policy(
+    body: OperatorMonitoringPolicyCreate, request: Request
+) -> dict[str, object]:
+    try:
+        row = monitoring_service.create_policy(body.name, body.config, datetime.now(UTC))
+        _audit_control_mutation(
+            "CONTROL_MONITORING_POLICY_CREATED",
+            "monitoring_policy",
+            row.policy_id,
+            _actor(request),
+            body.reason,
+            _correlation(request),
+        )
+        return _row(row)
     except ValueError as exc:
         raise HTTPException(422, str(exc)) from exc
 
@@ -855,7 +1262,7 @@ def trading_cycle(cycle_id: str) -> dict[str, object]:
     return _row(row)
 
 
-@app.post("/trading/cycles/run-paper")
+@app.post("/demo/trading/cycles/run-paper")
 def run_paper_cycle() -> dict[str, str]:
     bars = load_fixture(fixture)
     cycle_id = trading_service.run(
@@ -900,8 +1307,7 @@ def backtests() -> list[dict[str, object]]:
     return repository.list()
 
 
-@app.post("/research/experiments")
-@app.post("/api/research/experiments")
+@app.post("/demo/research/experiments")
 def create_research_experiment() -> dict[str, object]:
     return research_service.create_demo_experiment(fixture)
 

--- a/backend/src/quantlab/control_plane.py
+++ b/backend/src/quantlab/control_plane.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from quantlab.domain import require_utc
+from quantlab.market_data import AssetType, DatasetInvalid, Instrument
+from quantlab.multi_asset import STRATEGY_REGISTRY
+from quantlab.persistence import (
+    InstrumentRecord,
+    InstrumentSymbolRecord,
+    StrategyRecord,
+    UniverseDefinitionRecord,
+    UniverseMembershipRecord,
+)
+from quantlab.universe import UniverseDefinition, UniverseKind, UniverseMembership
+
+
+class ControlPlaneRegistryService:
+    """Malá persistentní hranice pro registry, jejichž domain model už existuje."""
+
+    def __init__(self, sessions: Callable[[], Session]) -> None:
+        self.sessions = sessions
+
+    def register_instrument(self, instrument: Instrument) -> InstrumentRecord:
+        if not instrument.instrument_id.strip() or not instrument.symbol.strip():
+            raise ValueError("Instrument identity a symbol jsou povinné")
+        if instrument.exchange != "XNYS" or instrument.calendar != "XNYS":
+            raise ValueError("Phase 6 control plane podporuje pouze XNYS")
+        if instrument.currency != "USD" or instrument.asset_type is not AssetType.EQUITY:
+            raise ValueError("Phase 6 control plane podporuje pouze USD equities")
+        if instrument.active_to is not None and instrument.active_to <= instrument.active_from:
+            raise ValueError("Active interval musí být neprázdný")
+        with self.sessions() as session, session.begin():
+            existing = session.get(InstrumentRecord, instrument.instrument_id)
+            identity = (
+                instrument.symbol,
+                instrument.exchange,
+                instrument.calendar,
+                instrument.currency,
+                instrument.asset_type.value,
+                instrument.active_from,
+                instrument.active_to,
+            )
+            if existing is not None:
+                persisted = (
+                    existing.symbol,
+                    existing.exchange,
+                    existing.calendar,
+                    existing.currency,
+                    existing.asset_type,
+                    existing.active_from.date(),
+                    existing.active_to.date() if existing.active_to else None,
+                )
+                if persisted != identity:
+                    raise DatasetInvalid("Instrument identity koliduje s immutable metadata")
+                session.expunge(existing)
+                return existing
+            symbol_conflict = session.scalar(
+                select(InstrumentRecord).where(
+                    InstrumentRecord.symbol == instrument.symbol,
+                    InstrumentRecord.exchange == instrument.exchange,
+                )
+            )
+            if symbol_conflict is not None:
+                raise DatasetInvalid("Symbol a venue již označují jiný canonical instrument")
+            row = InstrumentRecord(
+                instrument_id=instrument.instrument_id,
+                symbol=instrument.symbol,
+                exchange=instrument.exchange,
+                calendar=instrument.calendar,
+                currency=instrument.currency,
+                asset_type=instrument.asset_type.value,
+                active_from=datetime.combine(instrument.active_from, datetime.min.time(), UTC),
+                active_to=(
+                    datetime.combine(instrument.active_to, datetime.min.time(), UTC)
+                    if instrument.active_to
+                    else None
+                ),
+                created_at=require_utc(instrument.created_at),
+            )
+            session.add(row)
+            session.flush()
+            session.add(
+                InstrumentSymbolRecord(
+                    instrument_id=instrument.instrument_id,
+                    symbol=instrument.symbol,
+                    valid_from=row.active_from,
+                    valid_to=row.active_to,
+                )
+            )
+            session.expunge(row)
+            return row
+
+    def create_universe(self, definition: UniverseDefinition) -> UniverseDefinitionRecord:
+        if definition.kind is not UniverseKind.POINT_IN_TIME_MEMBERSHIP:
+            raise ValueError("Production Phase 6 bootstrap vyžaduje PIT universe")
+        with self.sessions() as session, session.begin():
+            existing = session.get(UniverseDefinitionRecord, definition.universe_id)
+            if existing is not None:
+                if existing.name != definition.name or existing.kind != definition.kind.value:
+                    raise DatasetInvalid("Universe identity koliduje s immutable metadata")
+                session.expunge(existing)
+                return existing
+            same_name = session.scalar(
+                select(UniverseDefinitionRecord).where(
+                    UniverseDefinitionRecord.name == definition.name
+                )
+            )
+            if same_name is not None:
+                raise DatasetInvalid("Universe name již používá jiná identity")
+            row = UniverseDefinitionRecord(
+                universe_id=definition.universe_id,
+                name=definition.name,
+                kind=definition.kind.value,
+                created_at=require_utc(definition.created_at),
+            )
+            session.add(row)
+            session.flush()
+            session.expunge(row)
+            return row
+
+    def add_membership(self, membership: UniverseMembership) -> UniverseMembershipRecord:
+        with self.sessions() as session, session.begin():
+            universe = session.get(UniverseDefinitionRecord, membership.universe_id)
+            if universe is None or universe.kind != UniverseKind.POINT_IN_TIME_MEMBERSHIP.value:
+                raise DatasetInvalid("Membership vyžaduje existující PIT universe")
+            if session.get(InstrumentRecord, membership.instrument_id) is None:
+                raise DatasetInvalid("Membership instrument neexistuje")
+            existing = session.scalar(
+                select(UniverseMembershipRecord).where(
+                    UniverseMembershipRecord.universe_id == membership.universe_id,
+                    UniverseMembershipRecord.instrument_id == membership.instrument_id,
+                    UniverseMembershipRecord.valid_from == membership.valid_from,
+                )
+            )
+            if existing is not None:
+                if (
+                    existing.valid_to != membership.valid_to
+                    or existing.known_at != membership.known_at
+                ):
+                    raise DatasetInvalid("Membership identity koliduje s immutable intervalem")
+                session.expunge(existing)
+                return existing
+            row = UniverseMembershipRecord(
+                universe_id=membership.universe_id,
+                instrument_id=membership.instrument_id,
+                valid_from=membership.valid_from,
+                valid_to=membership.valid_to,
+                known_at=membership.known_at,
+            )
+            session.add(row)
+            session.flush()
+            session.expunge(row)
+            return row
+
+    def ensure_strategy(self, name: str, version: str, now: datetime) -> StrategyRecord:
+        strategy_type = STRATEGY_REGISTRY.get(name)
+        if strategy_type is None or strategy_type().version != version:
+            raise DatasetInvalid("Strategie a verze nejsou v allowlistu")
+        implementation = {
+            "registry": "quantlab.multi_asset.STRATEGY_REGISTRY",
+            "class": strategy_type.__qualname__,
+            "version": version,
+        }
+        identity = hashlib.sha256(
+            json.dumps(implementation, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        with self.sessions() as session, session.begin():
+            existing = session.scalar(
+                select(StrategyRecord).where(
+                    StrategyRecord.strategy_name == name,
+                    StrategyRecord.strategy_version == version,
+                )
+            )
+            if existing is not None:
+                if existing.strategy_identity != identity:
+                    raise DatasetInvalid("Registrovaná strategy implementation identity koliduje")
+                session.expunge(existing)
+                return existing
+            row = StrategyRecord(
+                strategy_identity=identity,
+                strategy_name=name,
+                strategy_version=version,
+                created_at=require_utc(now),
+                metadata_json=json.dumps(implementation, sort_keys=True),
+            )
+            session.add(row)
+            session.flush()
+            session.expunge(row)
+            return row

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -799,13 +799,15 @@ class DeploymentService:
         actor: dict[str, str] | None = None,
         reason: str | None = None,
         correlation_id: str | None = None,
+        allow_already_approved: bool = False,
     ) -> None:
         approved_at = require_utc(approved_at)
         with self._sessions() as session, session.begin():
             row = session.get(StrategyDeploymentRecord, deployment_id, with_for_update=True)
-            if row is not None and row.status == "APPROVED":
-                return
-            if row is None or row.status != "PENDING_REVIEW":
+            already_approved = row is not None and row.status == "APPROVED"
+            if row is None or (
+                row.status != "PENDING_REVIEW" and not (already_approved and allow_already_approved)
+            ):
                 raise ValueError("Deployment neexistuje nebo není čekající na ruční schválení")
             experiment = session.get(ExperimentRecord, row.experiment_id)
             if experiment is None:
@@ -830,6 +832,8 @@ class DeploymentService:
                 raise DatasetInvalid("Deployment timeframe není podporován")
             if self._evidence(row.parameters_json, "deployment parameters") != parameters:
                 raise DatasetInvalid("Deployment parameters neodpovídají experiment evidence")
+            if already_approved:
+                return
             row.status = "APPROVED"
             row.approved_at = approved_at
             if actor is not None and reason is not None:

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -42,6 +43,7 @@ from quantlab.persistence import (
     UniverseMembershipRecord,
 )
 from quantlab.phase4 import (
+    AuditEventRecord,
     PaperAccountRecord,
     PositionRecord,
     TradingCycleRecord,
@@ -442,6 +444,34 @@ class Phase6ExperimentReplayService:
         return self._runner.replay(request)
 
 
+def _control_plane_audit(
+    session: Session,
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    actor: dict[str, str],
+    reason: str,
+    correlation_id: str | None,
+    evidence: dict[str, object],
+) -> None:
+    if not reason.strip():
+        raise ValueError("Audit reason nesmí být prázdný")
+    session.add(
+        AuditEventRecord(
+            id=str(uuid4()),
+            timestamp=datetime.now(UTC),
+            event_type=event_type,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            trading_cycle_id=None,
+            correlation_id=(correlation_id or str(uuid4()))[:64],
+            payload_json=json.dumps(
+                {"actor": actor, "reason": reason, **evidence}, sort_keys=True, default=str
+            ),
+        )
+    )
+
+
 def multi_asset_metrics(result: MultiAssetResult, initial_cash: Decimal) -> MultiAssetMetrics:
     values = [value for _, value in result.equity]
     if not values:
@@ -660,7 +690,14 @@ class Phase6EligibilityService:
     def __init__(self, session_factory: Callable[[], Session]) -> None:
         self._sessions = session_factory
 
-    def promote(self, experiment_id: str) -> ExperimentRecord:
+    def promote(
+        self,
+        experiment_id: str,
+        *,
+        actor: dict[str, str] | None = None,
+        reason: str | None = None,
+        correlation_id: str | None = None,
+    ) -> ExperimentRecord:
         with self._sessions() as session, session.begin():
             row = session.get(ExperimentRecord, experiment_id, with_for_update=True)
             if row is None:
@@ -668,7 +705,19 @@ class Phase6EligibilityService:
             DeploymentService.validate_experiment(session, row)
             if row.decision not in {"RESEARCH_ONLY", "PAPER_CANDIDATE"}:
                 raise DatasetInvalid("Experiment je v nekonzistentním decision state")
+            changed = row.decision == "RESEARCH_ONLY"
             row.decision = "PAPER_CANDIDATE"
+            if changed and actor is not None and reason is not None:
+                _control_plane_audit(
+                    session,
+                    "PHASE6_EXPERIMENT_PROMOTED",
+                    "experiment",
+                    row.id,
+                    actor,
+                    reason,
+                    correlation_id,
+                    {"resulting_decision": row.decision},
+                )
             session.flush()
             session.expunge(row)
             return row
@@ -686,6 +735,9 @@ class DeploymentService:
         currency: str = "USD",
         timeframe: str = "1d",
         created_at: datetime | None = None,
+        actor: dict[str, str] | None = None,
+        reason: str | None = None,
+        correlation_id: str | None = None,
     ) -> StrategyDeploymentRecord:
         created_at = require_utc(created_at or datetime.now(UTC))
         with self._sessions() as session, session.begin():
@@ -724,14 +776,35 @@ class DeploymentService:
                 timeframe=timeframe,
             )
             session.add(row)
+            if actor is not None and reason is not None:
+                _control_plane_audit(
+                    session,
+                    "PHASE6_DEPLOYMENT_CREATED",
+                    "deployment",
+                    row.deployment_id,
+                    actor,
+                    reason,
+                    correlation_id,
+                    {"experiment_id": experiment.id, "status": row.status},
+                )
             session.flush()
             session.expunge(row)
             return row
 
-    def approve(self, deployment_id: str, approved_at: datetime) -> None:
+    def approve(
+        self,
+        deployment_id: str,
+        approved_at: datetime,
+        *,
+        actor: dict[str, str] | None = None,
+        reason: str | None = None,
+        correlation_id: str | None = None,
+    ) -> None:
         approved_at = require_utc(approved_at)
         with self._sessions() as session, session.begin():
             row = session.get(StrategyDeploymentRecord, deployment_id, with_for_update=True)
+            if row is not None and row.status == "APPROVED":
+                return
             if row is None or row.status != "PENDING_REVIEW":
                 raise ValueError("Deployment neexistuje nebo není čekající na ruční schválení")
             experiment = session.get(ExperimentRecord, row.experiment_id)
@@ -759,6 +832,17 @@ class DeploymentService:
                 raise DatasetInvalid("Deployment parameters neodpovídají experiment evidence")
             row.status = "APPROVED"
             row.approved_at = approved_at
+            if actor is not None and reason is not None:
+                _control_plane_audit(
+                    session,
+                    "PHASE6_DEPLOYMENT_APPROVED",
+                    "deployment",
+                    row.deployment_id,
+                    actor,
+                    reason,
+                    correlation_id,
+                    {"experiment_id": row.experiment_id, "status": row.status},
+                )
 
     @classmethod
     def validate_experiment(

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from phase6_audit_helpers import CALENDAR, MappingProvider, daily_bar
+from sqlalchemy.orm import Session
+
+import quantlab.api as api_module
+from quantlab.persistence import DatasetSnapshotRecord, ExperimentRecord, StrategyDeploymentRecord
+from quantlab.phase7 import PaperMonitoringRunRecord
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_POSTGRES_TESTS") != "1", reason="vyžaduje PostgreSQL CI"
+)
+
+
+def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> None:
+    suffix = uuid4().hex
+    instrument_id = f"b1-{suffix[:36]}"
+    symbol = f"B{suffix[:7]}".upper()
+    universe_id = f"b1-u-{suffix[:32]}"
+    sessions = list(CALENDAR.sessions_between(date(2026, 1, 2), date(2026, 2, 6)))[:18]
+    provider = MappingProvider(
+        "stooq",
+        {
+            symbol: [
+                daily_bar(day, Decimal(100 + index), f"b1:{suffix}:{day}")
+                for index, day in enumerate(sessions)
+            ]
+        },
+        {},
+    )
+    monkeypatch.setattr(api_module, "StooqProvider", lambda: provider)
+    client = TestClient(api_module.app)
+    reason = "B1 PostgreSQL acceptance"
+
+    instrument = client.post(
+        "/operator/instruments",
+        json={
+            "instrument_id": instrument_id,
+            "symbol": symbol,
+            "active_from": "2020-01-01",
+            "reason": reason,
+        },
+    )
+    assert instrument.status_code == 200, instrument.text
+    assert (
+        client.post(
+            "/operator/instruments",
+            json={
+                "instrument_id": instrument_id,
+                "symbol": symbol,
+                "active_from": "2020-01-01",
+                "reason": reason,
+            },
+        ).json()["instrument_id"]
+        == instrument_id
+    )
+    assert (
+        client.post(
+            "/operator/universes",
+            json={"universe_id": universe_id, "name": universe_id, "reason": reason},
+        ).status_code
+        == 200
+    )
+    membership_payload = {
+        "instrument_id": instrument_id,
+        "valid_from": CALENDAR.session_open(sessions[0]).isoformat(),
+        "known_at": CALENDAR.session_open(sessions[0]).isoformat(),
+        "reason": reason,
+    }
+    membership = client.post(
+        f"/operator/universes/{universe_id}/memberships", json=membership_payload
+    )
+    assert membership.status_code == 200, membership.text
+    invalid = dict(membership_payload)
+    invalid["valid_to"] = membership_payload["valid_from"]
+    assert (
+        client.post(f"/operator/universes/{universe_id}/memberships", json=invalid).status_code
+        == 409
+    )
+    observed_at = datetime.now(UTC)
+    ingestion = client.post(
+        "/operator/market-data/ingestions",
+        json={
+            "instrument_id": instrument_id,
+            "start": sessions[0].isoformat(),
+            "end": sessions[-1].isoformat(),
+            "reason": reason,
+        },
+    )
+    assert ingestion.status_code == 200, ingestion.text
+    snapshot = client.post(
+        "/operator/datasets",
+        json={
+            "provider": "stooq",
+            "universe_id": universe_id,
+            "start": sessions[0].isoformat(),
+            "end": sessions[-1].isoformat(),
+            "as_of": observed_at.isoformat(),
+            "minimum_coverage": "1",
+            "reason": reason,
+        },
+    )
+    assert snapshot.status_code == 200, snapshot.text
+    experiment = client.post(
+        "/operator/research/experiments",
+        json={
+            "snapshot_id": snapshot.json()["snapshot_id"],
+            "strategy_name": "multi_asset_trend",
+            "strategy_version": "1.0.0",
+            "parameter_configs": [{"fast": 2, "slow": 3}, {"fast": 2, "slow": 4}],
+            "code_sha": "a" * 40,
+            "reason": reason,
+        },
+    )
+    assert experiment.status_code == 200, experiment.text
+    assert experiment.json()["status"] == "COMPLETED"
+    experiment_id = experiment.json()["id"]
+    assert (
+        client.post(
+            f"/operator/research/experiments/{experiment_id}/promote", json={"reason": reason}
+        ).json()["decision"]
+        == "PAPER_CANDIDATE"
+    )
+    deployment = client.post(
+        "/operator/deployments",
+        json={"experiment_id": experiment_id, "reason": reason},
+    )
+    assert deployment.status_code == 200, deployment.text
+    deployment_id = deployment.json()["deployment_id"]
+    unapproved = client.post(
+        "/operator/monitoring/enrollments",
+        json={"deployment_id": deployment_id, "policy_id": "missing", "reason": reason},
+    )
+    assert unapproved.status_code == 409
+    assert (
+        client.post(
+            f"/operator/deployments/{deployment_id}/approve", json={"reason": reason}
+        ).json()["status"]
+        == "APPROVED"
+    )
+    policy = client.post(
+        "/operator/monitoring/policies",
+        json={"name": universe_id, "reason": reason},
+    )
+    assert policy.status_code == 200, policy.text
+    enrollment = client.post(
+        "/operator/monitoring/enrollments",
+        json={
+            "deployment_id": deployment_id,
+            "policy_id": policy.json()["policy_id"],
+            "reason": reason,
+        },
+    )
+    assert enrollment.status_code == 200, enrollment.text
+    assert enrollment.json()["state"] == "ACTIVE"
+    retry = client.post(
+        "/operator/monitoring/enrollments",
+        json={
+            "deployment_id": deployment_id,
+            "policy_id": policy.json()["policy_id"],
+            "reason": reason,
+        },
+    )
+    assert retry.json()["monitoring_id"] == enrollment.json()["monitoring_id"]
+    with Session(api_module.paper_repository.engine) as session:
+        monitoring = session.get(PaperMonitoringRunRecord, enrollment.json()["monitoring_id"])
+        assert monitoring is not None
+        deployment_row = session.get(StrategyDeploymentRecord, monitoring.deployment_id)
+        assert deployment_row is not None
+        experiment_row = session.get(ExperimentRecord, deployment_row.experiment_id)
+        assert experiment_row is not None
+        snapshot_row = session.get(DatasetSnapshotRecord, experiment_row.snapshot_id)
+        assert snapshot_row is not None
+        assert deployment_row.snapshot_id == snapshot.json()["snapshot_id"]
+        assert snapshot_row.universe_id == universe_id
+        assert instrument_id in snapshot_row.manifest_json
+        assert all(
+            item["observation_id"] in snapshot_row.manifest_json
+            for item in ingestion.json()["observations"]
+        )
+
+
+def test_control_plane_requires_admin_and_authentication() -> None:
+    client = TestClient(api_module.app)
+    payload = {
+        "instrument_id": "forbidden",
+        "symbol": "DENY",
+        "active_from": "2020-01-01",
+        "reason": "security negative",
+    }
+    client.headers["Authorization"] = f"Bearer {api_module.settings.api_viewer_token}"
+    assert client.post("/operator/instruments", json=payload).status_code == 403
+    del client.headers["Authorization"]
+    assert client.post("/operator/instruments", json=payload).status_code == 401

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -84,7 +84,6 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
         client.post(f"/operator/universes/{universe_id}/memberships", json=invalid).status_code
         == 409
     )
-    observed_at = datetime.now(UTC)
     ingestion = client.post(
         "/operator/market-data/ingestions",
         json={
@@ -95,6 +94,11 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
         },
     )
     assert ingestion.status_code == 200, ingestion.text
+    ingested_observations = ingestion.json()["observations"]
+    assert ingested_observations
+    observed_at = max(
+        datetime.fromisoformat(item["observed_at"]) for item in ingested_observations
+    )
     snapshot = client.post(
         "/operator/datasets",
         json={
@@ -183,7 +187,7 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
         assert instrument_id in snapshot_row.manifest_json
         assert all(
             item["observation_id"] in snapshot_row.manifest_json
-            for item in ingestion.json()["observations"]
+            for item in ingested_observations
         )
 
 

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -96,9 +96,7 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
     assert ingestion.status_code == 200, ingestion.text
     ingested_observations = ingestion.json()["observations"]
     assert ingested_observations
-    observed_at = max(
-        datetime.fromisoformat(item["observed_at"]) for item in ingested_observations
-    )
+    observed_at = max(datetime.fromisoformat(item["observed_at"]) for item in ingested_observations)
     snapshot = client.post(
         "/operator/datasets",
         json={
@@ -186,8 +184,7 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
         assert snapshot_row.universe_id == universe_id
         assert instrument_id in snapshot_row.manifest_json
         assert all(
-            item["observation_id"] in snapshot_row.manifest_json
-            for item in ingested_observations
+            item["observation_id"] in snapshot_row.manifest_json for item in ingested_observations
         )
 
 

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+import json
 import os
-from datetime import UTC, date, datetime
+from datetime import date, datetime
 from decimal import Decimal
 from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
 from phase6_audit_helpers import CALENDAR, MappingProvider, daily_bar
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 import quantlab.api as api_module
-from quantlab.persistence import DatasetSnapshotRecord, ExperimentRecord, StrategyDeploymentRecord
+from quantlab.persistence import (
+    DatasetSnapshotRecord,
+    ExperimentRecord,
+    InstrumentRecord,
+    StrategyDeploymentRecord,
+    UniverseMembershipRecord,
+)
 from quantlab.phase7 import PaperMonitoringRunRecord
 
 pytestmark = pytest.mark.skipif(
@@ -182,10 +190,25 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
         assert snapshot_row is not None
         assert deployment_row.snapshot_id == snapshot.json()["snapshot_id"]
         assert snapshot_row.universe_id == universe_id
-        assert instrument_id in snapshot_row.manifest_json
-        assert all(
-            item["observation_id"] in snapshot_row.manifest_json for item in ingested_observations
+
+        membership_row = session.scalar(
+            select(UniverseMembershipRecord).where(
+                UniverseMembershipRecord.universe_id == universe_id,
+                UniverseMembershipRecord.instrument_id == instrument_id,
+            )
         )
+        assert membership_row is not None
+        assert session.get(InstrumentRecord, membership_row.instrument_id) is not None
+
+        manifest = json.loads(snapshot_row.manifest_json)
+        manifest_observations = {
+            (item["id"], item["revision"], item["hash"]) for item in manifest["observations"]
+        }
+        ingested_lineage = {
+            (item["observation_id"], item["revision"], item["source_hash"])
+            for item in ingested_observations
+        }
+        assert manifest_observations == ingested_lineage
 
 
 def test_control_plane_requires_admin_and_authentication() -> None:

--- a/backend/tests/test_vertical_slice.py
+++ b/backend/tests/test_vertical_slice.py
@@ -77,7 +77,7 @@ def test_api_and_dashboard() -> None:
 
 def test_research_api_persists_experiment_and_exposes_report() -> None:
     client = TestClient(app)
-    created = client.post("/research/experiments")
+    created = client.post("/demo/research/experiments")
     assert created.status_code == 200
     experiment_id = created.json()["id"]
     fetched = client.get(f"/research/experiments/{experiment_id}")

--- a/docs/operational-readiness-audit.md
+++ b/docs/operational-readiness-audit.md
@@ -135,18 +135,16 @@ Rozlišení v tabulkách:
 
 ## 5. BLOCKER findings
 
-### B1 — Phase 6 workflow není provozně dosažitelný
+### B1 — RESOLVED — podporovaný Phase 6 control plane
 
-**Dopad:** Z čistého vstupu nelze dodaným produktem vytvořit instrument/universe, ingestovat data,
-sestavit snapshot, spustit Phase 6 experiment, provést promotion a vytvořit/schválit deployment.
-API pro tyto entity nabízí převážně GET. POST `/research/experiments` volá
-`ResearchService.create_demo_experiment()` nad `tests/fixtures/sample_market_data.csv`; POST
-`/trading/cycles/run-paper` rovněž používá fixture a pevné SPY targety. Správné Phase 6 služby jsou
-volány pouze testy nebo by je musel operátor ručně importovat ve vlastním Python skriptu.
+Původní příčinou byla absence mutation orchestrace nad existujícími Phase 6 službami. Nový
+autentizovaný ADMIN control plane pokrývá canonical instrument, PIT universe a membership, skutečný
+provider ingest, validovaný snapshot, allowlisted multi-parameter experiment, explicitní promotion,
+deployment create/approve a monitoring policy/enrollment. Actor a reason se ukládají do audit
+evidence a domain identity zajišťují bezpečné retry. Podrobnosti a PostgreSQL důkaz jsou v
+[`operational-readiness-remediation-b1.md`](operational-readiness-remediation-b1.md).
 
-**Proč je to blocker:** autonomní laboratoř nelze bootstrapovat ani auditovatelně ovládat bez
-nezdokumentovaného programování nebo přímé manipulace aplikačními službami. DB insert není přijatelný
-workflow a obchází validační/actor hranice.
+Tato změna **nemění celkový verdikt NOT READY**. Zejména B2, H1, H2, H3 a M1 zůstávají otevřené.
 
 ### B2 — Worker neprovádí schválený deployment ani strategii
 

--- a/docs/operational-readiness-remediation-b1.md
+++ b/docs/operational-readiness-remediation-b1.md
@@ -1,0 +1,49 @@
+# Operational Readiness Remediation P0 — B1 Phase 6 Control Plane
+
+## Příčina a implementovaný workflow
+
+Domain služby existovaly, ale runtime vystavoval jen read API a produkčně vypadající fixture demo
+mutace. Nová orchestration boundary poskytuje tok `instrument → PIT universe/membership → Stooq
+ingest → VALID snapshot → allowlisted Phase 6 experiment → promotion → PENDING_REVIEW deployment →
+explicit approval → monitoring policy → ACTIVE enrollment`. Business logika zůstává v domain
+službách.
+
+## API, RBAC a audit
+
+Bearer-authenticated ADMIN mutation surface je:
+
+- `POST /operator/instruments`
+- `POST /operator/universes` a `POST /operator/universes/{id}/memberships`
+- `POST /operator/market-data/ingestions` a `POST /operator/datasets`
+- `POST /operator/research/experiments` a `POST /operator/research/experiments/{id}/promote`
+- `POST /operator/deployments` a `POST /operator/deployments/{id}/approve`
+- `POST /operator/monitoring/policies` a `POST /operator/monitoring/enrollments`
+
+Actor se odvozuje výhradně z bearer principalu; body jej nepřijímá. Každá operace vyžaduje reason.
+Promotion a deployment stavové změny zapisují immutable audit ve stejné transakci; ostatní mutace
+ukládají idempotentní audit evidence s actor ID/rolí, reason a correlation ID.
+
+## Idempotence, lineage a demo hranice
+
+Immutable registry identity failují při konfliktu a identický retry vrací původní objekt. Ingest,
+snapshot, experiment, promotion, deployment, approval, policy a enrollment používají existující
+content/scope identity a uniqueness invarianty. Snapshot validation ani PIT knowledge timing nelze
+obejít. Experiment přijme pouze přesnou verzi z `STRATEGY_REGISTRY`, nikoli import path, a jeho
+identity zahrnuje snapshot, parameter space, chronologický split, seed, code SHA a cost model.
+
+Fixture mutace jsou explicitně `POST /demo/research/experiments` a
+`POST /demo/trading/cycles/run-paper`; nejsou podporovaným Phase 6 workflow. CLI framework nebyl
+zaveden. Existující UI výslednou operator evidence zobrazuje a kompletní bootstrap je dostupný přes
+API bez SQL či Python shellu.
+
+## E2E proof a zbývající scope
+
+`backend/tests/test_b1_control_plane_postgres.py` prochází přes HTTP celý tok z čistých business
+identit po ACTIVE monitoring s deterministickým providerem přes stejnou ingest boundary. Ověřuje i
+viewer/unauthenticated zákaz, invalid PIT interval, enrollment před approval a retry bez duplicit.
+Lineage monitoring → deployment → experiment/strategy → snapshot manifest → universe/instrument →
+observation revisions zajišťují stávající FK a immutable manifesty.
+
+B2 worker integration, H1 refresh/scheduler, H2 corporate-actions provider, H3 policy versioning a
+M1 scoring redesign zůstávají otevřené. Approved deployment se automaticky neobchoduje. PAPER-only
+cesta a B3 invariant `close T → next valid XNYS raw open T+1` se nemění.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -5,7 +5,9 @@ Production-like PAPER provoz vyžaduje explicitní migration step, strong secret
 
 1. Spusťte PostgreSQL a `uv run alembic -c ../alembic.ini upgrade head`.
 2. Před prvním cyklem a po incidentu volejte `POST /reconciliation/run`.
-3. Cycle spouští `POST /trading/cycles/run-paper`; incident zastaví `POST /risk/halt`.
+3. Legacy fixture cycle je pouze development demo na `POST /demo/trading/cycles/run-paper`;
+   schválený Phase 6 deployment tento B1 control plane záměrně nespouští (B2 zůstává otevřené).
+   Incident zastaví `POST /risk/halt`.
 4. `/risk/resume` funguje jen po safe reconciliation.
 
 Diagnostika používá risk events/decisions, orders, audit a reconciliation status. Po crashi spusťte stejný logical cycle: DB identity obnoví existující stav namísto nového obchodu. Testy: `uv run pytest -q`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,6 +56,13 @@ aplikují dostupné security aktualizace. Nejde o blanket potlačení reportu.
 
 | Method | Path | Permission |
 |---|---|---|
+| POST | `/operator/instruments` | ADMIN |
+| POST | `/operator/universes` a `/{id}/memberships` | ADMIN |
+| POST | `/operator/market-data/ingestions` | ADMIN |
+| POST | `/operator/datasets` | ADMIN |
+| POST | `/operator/research/experiments` a `/{id}/promote` | ADMIN |
+| POST | `/operator/deployments` a `/{id}/approve` | ADMIN |
+| POST | `/operator/monitoring/policies` a `/enrollments` | ADMIN |
 | POST | `/operator/risk/halt` | OPERATOR/ADMIN |
 | POST | `/operator/risk/resume` | ADMIN |
 | POST | `/paper/monitoring/policies` | ADMIN |
@@ -71,8 +78,7 @@ aplikují dostupné security aktualizace. Nejde o blanket potlačení reportu.
 | POST | `/automation/runs/{run_id}/retry` | ADMIN |
 | POST | `/risk/halt` | OPERATOR/ADMIN |
 | POST | `/risk/resume` | ADMIN |
-| POST | `/trading/cycles/run-paper` | ADMIN |
+| POST | `/demo/trading/cycles/run-paper` | ADMIN |
 | POST | `/reconciliation/run` | ADMIN |
 | POST | `/api/backtests/demo` | ADMIN |
-| POST | `/research/experiments` | ADMIN |
-| POST | `/api/research/experiments` | ADMIN |
+| POST | `/demo/research/experiments` | ADMIN |


### PR DESCRIPTION
### Motivation
- Audit odhalil, že Phase 6 službám chybí provozně dosažitelná mutation cesta, takže bootstrap z čisté DB nebyl možný bez přímého volání služeb nebo SQL insertů.
- Cílem je zavést minimální bezpečnou orchestration vrstvu, která použije stávající domain služby (ingest, snapshot, experiment, promotion, deployment, monitoring) bez kopírování business logiky.
- Zachovat projektové invarianty: PAPER‑only hranice, idempotence, RBAC, actor/reason audit a B3 timing/no‑lookahead pravidla.
- Nepřidávat worker integration, automatický refresh ani live trading (B2/H1/H2/H3/M1 zůstávají otevřené). 

### Description
- Přidána nová service vrstva `ControlPlaneRegistryService` (`backend/src/quantlab/control_plane.py`) pro idempotentní registraci canonical instrumentů, vytvoření PIT universa a membership; konflikt immutable identity failuje closed.
- Rozšířen `phase6_runtime` o auditní hooky a volitelné actor/reason/correlation evidence při `promote`, `create deployment` a `approve` tak, aby state change zapisovala immutable audit události v jedné transakci; taky drobné idempotentní ochrany (approve early return).
- Nové autentizované operator API pod `/operator` (v `backend/src/quantlab/api.py`) vystavuje mutationy: `instruments`, `universes`, `memberships`, `market-data/ingestions`, `datasets`, `research/experiments`, `research/experiments/{id}/promote`, `deployments`, `deployments/{id}/approve`, `monitoring/policies` a `monitoring/enrollments`; každá mutation vyžaduje reason a actor je odvozen z bearer principalu.
- Demo mutace jsou explicitně izolovány do `/demo` namespace (`/demo/research/experiments`, `/demo/trading/cycles/run-paper`) aby se předešlo mylnému prezentování fixture jako production toku.
- Přidán PostgreSQL E2E acceptance test `backend/tests/test_b1_control_plane_postgres.py`, který z čisté DB přes HTTP provede celý tok až po ACTIVE monitoring a ověří lineage do snapshot manifestu; zahrnuje negativní RBAC a idempotency kontroly.
- Dokumentace aktualizována: `docs/operational-readiness-audit.md` (označení B1 jako resolved pro tento PR), přidán `docs/operational-readiness-remediation-b1.md`, doplněny `docs/security.md` a `docs/operations.md`, a stručná poznámka v `README.md` o dostupnosti operator control‑plane.

### Testing
- Spuštěné statické a sanity kontroly backendu: `ruff format/check` a `python -m compileall` — tyto kontroly prošly lokálně (PASS).
- Frontend lockfile check `npm run lockfile:check` prošel (PASS), ale úplné frontend build/typecheck/test běhy byly blokovány chybějícími npm artefakty (registry 403) a proto nebyly úspěšně vykonány (BLOCKED BY ENVIRONMENT).
- Pokusy o `uv lock --check` / `uv sync --locked --all-groups` a `uv run pytest` byly lokálně blokovány mismatched/pinned `uv` verzí a síťovými omezeními, takže integrační pytest běhy a mypy přes `uv` nebyly dokončeny zde (BLOCKED BY ENVIRONMENT).
- Připravený PostgreSQL E2E test `backend/tests/test_b1_control_plane_postgres.py` je zařazen jako autoritativní CI gate a vyžaduje `RUN_POSTGRES_TESTS=1`; test byl spuštěn pouze v konstrukci lokálně jako strukturovaný test, ale běh proti reálnému PostgreSQL runneru je očekáván v CI (INTENDED FOR CI).
- Shrnutí výsledků: lokální lint/format/compile prošly, frontend lockfile check prošel, integrační end‑to‑end běhy (uv/mypy/pytest, frontend build) byly zablokovány prostředím a proto reportovány jako `BLOCKED BY ENVIRONMENT` místo PASS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8ee89004ac8332abc2c34072405cbb)