### PR TITLE
Fail-closed corporate-action readiness gate (H2‑A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
         run: uv run pytest -q tests/test_p0b_worker_runtime_postgres.py
       - name: Stage C autonomous market-data/session orchestration acceptance
         run: uv run pytest -q tests/test_stage_c_autonomous_session_postgres.py
+      - name: H2 corporate-action capability/readiness acceptance
+        run: uv run pytest -q tests/test_h2_corporate_action_readiness_postgres.py
 
   frontend:
     runs-on: ubuntu-latest

--- a/alembic/versions/20260827_01_h2_action_readiness.py
+++ b/alembic/versions/20260827_01_h2_action_readiness.py
@@ -1,0 +1,62 @@
+"""Přidá neměnnou evidence úplnosti corporate actions.
+
+Revision ID: 20260827_01
+Revises: 20260826_01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260827_01"
+down_revision = "20260826_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if "corporate_action_readiness" in sa.inspect(bind).get_table_names():
+        return
+    op.create_table(
+        "corporate_action_readiness",
+        sa.Column("evidence_id", sa.String(64), primary_key=True),
+        sa.Column("provider", sa.String(40), nullable=False),
+        sa.Column("provider_version", sa.String(40), nullable=False),
+        sa.Column("instrument_id", sa.String(64), nullable=False),
+        sa.Column("requested_start", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("requested_end", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("knowledge_cutoff", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("checked_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("supports_actions", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("blocking_reason", sa.String(80), nullable=True),
+        sa.Column("action_count", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["instrument_id"], ["instruments.instrument_id"], ondelete="RESTRICT"
+        ),
+    )
+    op.create_index(
+        "ix_corporate_action_readiness_provider",
+        "corporate_action_readiness",
+        ["provider"],
+    )
+    op.create_index(
+        "ix_corporate_action_readiness_instrument_id",
+        "corporate_action_readiness",
+        ["instrument_id"],
+    )
+    op.create_index(
+        "ix_action_readiness_scope",
+        "corporate_action_readiness",
+        [
+            "instrument_id",
+            "provider",
+            "requested_start",
+            "requested_end",
+            "knowledge_cutoff",
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("corporate_action_readiness")

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -1017,7 +1017,10 @@ class JobExecutor:
                     "no_action_reason": f"MONITORING_{monitoring.state}",
                 }
         service = Phase6PaperExecutionService(
-            sessions, ValidatedCurrentDataAccessor(sessions), self.trading
+            sessions,
+            ValidatedCurrentDataAccessor(sessions),
+            self.trading,
+            require_corporate_action_readiness=True,
         )
         try:
             cycle_id = service.run(

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -929,7 +929,7 @@ class JobExecutor:
     def _run_paper_deployment(
         self, account_id: str, payload: dict[str, Any], run: JobRun
     ) -> dict[str, str | None]:
-        from quantlab.market_data import DatasetInvalid
+        from quantlab.market_data import DatasetInvalid, StooqProvider
         from quantlab.persistence import StrategyDeploymentRecord
         from quantlab.phase6_runtime import (
             Phase6PaperExecutionService,
@@ -1016,11 +1016,13 @@ class JobExecutor:
                     "outcome": "BLOCKED_BY_LIFECYCLE",
                     "no_action_reason": f"MONITORING_{monitoring.state}",
                 }
+        provider = self.provider_factory() if self.provider_factory else StooqProvider()
         service = Phase6PaperExecutionService(
             sessions,
             ValidatedCurrentDataAccessor(sessions),
             self.trading,
             require_corporate_action_readiness=True,
+            corporate_action_provider_identity=(provider.metadata.name, provider.metadata.version),
         )
         try:
             cycle_id = service.run(

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -684,6 +684,7 @@ class JobExecutor:
         """Obnoví PIT scope po close a připraví pouze next-session execution occurrence."""
         from quantlab.market_data import (
             AssetType,
+            DatasetInvalid,
             Instrument,
             ProviderError,
             StooqProvider,
@@ -691,6 +692,7 @@ class JobExecutor:
         )
         from quantlab.market_data_service import PersistentMarketDataService
         from quantlab.persistence import (
+            DatasetSnapshotRecord,
             InstrumentRecord,
             MarketDataIngestionRecord,
             MarketObservationRecord,
@@ -720,6 +722,9 @@ class JobExecutor:
                 raise PermanentJobError("Orchestrace vyžaduje APPROVED deployment")
             if deployment.paper_account_id != account_id:
                 raise PermanentJobError("Orchestration account neodpovídá deployment lineage")
+            snapshot = session.get(DatasetSnapshotRecord, deployment.snapshot_id)
+            if snapshot is None:
+                raise PermanentJobError("Deployment snapshot neexistuje")
             monitoring = session.scalar(
                 select(PaperMonitoringRunRecord).where(
                     PaperMonitoringRunRecord.deployment_id == deployment_id,
@@ -773,6 +778,7 @@ class JobExecutor:
             raise PermanentJobError("PIT universe scope je prázdný nebo nekonzistentní")
         provider = self.provider_factory() if self.provider_factory else StooqProvider()
         ingestions: list[str] = []
+        action_evidence: list[str] = []
         for row in sorted(rows, key=lambda item: item.instrument_id):
             instrument = Instrument(
                 row.instrument_id,
@@ -785,6 +791,31 @@ class JobExecutor:
                 row.active_to.date() if row.active_to else None,
                 utc(row.created_at),
             )
+            if instrument.asset_type == AssetType.EQUITY:
+                try:
+                    action_evidence.append(
+                        PersistentMarketDataService(
+                            sessions, calendar, clock=lambda: now
+                        ).verify_corporate_action_readiness(
+                            provider,
+                            instrument,
+                            snapshot.start_at.date(),
+                            signal_session,
+                            signal_close,
+                        )
+                    )
+                except DatasetInvalid as exc:
+                    return {
+                        "deployment_id": deployment_id,
+                        "monitoring_id": monitoring.monitoring_id,
+                        "trading_cycle_id": None,
+                        "reconciliation_id": None,
+                        "outcome": "NOT_READY",
+                        "no_action_reason": str(exc),
+                        "corporate_action_evidence_ids": ",".join(action_evidence),
+                    }
+                except ProviderError as exc:
+                    raise TransientJobError("CORPORATE_ACTIONS_UNAVAILABLE") from exc
             if row.instrument_id in eligible_ids:
                 with sessions() as session:
                     signal_ready = session.scalar(
@@ -892,6 +923,7 @@ class JobExecutor:
             "no_action_reason": None,
             "execution_run_id": run_id,
             "ingestion_ids": ",".join(ingestions),
+            "corporate_action_evidence_ids": ",".join(action_evidence),
         }
 
     def _run_paper_deployment(

--- a/backend/src/quantlab/market_data_service.py
+++ b/backend/src/quantlab/market_data_service.py
@@ -24,6 +24,7 @@ from quantlab.market_data import (
     normalize_bar,
 )
 from quantlab.persistence import (
+    CorporateActionReadinessRecord,
     CorporateActionRecord,
     DatasetSnapshotRecord,
     InstrumentRecord,
@@ -120,6 +121,86 @@ class PersistentMarketDataService:
             executable_open=True,
         )
 
+    def verify_corporate_action_readiness(
+        self,
+        provider: MarketDataProvider,
+        instrument: Instrument,
+        start: date,
+        end: date,
+        knowledge_cutoff: datetime,
+    ) -> str:
+        """Připne úplnost intervalu; prázdný výsledek je úplný jen u capable provideru."""
+        cutoff = require_utc(knowledge_cutoff)
+        identity = "|".join(
+            (
+                provider.metadata.name,
+                provider.metadata.version,
+                instrument.instrument_id,
+                start.isoformat(),
+                end.isoformat(),
+                cutoff.isoformat(),
+            )
+        )
+        with self._sessions() as session:
+            existing = session.scalar(
+                select(CorporateActionReadinessRecord).where(
+                    CorporateActionReadinessRecord.provider == provider.metadata.name,
+                    CorporateActionReadinessRecord.provider_version == provider.metadata.version,
+                    CorporateActionReadinessRecord.instrument_id == instrument.instrument_id,
+                    CorporateActionReadinessRecord.requested_start == _instant(start),
+                    CorporateActionReadinessRecord.requested_end == _instant(end),
+                    CorporateActionReadinessRecord.knowledge_cutoff == cutoff,
+                    CorporateActionReadinessRecord.status == "COMPLETE",
+                )
+            )
+            if existing is not None:
+                return existing.evidence_id
+
+        status = "UNSUPPORTED"
+        reason: str | None = "CORPORATE_ACTIONS_UNSUPPORTED"
+        actions: list[CorporateAction] = []
+        error: Exception | None = None
+        if provider.metadata.supports_actions:
+            try:
+                actions = provider.corporate_actions(instrument.symbol, start, end)
+                if any(action.instrument_id != instrument.instrument_id for action in actions):
+                    raise DatasetInvalid("Corporate action neodpovídá požadovanému instrumentu")
+                if any(require_utc(action.known_at) > cutoff for action in actions):
+                    raise DatasetInvalid("Corporate action porušuje knowledge cutoff")
+                status, reason = "COMPLETE", None
+            except Exception as exc:
+                status, reason, error = "FAILED", "CORPORATE_ACTIONS_UNAVAILABLE", exc
+        evidence_payload = "|".join(sorted(action.action_id for action in actions))
+        evidence_id = hashlib.sha256(f"{identity}|{status}|{evidence_payload}".encode()).hexdigest()
+        checked_at = require_utc(self.clock())
+        with self._sessions() as session, session.begin():
+            _lock(session, f"action-readiness:{evidence_id}")
+            if session.get(CorporateActionReadinessRecord, evidence_id) is None:
+                session.add(
+                    CorporateActionReadinessRecord(
+                        evidence_id=evidence_id,
+                        provider=provider.metadata.name,
+                        provider_version=provider.metadata.version,
+                        instrument_id=instrument.instrument_id,
+                        requested_start=_instant(start),
+                        requested_end=_instant(end),
+                        knowledge_cutoff=cutoff,
+                        checked_at=checked_at,
+                        supports_actions=int(provider.metadata.supports_actions),
+                        status=status,
+                        blocking_reason=reason,
+                        action_count=len(actions),
+                    )
+                )
+                for action in actions:
+                    if session.get(CorporateActionRecord, action.action_id) is None:
+                        session.add(self._action_record(action))
+        if status != "COMPLETE":
+            if error is not None:
+                raise error
+            raise DatasetInvalid(reason or "CORPORATE_ACTIONS_NOT_READY")
+        return evidence_id
+
     def _ingest(
         self,
         provider: MarketDataProvider,
@@ -169,7 +250,11 @@ class PersistentMarketDataService:
                 )
         try:
             bars = provider.historical_daily(instrument.symbol, start, end)
-            actions = provider.corporate_actions(instrument.symbol, start, end)
+            actions = (
+                provider.corporate_actions(instrument.symbol, start, end)
+                if provider.metadata.supports_actions
+                else []
+            )
             knowledge_time = require_utc(self.clock()) if executable_open else observed_at
             if executable_open and not self.calendar.is_executable_open_time(start, knowledge_time):
                 raise DatasetInvalid(

--- a/backend/src/quantlab/persistence.py
+++ b/backend/src/quantlab/persistence.py
@@ -114,6 +114,36 @@ class CorporateActionRecord(Base):
     new_symbol: Mapped[str | None] = mapped_column(String(32))
 
 
+class CorporateActionReadinessRecord(Base):
+    """Neměnný důkaz, že provider prověřil konkrétní interval akcí."""
+
+    __tablename__ = "corporate_action_readiness"
+    evidence_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    provider: Mapped[str] = mapped_column(String(40), nullable=False, index=True)
+    provider_version: Mapped[str] = mapped_column(String(40), nullable=False)
+    instrument_id: Mapped[str] = mapped_column(
+        ForeignKey("instruments.instrument_id", ondelete="RESTRICT"), index=True
+    )
+    requested_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    requested_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    knowledge_cutoff: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    checked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    supports_actions: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    blocking_reason: Mapped[str | None] = mapped_column(String(80))
+    action_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    __table_args__ = (
+        Index(
+            "ix_action_readiness_scope",
+            "instrument_id",
+            "provider",
+            "requested_start",
+            "requested_end",
+            "knowledge_cutoff",
+        ),
+    )
+
+
 class UniverseDefinitionRecord(Base):
     __tablename__ = "universe_definitions"
     universe_id: Mapped[str] = mapped_column(String(64), primary_key=True)

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -935,10 +935,13 @@ class Phase6PaperExecutionService:
         session_factory: Callable[[], Session],
         current_data: ValidatedCurrentDataAccessor,
         trading_cycle: TradingCycleService,
+        *,
+        require_corporate_action_readiness: bool = False,
     ) -> None:
         self._sessions = session_factory
         self.current_data = current_data
         self.trading_cycle = trading_cycle
+        self.require_corporate_action_readiness = require_corporate_action_readiness
 
     def _ensure_cycle_lineage(
         self,
@@ -1110,23 +1113,24 @@ class Phase6PaperExecutionService:
                 raise DatasetInvalid("Current universe není podporovaný USD/XNYS equity scope")
             from quantlab.persistence import CorporateActionReadinessRecord
 
-            readiness = tuple(
-                session.scalars(
-                    select(CorporateActionReadinessRecord).where(
-                        CorporateActionReadinessRecord.instrument_id.in_(execution_instruments),
-                        CorporateActionReadinessRecord.requested_start <= snapshot.start_at,
-                        CorporateActionReadinessRecord.requested_end
-                        >= datetime.combine(timing.signal_session, time(), UTC),
-                        CorporateActionReadinessRecord.knowledge_cutoff == decision_time,
-                        CorporateActionReadinessRecord.checked_at <= as_of,
-                        CorporateActionReadinessRecord.supports_actions == 1,
-                        CorporateActionReadinessRecord.status == "COMPLETE",
+            if self.require_corporate_action_readiness:
+                readiness = tuple(
+                    session.scalars(
+                        select(CorporateActionReadinessRecord).where(
+                            CorporateActionReadinessRecord.instrument_id.in_(execution_instruments),
+                            CorporateActionReadinessRecord.requested_start <= snapshot.start_at,
+                            CorporateActionReadinessRecord.requested_end
+                            >= datetime.combine(timing.signal_session, time(), UTC),
+                            CorporateActionReadinessRecord.knowledge_cutoff == decision_time,
+                            CorporateActionReadinessRecord.checked_at <= as_of,
+                            CorporateActionReadinessRecord.supports_actions == 1,
+                            CorporateActionReadinessRecord.status == "COMPLETE",
+                        )
                     )
                 )
-            )
-            ready_instruments = {item.instrument_id for item in readiness}
-            if ready_instruments != set(execution_instruments):
-                raise DatasetInvalid("CORPORATE_ACTIONS_NOT_READY")
+                ready_instruments = {item.instrument_id for item in readiness}
+                if ready_instruments != set(execution_instruments):
+                    raise DatasetInvalid("CORPORATE_ACTIONS_NOT_READY")
             action_rows = tuple(
                 session.scalars(
                     select(CorporateActionRecord).where(

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, time
 from decimal import Decimal
 from uuid import uuid4
 
@@ -1108,6 +1108,25 @@ class Phase6PaperExecutionService:
                 for item in instruments.values()
             ):
                 raise DatasetInvalid("Current universe není podporovaný USD/XNYS equity scope")
+            from quantlab.persistence import CorporateActionReadinessRecord
+
+            readiness = tuple(
+                session.scalars(
+                    select(CorporateActionReadinessRecord).where(
+                        CorporateActionReadinessRecord.instrument_id.in_(execution_instruments),
+                        CorporateActionReadinessRecord.requested_start <= snapshot.start_at,
+                        CorporateActionReadinessRecord.requested_end
+                        >= datetime.combine(timing.signal_session, time(), UTC),
+                        CorporateActionReadinessRecord.knowledge_cutoff == decision_time,
+                        CorporateActionReadinessRecord.checked_at <= as_of,
+                        CorporateActionReadinessRecord.supports_actions == 1,
+                        CorporateActionReadinessRecord.status == "COMPLETE",
+                    )
+                )
+            )
+            ready_instruments = {item.instrument_id for item in readiness}
+            if ready_instruments != set(execution_instruments):
+                raise DatasetInvalid("CORPORATE_ACTIONS_NOT_READY")
             action_rows = tuple(
                 session.scalars(
                     select(CorporateActionRecord).where(

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -937,11 +937,13 @@ class Phase6PaperExecutionService:
         trading_cycle: TradingCycleService,
         *,
         require_corporate_action_readiness: bool = False,
+        corporate_action_provider_identity: tuple[str, str] | None = None,
     ) -> None:
         self._sessions = session_factory
         self.current_data = current_data
         self.trading_cycle = trading_cycle
         self.require_corporate_action_readiness = require_corporate_action_readiness
+        self.corporate_action_provider_identity = corporate_action_provider_identity
 
     def _ensure_cycle_lineage(
         self,
@@ -1114,10 +1116,15 @@ class Phase6PaperExecutionService:
             from quantlab.persistence import CorporateActionReadinessRecord
 
             if self.require_corporate_action_readiness:
+                if self.corporate_action_provider_identity is None:
+                    raise DatasetInvalid("CORPORATE_ACTION_PROVIDER_IDENTITY_MISSING")
+                provider_name, provider_version = self.corporate_action_provider_identity
                 readiness = tuple(
                     session.scalars(
                         select(CorporateActionReadinessRecord).where(
                             CorporateActionReadinessRecord.instrument_id.in_(execution_instruments),
+                            CorporateActionReadinessRecord.provider == provider_name,
+                            CorporateActionReadinessRecord.provider_version == provider_version,
                             CorporateActionReadinessRecord.requested_start <= snapshot.start_at,
                             CorporateActionReadinessRecord.requested_end
                             >= datetime.combine(timing.signal_session, time(), UTC),

--- a/backend/tests/phase6_audit_helpers.py
+++ b/backend/tests/phase6_audit_helpers.py
@@ -33,7 +33,7 @@ class MappingProvider:
 
     @property
     def metadata(self) -> ProviderMetadata:
-        return ProviderMetadata(self.name, "1", False, False)
+        return ProviderMetadata(self.name, "1", True, False)
 
     def resolve(self, symbol: str) -> dict[str, str]:
         return {"symbol": symbol}
@@ -97,6 +97,9 @@ def seed_phase6_snapshot(
             min(observed_at, CALENDAR.session_close(day)),
         )
         assert result.status == "SUCCEEDED"
+    market_data.verify_corporate_action_readiness(
+        provider, instrument, sessions[0], sessions[-1], observed_at
+    )
     universe_id = f"universe-{suffix}"
     with factory() as session, session.begin():
         session.add(

--- a/backend/tests/test_h2_corporate_action_readiness_postgres.py
+++ b/backend/tests/test_h2_corporate_action_readiness_postgres.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from quantlab.market_data import (
+    AssetType,
+    CorporateAction,
+    CorporateActionKind,
+    DatasetInvalid,
+    Instrument,
+    ProviderMetadata,
+    ProviderUnavailable,
+    StooqProvider,
+)
+from quantlab.market_data_service import PersistentMarketDataService
+from quantlab.persistence import CorporateActionReadinessRecord, InstrumentRecord
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("RUN_POSTGRES_TESTS") != "1", reason="vyžaduje PostgreSQL CI"
+)
+
+
+@dataclass
+class ActionProvider:
+    supports: bool
+    actions: list[CorporateAction]
+    fails: bool = False
+
+    @property
+    def metadata(self) -> ProviderMetadata:
+        return ProviderMetadata(f"h2-{self.supports}-{self.fails}", "1", self.supports, False)
+
+    def resolve(self, symbol: str) -> dict[str, str]:
+        return {"symbol": symbol}
+
+    def historical_daily(self, symbol, start, end):  # type: ignore[no-untyped-def]
+        return []
+
+    def corporate_actions(self, symbol, start, end):  # type: ignore[no-untyped-def]
+        if self.fails:
+            raise ProviderUnavailable("simulované selhání actions API")
+        return self.actions
+
+
+@pytest.fixture
+def scope():
+    engine = create_engine(os.environ["DATABASE_URL"])
+    factory = sessionmaker(engine, expire_on_commit=False)
+    suffix = uuid4().hex
+    instrument = Instrument(
+        f"h2-{suffix}", "H2A", "XNYS", "XNYS", "USD", AssetType.EQUITY, date(2020, 1, 1)
+    )
+    with factory() as session, session.begin():
+        session.add(
+            InstrumentRecord(
+                instrument_id=instrument.instrument_id,
+                symbol=instrument.symbol,
+                exchange="XNYS",
+                calendar="XNYS",
+                currency="USD",
+                asset_type="EQUITY",
+                active_from=datetime(2020, 1, 1, tzinfo=UTC),
+                active_to=None,
+                created_at=datetime(2020, 1, 1, tzinfo=UTC),
+            )
+        )
+    return factory, instrument
+
+
+@pytest.mark.parametrize("kind", [CorporateActionKind.SPLIT, CorporateActionKind.CASH_DIVIDEND])
+def test_unsupported_provider_is_not_empty_complete_even_with_hidden_event(scope, kind) -> None:
+    factory, instrument = scope
+    cutoff = datetime(2026, 8, 26, 20, tzinfo=UTC)
+    hidden = CorporateAction(
+        uuid4().hex,
+        instrument.instrument_id,
+        kind,
+        datetime(2026, 8, 20, tzinfo=UTC),
+        datetime(2026, 8, 19, tzinfo=UTC),
+        Decimal("2") if kind == CorporateActionKind.SPLIT else Decimal("1.25"),
+    )
+    service = PersistentMarketDataService(factory, clock=lambda: cutoff)
+    with pytest.raises(DatasetInvalid, match="CORPORATE_ACTIONS_UNSUPPORTED"):
+        service.verify_corporate_action_readiness(
+            ActionProvider(False, [hidden]), instrument, date(2026, 8, 1), date(2026, 8, 26), cutoff
+        )
+    with factory() as session:
+        evidence = session.scalar(
+            select(CorporateActionReadinessRecord).where(
+                CorporateActionReadinessRecord.instrument_id == instrument.instrument_id
+            )
+        )
+        assert evidence is not None
+        assert evidence.status == "UNSUPPORTED"
+        assert evidence.action_count == 0
+
+
+@pytest.mark.parametrize("actions", [[], ["split"]])
+def test_capable_provider_can_prove_empty_or_pit_valid_actions(scope, actions) -> None:
+    factory, instrument = scope
+    cutoff = datetime(2026, 8, 26, 20, tzinfo=UTC)
+    payload = (
+        []
+        if not actions
+        else [
+            CorporateAction(
+                uuid4().hex,
+                instrument.instrument_id,
+                CorporateActionKind.SPLIT,
+                datetime(2026, 8, 20, tzinfo=UTC),
+                datetime(2026, 8, 19, tzinfo=UTC),
+                Decimal("2"),
+            )
+        ]
+    )
+    service = PersistentMarketDataService(factory, clock=lambda: cutoff)
+    first = service.verify_corporate_action_readiness(
+        ActionProvider(True, payload), instrument, date(2026, 8, 1), date(2026, 8, 26), cutoff
+    )
+    second = service.verify_corporate_action_readiness(
+        ActionProvider(True, payload), instrument, date(2026, 8, 1), date(2026, 8, 26), cutoff
+    )
+    assert first == second
+    with factory() as session:
+        evidence = session.get(CorporateActionReadinessRecord, first)
+        assert evidence is not None and evidence.status == "COMPLETE"
+        assert evidence.action_count == len(payload)
+
+
+def test_action_api_failure_is_persisted_and_fails_closed(scope) -> None:
+    factory, instrument = scope
+    cutoff = datetime(2026, 8, 26, 20, tzinfo=UTC)
+    with pytest.raises(ProviderUnavailable):
+        PersistentMarketDataService(
+            factory, clock=lambda: cutoff
+        ).verify_corporate_action_readiness(
+            ActionProvider(True, [], fails=True),
+            instrument,
+            date(2026, 8, 1),
+            date(2026, 8, 26),
+            cutoff,
+        )
+    with factory() as session:
+        evidence = session.scalar(
+            select(CorporateActionReadinessRecord).where(
+                CorporateActionReadinessRecord.instrument_id == instrument.instrument_id
+            )
+        )
+        assert evidence is not None
+        assert evidence.status == "FAILED"
+        assert evidence.blocking_reason == "CORPORATE_ACTIONS_UNAVAILABLE"
+
+
+def test_standard_stooq_is_explicitly_unsupported(scope) -> None:
+    factory, instrument = scope
+    cutoff = datetime(2026, 8, 26, 20, tzinfo=UTC)
+    with pytest.raises(DatasetInvalid, match="CORPORATE_ACTIONS_UNSUPPORTED"):
+        PersistentMarketDataService(
+            factory, clock=lambda: cutoff
+        ).verify_corporate_action_readiness(
+            StooqProvider(lambda url, timeout: pytest.fail("unsupported provider se nesmí volat")),
+            instrument,
+            date(2026, 8, 1),
+            date(2026, 8, 26),
+            cutoff,
+        )

--- a/backend/tests/test_phase7_e2e_postgres.py
+++ b/backend/tests/test_phase7_e2e_postgres.py
@@ -103,7 +103,11 @@ def _full_multi_session_flow(
         instrument_allowlist=frozenset({instrument.instrument_id}),
     )
     execution = Phase6PaperExecutionService(
-        factory, ValidatedCurrentDataAccessor(factory), TradingCycleService(repository, risk)
+        factory,
+        ValidatedCurrentDataAccessor(factory),
+        TradingCycleService(repository, risk),
+        require_corporate_action_readiness=True,
+        corporate_action_provider_identity=(f"p7-{instrument.symbol}", "1"),
     )
     performance = PaperPerformanceService(factory, ValidatedCurrentDataAccessor(factory))
     evaluation = PaperPerformanceEvaluationService(factory)
@@ -133,6 +137,16 @@ def _full_multi_session_flow(
             .ingest(provider, instrument, session_day, session_day, observed_at)
             .status
             == "SUCCEEDED"
+        )
+        signal_session = CALENDAR.previous_session(session_day)
+        PersistentMarketDataService(
+            factory, clock=lambda execution_as_of=execution_as_of: execution_as_of
+        ).verify_corporate_action_readiness(
+            provider,
+            instrument,
+            source_snapshot.start_at.date(),
+            signal_session,
+            CALENDAR.session_close(signal_session),
         )
         _seed_opening_observation(factory, instrument.instrument_id, session_day, price)
         execution.run(deployment.deployment_id, execution_as_of)

--- a/backend/tests/test_phase7_e2e_postgres.py
+++ b/backend/tests/test_phase7_e2e_postgres.py
@@ -144,7 +144,7 @@ def _full_multi_session_flow(
         ).verify_corporate_action_readiness(
             provider,
             instrument,
-            source_snapshot.start_at.date(),
+            source_snapshot.start,
             signal_session,
             CALENDAR.session_close(signal_session),
         )

--- a/docs/market-data.md
+++ b/docs/market-data.md
@@ -17,6 +17,12 @@ Snapshot ukládá `as_of`, provider, calendar identity, PIT universe, rozsah, co
 ## Persistentní runtime a známé omezení
 Produkční `PersistentMarketDataService` zapisuje ingestion, immutable revisions a corporate actions v jedné DB transakci. Deterministický scope identifikátor dělá restart stejného požadavku idempotentní; PostgreSQL advisory transaction lock serializuje stejný scope. Selhání se audituje jako `FAILED` bez observation řádků. In-memory adapter je pouze testovací/reference adapter.
 
+Úspěšný price ingestion není důkazem úplnosti corporate actions. Samostatná immutable
+`corporate_action_readiness` evidence rozlišuje `COMPLETE`, `UNSUPPORTED` a `FAILED` pro provider,
+instrument, interval a knowledge cutoff. Prázdný seznam je complete pouze po úspěšném volání
+provideru s `supports_actions=True`; podrobnosti popisuje
+[`operational-readiness-remediation-h2-corporate-action-gate.md`](operational-readiness-remediation-h2-corporate-action-gate.md).
+
 `DatasetSnapshotService` vybírá přes SQL window autoritativní revision známou k `as_of`. Coverage denominator je průnik session, active intervalu instrumentu a membership intervalu známého k `as_of`, nikoli kartézský součin. Prázdný nebo nedostatečně pokrytý snapshot je `INVALID`.
 
 Kalendář zachovává interní XNYS adapter, ale autoritativní schedule poskytuje zamknutá maintained knihovna `exchange-calendars`.

--- a/docs/operational-readiness-remediation-h2-corporate-action-gate.md
+++ b/docs/operational-readiness-remediation-h2-corporate-action-gate.md
@@ -1,0 +1,61 @@
+# Operational Readiness H2-A — corporate-action readiness gate
+
+## Root cause a rozsah
+
+Stooq správně deklaroval `supports_actions=False`, ale jeho `corporate_actions()` vracelo `[]`.
+Ingestion i autonomní `PREPARE_PAPER_SESSION` prázdný výsledek nerozlišovaly od autoritativního
+potvrzení, že v intervalu žádná akce nenastala. Phase 6 následně upravila signal prices pouze podle
+řádků, které už v databázi existovaly, a mohla vytvořit paper order bez důkazu úplnosti. Úspěšné
+načtení barů tak bylo chybně použitelné jako implicitní action readiness.
+
+Tato změna řeší **unsafe H2 execution path — RESOLVED**. Nezavádí externí zdroj corporate actions;
+**production corporate-action source — STILL OPEN**. Celkový systém proto není deklarován jako
+production-ready.
+
+## Tři odlišné stavy
+
+1. `supports_actions=True` a úspěšná odpověď vytvoří `COMPLETE` evidence pro přesný provider,
+   instrument, interval a knowledge cutoff.
+2. Stejná úspěšná odpověď smí obsahovat `[]`; jde o legitimní **empty-but-complete** interval.
+3. `supports_actions=False` vytvoří `UNSUPPORTED` evidence s důvodem
+   `CORPORATE_ACTIONS_UNSUPPORTED`. Metoda provideru se v tomto stavu vůbec nepoužije jako důkaz.
+
+Chyba capable provideru vytvoří `FAILED` evidence s důvodem `CORPORATE_ACTIONS_UNAVAILABLE` a
+propaguje chybu do stávající retry cesty. Staré action řádky samy o sobě readiness nikdy
+neprokazují.
+
+## Evidence, idempotence a PIT
+
+Tabulka `corporate_action_readiness` je oddělená od price-ingestion statusu. Deterministické ID je
+hash provider identity a verze, instrumentu, kontrolovaného intervalu, UTC knowledge cutoffu,
+výsledku a identity vrácených akcí.
+Opakovaná kontrola stejného scope proto nevytváří duplicity. Evidence obsahuje capability,
+`checked_at`, výsledek, blocking reason a počet přijatých akcí.
+
+Provider smí pro action-complete scope vrátit pouze akce stejného instrumentu s
+`known_at <= knowledge_cutoff`. Future-known split nebo dividenda kontrolu zneplatní; nedostane se
+do adjusted-price ani paper-ledger cesty. Snapshot a Phase 6 nadále používají pouze kauzálně známé
+akce.
+
+## Dvě fail-closed brány
+
+`PREPARE_PAPER_SESSION` před vytvořením executable occurrence ověřuje všechny equity instrumenty
+z PIT universe i držených pozic. Scope začíná na začátku pinovaného snapshotu a končí signal
+session. Unsupported Stooq vrátí auditovatelný `NOT_READY / CORPORATE_ACTIONS_UNSUPPORTED`; žádný
+execution run se nematerializuje.
+
+`Phase6PaperExecutionService` důkaz kontroluje znovu před strategií, aplikací corporate actions a
+trading cycle. Vyžaduje `COMPLETE`, capable evidence pro každý executable instrument, pokrytí
+požadovaného intervalu, přesný decision-time cutoff a kontrolu provedenou nejpozději v execution
+čase. Scheduler/worker race ani přímé obejití prepare brány proto nemůže mít ekonomický efekt.
+
+`PaperCorporateActionService` zůstává jedinou cestou, která mění paper quantity, cost basis nebo
+dividend cash. Nová readiness evidence nic neúčtuje a nevytváří paralelní ledger.
+
+## Standardní Stooq a zbývající práce
+
+Standardní Stooq má nadále `supports_actions=False`. Autonomní equity deployment přes něj je nyní
+záměrně `NOT_READY`; raw ani případně adjusted cena není náhradou za prokazatelnou úplnost akcí.
+Pro skutečné production nasazení je stále nutné dodat a samostatně validovat production provider
+corporate actions s úplností intervalu, stabilní identitou a PIT `known_at` metadaty. Tento PR
+nepřidává live broker, live flag, H3, ML ani jinou execution cestu.

--- a/docs/operational-readiness-remediation-h2-corporate-action-gate.md
+++ b/docs/operational-readiness-remediation-h2-corporate-action-gate.md
@@ -47,7 +47,9 @@ execution run se nematerializuje.
 `Phase6PaperExecutionService` důkaz kontroluje znovu před strategií, aplikací corporate actions a
 trading cycle. Vyžaduje `COMPLETE`, capable evidence pro každý executable instrument, pokrytí
 požadovaného intervalu, přesný decision-time cutoff a kontrolu provedenou nejpozději v execution
-čase. Scheduler/worker race ani přímé obejití prepare brány proto nemůže mít ekonomický efekt.
+čase. Evidence se navíc musí shodovat se jménem i verzí provideru, které production executor
+získal ze stejné provider factory; complete evidence jiného provideru proto gate neodemkne.
+Scheduler/worker race ani přímé obejití prepare brány proto nemůže mít ekonomický efekt.
 
 `PaperCorporateActionService` zůstává jedinou cestou, která mění paper quantity, cost basis nebo
 dividend cash. Nová readiness evidence nic neúčtuje a nevytváří paralelní ledger.


### PR DESCRIPTION
### Motivation
- Opravit bezpečnostní nedostatek, kdy `supports_actions=False` (např. Stooq) byl nesprávně považován za ekvivalent „žádné corporate actions“, čímž mohlo dojít k autonomnímu equity execution bez důkazu úplnosti akcí.
- Zajistit deterministickou, auditovatelnou a idempotentní evidence úplnosti corporate actions vázanou na provider, instrument, interval a knowledge‑cutoff tak, aby chybějící completeness vedla k fail‑closed chování.
- Přidat fail‑closed kontrolu na orchestrace i doménové hranici (PREPARE_PAPER_SESSION i Phase6PaperExecutionService) a zachovat stávající paper‑ledger a PIT/no‑lookahead invarianty.

### Description
- Přidána nová ORM třída `CorporateActionReadinessRecord` a Alembic migrace `20260827_01_h2_action_readiness.py` pro neměnnou evidence úplnosti corporate actions v DB.
- Implementována metoda `PersistentMarketDataService.verify_corporate_action_readiness(...)`, která vytvoří deterministické evidence_id, volá provider API jen pro `supports_actions==True`, validuje `known_at <= knowledge_cutoff`, persistuje akce a uloží status `COMPLETE|UNSUPPORTED|FAILED` s blokujícím důvodem.
- Upraven `PersistentMarketDataService._ingest` tak, aby se nefallbackovalo na prázdný seznam akcí pro provider s `supports_actions==False` (actions se volají jen u capable providerů) a aby ingestion nezaměňoval price ingestion za action completeness.
- Změny v orchestrace: `PREPARE_PAPER_SESSION` nyní volá `verify_corporate_action_readiness` pro každý equity instrument v PIT/universe a při chybě vrací `NOT_READY` s explicitním `no_action_reason` (preferovaný důvod `CORPORATE_ACTIONS_UNSUPPORTED`), včetně auditovatelného `corporate_action_evidence_ids` ve výsledku.
- Změny v doméně: `Phase6PaperExecutionService.run` nyní před aplikací strategie vyžaduje existenci `COMPLETE` readiness evidence pro všechna executable instrumenta a failne closed s `CORPORATE_ACTIONS_NOT_READY`, čímž se zabraňuje bypassu nebo race scénáři.
- Testy a dokumentace: přidán integrační PostgreSQL test `backend/tests/test_h2_corporate_action_readiness_postgres.py` pokrývající Stooq unsupported, capable provider (empty i non‑empty), provider failure; doplněna dokumentace `docs/operational-readiness-remediation-h2-corporate-action-gate.md` a upraven `docs/market-data.md`; CI krok `H2 corporate-action capability/readiness acceptance` přidán do `integration-postgres` workflow.

### Testing
- Statické a syntaktické kontroly proběhly lokálně úspěšně: `ruff format` a `ruff check` prošly a `python -m compileall` také proběhl bez chyb.
- Typová kontrola `mypy` hlásila chybějící závislosti (např. SQLAlchemy, FastAPI, exchange_calendars, pyarrow) v tomto prostředí, takže úplné mypy ověření nebylo dokončeno; to je environmentální omezení, nikoli regresní chyba v logice.
- Snažil jsem se spustit pinned dependency sync (`uv sync --locked --all-groups`) a spustit PostgreSQL acceptance tests, ale instalace požadované `uv==0.12.3` selhala kvůli omezením prostředí/registry (proxy 403), takže integrační PostgreSQL testy nebyly vykonány v tomto běhu; nově přidané acceptance testy a CI krok jsou připravené k běhu v CI s funkčním prostředím.
- Lokální unit/integration příprava zahrnovala běh reformátování, kontrol a kompilace a commitování změn; nová větev `remediation/corporate-action-readiness-gate` obsahuje změny a testy připravené pro CI ověření.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a90423a12c48332bea8b00ddf75a607)