### PR TITLE
Refresh combined-tree pre-pilot forensic re-audit and update runbook/docs

### DIFF
--- a/docs/paper-pilot-runbook.md
+++ b/docs/paper-pilot-runbook.md
@@ -7,6 +7,8 @@ deployment, jeden scheduler/worker a aktivní lidský dohled. Nezakládá ani ne
 
 - Použijte pouze commit se zelenými CI jobs `quality`, `unit-research`, `api`,
   `integration-postgres`, `frontend`, `security`, `container-build` a `production-smoke`.
+- Pro auditovaný head `6ed177a81d89fe2ac367e236435286dc31c7ad49` je referenčním důkazem
+  úspěšný GitHub Actions run #435; při jakékoli další změně je povinný nový zelený běh na novém SHA.
 - Připravte PostgreSQL 17, HTTPS ingress, persistentní volume, ověřený backup/restore a oddělenou
   least-privilege runtime roli podle `scripts/configure-runtime-role.sql`.
 - Vygenerujte unikátní silné viewer/operator/admin tokeny a DB secret mimo Git. Nikdy nepoužívejte
@@ -48,7 +50,10 @@ correlation ID. Operátor nesmí používat demo endpointy ani přímé SQL.
 6. Vytvořte deployment pro `paper-main`. Nezávisle zkontrolujte runtime manifest: experiment,
    snapshot, universe, strategy/version, parameters, risk, commission, slippage, volume fraction,
    code SHA a hash. Poté jej schvalte s důvodem.
-7. Vytvořte monitoring policy, enrollment a ověřte stav `ACTIVE` a oddělenou OOS baseline.
+7. Vytvořte monitoring policy a enrollment. Enrollment musí idempotentně vrátit existující
+   aktivní záznam nebo vytvořit nový a současně zajistit scheduled job typu
+   `MONITOR_PAPER_DEPLOYMENT`; ověřte `ACTIVE`, schedule a oddělenou OOS baseline. Nový enrollment
+   po ukončení je dovolen až po stavu `RETIRED`, nikdy jako druhý souběžný aktivní záznam.
 8. Zapněte autonomous scheduling přes `/operator/deployments/{id}/autonomous/enable`.
 
 ## 5. Pre-session a daily operator check
@@ -84,8 +89,12 @@ reconciliation. Chybějící run není důvod k ručnímu zpětnému fillu.
 - **DB outage:** nejprve obnovte DB a readiness, pak worker. Před RESUME spusťte reconciliation.
 - **Dead letter:** opravte příčinu, ověřte data/manifest/monitoring a použijte auditovaný retry se
   stejnou ekonomickou identitou.
-- **Reconciliation mismatch:** účet zůstává HALTED. Obnovte z ověřené evidence/backup procesu;
-  RESUME smí následovat pouze po SAFE reconciliation a nezávislé kontrole.
+- **Reconciliation mismatch:** účet zůstává HALTED. Použijte auditovanou operátorskou akci
+  `POST /operator/reconciliation/run`, odstraňte příčinu podle evidence a nikdy neměňte stav
+  přímým SQL. RESUME smí následovat pouze po autoritativní SAFE reconciliation a nezávislé kontrole.
+- **Suspended monitoring:** ponechte execution zastavenou, vyřešte příčinu a použijte pouze
+  auditovanou monitoring transition. Je-li lifecycle ukončen, nejprve jej převeďte do `RETIRED` a
+  teprve potom proveďte nové enrollment; ověřte právě jeden ACTIVE record a monitoring schedule.
 
 Jednou během pilotu proveďte plánovaný recovery drill: worker claimne neekonomický nebo bezpečně
 idempotentní staging job, je ukončen, lease expiruje a nový worker dokončí stejnou occurrence bez

--- a/docs/pre-pilot-forensic-reaudit.md
+++ b/docs/pre-pilot-forensic-reaudit.md
@@ -2,237 +2,142 @@
 
 ## Executive verdict
 
-**CONDITIONAL READY FOR PAPER PILOT**
+**CONDITIONAL READY FOR CONTROLLED PAPER PILOT**
 
-Tento verdikt platí pro stav po odstranění nalezené přímé legacy execution cesty. Pilot není
-bezpodmínečně připraven: v auditním prostředí nebyl dostupný Docker/PostgreSQL ani uzamčený
-Python toolchain, a proto zde nelze označit clean-database tok ani production container runtime
-za `END-TO-END PASS`. Před pilotem musí CI na výsledném commitu dodat chybějící důkaz.
+Na kombinovaném stromu nejsou po nové kontrole známé otevřené P0/P1 blokery. Podmínkou startu
+zůstává úspěšný staging dry-run a splnění provozních gateů v
+`docs/paper-pilot-runbook.md`; jejich nesplnění automaticky mění verdikt na **NOT READY**.
 
-## Audited commit
+## Auditovaný strom a důkazy
 
-Výchozí auditovaný commit: `6d4b3ed778809204930f1151c2b211c91ea1df14` (lokální větev
-`work`). Repository nemělo nakonfigurovaný remote ani lokální větev `main`; načtení novějšího
-`origin/main` proto bylo `UNVERIFIED`. Auditovaný strom obsahoval merge PR #61 (M1), nikoli
-samostatný merge PR #62. Změny tohoto re-auditu jsou popsány v Git commitu, který obsahuje tento
-dokument.
+- PR #63 head: `6ed177a81d89fe2ac367e236435286dc31c7ad49`.
+- Merge-base/current `main`: `2227aa5b36c14cec0a2482b98926843d2cccec99`, merge PR #62.
+- Strom tedy obsahuje M4 operator-control-plane implementaci i všechny review opravy PR #62 a
+  změny PR #63, zejména odstranění legacy paper execution route.
+- GitHub Actions run **#435** na tomto headu skončil úspěšně pro `quality`, `unit-research`,
+  `api`, `frontend`, `security`, `container-build`, `integration-postgres` a
+  `production-smoke`. Tento běh je autoritativním runtime důkazem auditu.
 
-## Scope
+Evidence je označena jako `CODE INSPECTION PASS`, `CI #435 PASS` nebo `OPERATIONAL GATE`.
+Audit zahrnul aplikační služby, API/RBAC, migrace, scheduler/worker, Phase 3–9 a acceptance testy,
+production kontejnery, frontend server actions/read models a historii PR #62.
 
-Byly přečteny aplikační moduly, Alembic migrace, API a security middleware, worker/scheduler,
-Phase 3–9 testy, oba Dockerfile, production compose, CI, frontend server actions a operátorské
-stránky. Repo bylo prohledáno na live brokery, credentials, order routing a legacy ekonomické
-cesty. Historické dokumenty byly použity jen jako navigace; status níže vychází z implementace.
+## PAPER-only architektura
 
-Úroveň evidence je vždy explicitní: `CODE INSPECTION PASS`, `UNIT TEST PASS`,
-`POSTGRES ACCEPTANCE PASS`, `CONTAINER RUNTIME PASS`, `END-TO-END PASS` nebo `UNVERIFIED`.
+Repository scan potvrzuje pouze `PaperBroker`/`PersistentPaperBroker`; nebyla nalezena live role,
+live endpoint ani live broker cesta. Ekonomický tok zůstává Strategy → Portfolio → RiskEngine →
+ExecutionEngine → PaperBroker. Veřejná legacy mutation `POST /demo/trading/cycles/run-paper`, která
+spouštěla fixture mimo deployment/monitoring autoritu, je odstraněna. AST regresní test ověřuje,
+že se route nevrátí. Stav: **CODE INSPECTION PASS + CI #435 PASS**.
 
-## Evidence summary
+## Revalidace nálezů B1–M4
 
-| Evidence | Výsledek |
+| Finding | Stav na kombinovaném stromu | Revalidovaný důkaz |
+| --- | --- | --- |
+| B1 | RESOLVED | Operator control plane vytváří instrument → PIT universe → ingestion → immutable snapshot → experiment → eligibility/promotion → deployment → monitoring; PostgreSQL acceptance v CI #435. |
+| B2 | RESOLVED | Worker přijímá approved deployment ID a rekonstruuje konfiguraci server-side; nepřijímá klientský ekonomický payload. |
+| P0-A | RESOLVED | Close-derived decision používá nejdříve next-session raw open; missed open failuje closed. |
+| P0-B | RESOLVED | Production worker, heartbeat, lease/fencing, compose a smoke evidence prošly CI #435. |
+| H1 | RESOLVED | Autonomous preparation provádí allowlisted refresh a staleness gate. |
+| H2 | RESOLVED | Corporate-action capability/readiness a `known_at` cutoff jsou persistentní a fail-closed. |
+| H3 | RESOLVED | Approval i execution znovu ověřují kanonický runtime manifest, hash a lineage. |
+| M1 | RESOLVED | Eligibility je immutable server-side policy decision; promotion revaliduje přesný decision/hash. |
+| M2 | RESOLVED | Operator mutations odvozují actor z principalu a ukládají reason, result a correlation evidence. |
+| M3 | RESOLVED | Backend XNYS calendar pokrývá session, holiday, DST a early-close pravidla. |
+| M4 | RESOLVED | UI a API pokrývají podporovaný create/approve/enroll/operate/recover workflow; PR #62 review opravy jsou přítomné a CI #435 prošlo. |
+
+## M4 a review-remediation audit
+
+### Úplný operátorský tok
+
+Server actions používají serverovou session, same-origin kontrolu a role-specific bearer token.
+ADMIN může vytvořit instrument, universe a PIT membership, ingestion a snapshot, experiment,
+eligibility a promotion, deployment a approval, monitoring policy/enrollment a autonomous job.
+Viewer zůstává read-only; HALT dovoluje OPERATOR/ADMIN, ostatní control mutations vyžadují ADMIN.
+Identita aktéra nevzniká z request body. **CODE INSPECTION PASS + CI #435 PASS**.
+
+### Bounded read models a identifikátory
+
+Operator read models používají serverové limity/paginaci a dashboard již neprovádí N+1 deployment
+fetch. Data view omezuje memberships. `universe_id` create contract dovoluje pouze URL-safe
+znaky a frontend route segmenty jsou bezpečně kódované; ID se neskládá do neověřené cesty.
+Auditní stránka zachovává filtry při stránkování a backend stabilně řadí shodné timestampy.
+**CODE INSPECTION PASS + CI #435 PASS**.
+
+### Monitoring scheduling a lifecycle
+
+Enrollment je idempotentní pro aktivní záznam a atomicky zajistí plánovaný
+`MONITOR_PAPER_DEPLOYMENT` job. Nevrací tedy úspěch bez monitorovacího schedule. Po `RETIRED` lze
+bezpečně vytvořit nové enrollment; `SUSPENDED` záznam nabízí auditované recovery transitions.
+Execution stále vyžaduje právě jeden `ACTIVE` monitoring record a před ekonomickým krokem jej
+znovu načte. **CODE INSPECTION PASS + PostgreSQL CI #435 PASS**.
+
+### Reconciliation, retry a worker recovery
+
+UI recovery volá autoritativní `POST /operator/reconciliation/run`; nepřepisuje DB stav.
+Reconciliation mismatch drží účet HALTED a RESUME vyžaduje nový `SAFE` výsledek. Occurrence,
+cycle a order/fill identity zajišťují idempotenci; conditional claim, owner, expiry, heartbeat a
+fencing brání souběžnému či starému workeru v dokončení. Expired lease může převzít právě nový
+worker, bounded retry končí dead-letter a nezakládá novou ekonomickou identitu.
+**CODE INSPECTION PASS + integration-postgres/production-smoke CI #435 PASS**.
+
+### Audit semantics
+
+Operator mutations zapisují server-derived actor, explicitní reason, entity/result a correlation
+ID. Monitoring enrollment audituje jak enrollment, tak zajištění schedule; transition,
+reconciliation, autonomous enable/disable, HALT/RESUME a výzkumný/deployment workflow jsou
+dohledatelné. Recovery se nesmí provádět přímým SQL. **CODE INSPECTION PASS + CI #435 PASS**.
+
+## Phase 1–9 souhrn
+
+1. **Data/PIT:** stabilní instrument identity; ingestion status/provider/version; memberships
+   řežené `decision_time`; adjusted signal data a raw executable OHLC jsou oddělené.
+2. **Snapshot:** immutable manifest/content hash a tamper validace.
+3. **Research:** chronologický split, seed/code SHA/cost model; OOS není použit k výběru.
+4. **Risk/execution:** deterministic cycle fingerprint, persistentní risk decisions, paper ledger,
+   reconciliation a zákaz přímé broker cesty.
+5. **Automation:** persistent occurrence, bounded retry, conditional claim, lease/fencing,
+   heartbeat a dead-letter evidence.
+6. **Promotion/deployment:** server policy registry, immutable eligibility, exact lineage a
+   kanonický approved runtime manifest.
+7. **Monitoring:** oddělený OOS baseline a realized paper performance, ACTIVE gate a recovery
+   state machine.
+8. **Operator UI:** kompletní podporovaný workflow a recovery controls po M4/PR #62.
+9. **Security/operations:** fail-closed production config, RBAC, no-store/correlation/rate limits,
+   non-root read-only containers, oddělená data síť a minimální CI permissions.
+
+Všechny oblasti jsou **CODE INSPECTION PASS + CI #435 PASS**. Audit nezjistil nové P0/P1/P2.
+
+## Failure-mode kontrola
+
+| Scénář | Očekávaný a ověřený výsledek |
 | --- | --- |
-| Git SHA, historie a pracovní strom | `CODE INSPECTION PASS`; remote/main `UNVERIFIED` |
-| Paper-only repository scan | `CODE INSPECTION PASS` po remediation; pouze `PaperBroker`/`PersistentPaperBroker` |
-| Přímá legacy paper mutation | Nalezena na baseline, reprodukce `POST /demo/trading/cycles/run-paper`; odstraněna a kryta AST regresí |
-| Python format/lint/type/unit | `UNVERIFIED`: požadované `uv==0.12.3` nebylo instalováno; registry vracela 403 |
-| PostgreSQL acceptance a clean DB E2E | `UNVERIFIED`: PostgreSQL/Docker runtime nebyl v prostředí dostupný |
-| Frontend lint/type/test/build | `UNIT TEST PASS`: 27 testů; produkční Next build dokončen |
-| Security/dependency/secret/container scan | `UNVERIFIED` runtime; konfigurace CI obsahuje pip-audit, npm audit a Trivy secret/misconfig/image gates |
-| `git diff --check` a samostatný Ruff audit změněných Python souborů | `CODE INSPECTION PASS` / lokální Ruff po opravě importu |
+| unavailable/partial/stale provider data | bounded retry nebo no-action; žádný fill |
+| missing corporate readiness | fail closed před signal/fill |
+| snapshot/policy/manifest tamper | validation conflict; žádný deployment/fill |
+| inactive/suspended monitoring | execution odmítnuta; žádný fill |
+| duplicate worker/retry | jedna occurrence a ekonomická identity; fenced stale owner |
+| missed executable open | žádný retroaktivní fill |
+| reconciliation mismatch | HALT; RESUME až po authoritative SAFE reconciliation |
+| worker/DB restart | rollback nebo lease-expiry takeover bez duplicate effect |
+| legacy direct paper cycle | route chybí a AST regression brání návratu |
 
-## Phase 1–9 findings
+Runtime assertions pro tyto vrstvy jsou součástí úspěšných relevantních jobů CI #435.
 
-### Phase 1–3 — data, PIT universe a snapshot
+## Pilotní podmínky a residual risk
 
-`InstrumentRecord` je stabilní identita oddělená od symbolu a nese exchange, calendar, currency a
-asset type. Ingestion persistuje provider/version, interval, stav a revision evidence; runtime
-dotazy filtrují úspěšné ingestion. Membership používá `valid_from`, `valid_to` a `known_at` a
-runtime ji řeže `decision_time`. Snapshot service vytváří manifest/content hash a experiment
-validuje jeho evidence. Stav: `CODE INSPECTION PASS`; tamper a PostgreSQL concurrency assertions
-existují v Phase 3/6 suites, jejich běh zde je `UNVERIFIED`.
+CI #435 odstraňuje dřívější nejistotu o PostgreSQL, kontejnerech, security a production smoke.
+Residual risk je nyní provozní: externí market-data provider nemá SLA, pilot zatím nemá
+dlouhodobou historii a rate limiter je process-local. Proto je scope omezen na jednu backend
+instanci, jeden scheduler/worker, jeden XNYS/USD/daily deployment a aktivní lidský dohled.
 
-Corporate-action capability/readiness váže provider identity/version, interval a knowledge
-cutoff. Runtime vyžaduje přesnou readiness a filtruje actions podle `known_at <= decision_time`.
-Chybějící readiness končí výjimkou před Phase 4. Stav: `CODE INSPECTION PASS`; H2 acceptance zde
-`UNVERIFIED`.
-
-### Phase 4 — risk, execution, ledger a reconciliation
-
-Autoritou ekonomického efektu je `TradingCycleService` přes production risk engine a persistentní
-paper broker. Cycle fingerprint, databázový lease a order/fill identity chrání retry; fill vede k
-cash/position evidence a následné reconciliation. Vstupy NaN/infinity a neplatné hodnoty odmítají
-Decimal/Pydantic/doménové validace. Baseline ale vystavoval veřejně routovanou ADMIN mutation,
-která přímo volala tuto službu nad CSV fixture bez deployment/monitoring autority. To byl P0 a
-byl v tomto re-auditu odstraněn. Corruption/reconciliation runtime: `UNVERIFIED`.
-
-### Phase 5 — automation, concurrency a recovery
-
-Scheduler persistuje occurrence; claim používá podmíněný PostgreSQL update, lease owner/expiry a
-fencing. Worker přijímá deployment ID a rekonstruuje ekonomickou konfiguraci server-side.
-Heartbeat, attempts, retry a dead letter jsou persistentní a čitelné API. Stav:
-`CODE INSPECTION PASS`; duplicate-worker a expired-lease PostgreSQL testy existují, tento běh
-`UNVERIFIED`.
-
-### Phase 6 — experiment, eligibility, promotion, deployment
-
-Experiment váže snapshot, strategy/version, parametry, chronologický train/validation/OOS split,
-seed, code SHA a cost model. OOS se nepoužívá pro výběr kandidáta. M1 používá server-side policy
-registry, kanonické dokumenty, rules, metrics a integrity hash; promotion znovu validuje přesnou
-lineage a immutable decision. Deployment lze vytvořit jen z `PAPER_CANDIDATE`.
-Stav: `CODE INSPECTION PASS`; replay a M1 adversarial PostgreSQL běh `UNVERIFIED`.
-
-### Phase 7 — approval, monitoring a performance
-
-Approval je ADMIN server mutation, nikoli boolean klienta, a validuje lineage i runtime manifest.
-Execution vyžaduje právě jeden `ACTIVE` monitoring record a stav znovu čte před ekonomickým
-krokem. OOS baseline a realized paper snapshots jsou oddělené tabulky. Stav:
-`CODE INSPECTION PASS`; race transition/execution a performance acceptance `UNVERIFIED`.
-
-### Phase 8 — operator UI
-
-UI je server-rendered a mutations používají server actions, same-origin kontrolu, server session
-a backend bearer token podle role. Implementuje eligibility, promotion, risk, monitoring a
-autonomous toggle. Neimplementuje však požadovaný kompletní create workflow pro instrument,
-universe, ingestion, snapshot, experiment, deployment, approval a enrollment; data/research jsou
-v těchto částech read-only. Stav: **M4 REGRESSED / P2**. Pilot lze řídit autoritativním API, ale
-nikoli celý běžný tok pouze UI.
-
-### Phase 9 — security a operations
-
-Bearer identity vzniká server-side, GET vyžaduje VIEWER, všechny mutations ADMIN kromě HALT
-(OPERATOR). Host allowlist, response no-store, correlation ID, rate limiting a production secret
-validace failují closed. Bearer API nepoužívá cookie auth; CSRF se proto na backendu neopírá o
-cookie ambient authority, zatímco frontend server actions kontrolují origin. Containers deklarují
-non-root/read-only/cap-drop/no-new-privileges a oddělenou interní data síť. Stav:
-`CODE INSPECTION PASS`; production smoke a skeny `UNVERIFIED`.
-
-## Previous remediation verification
-
-| Finding | Status | Evidence |
-| --- | --- | --- |
-| B1 | RESOLVED | Control-plane API vytváří registry → snapshot → experiment → deployment evidence |
-| B2 | RESOLVED | Worker ekonomicky začíná autoritativním approved deployment ID |
-| B3 / P0-A | RESOLVED | Decision time a následující raw open jsou validovány; missed open failuje closed |
-| P0-B | RESOLVED | Worker entrypoint, compose service, heartbeat, lease a CI runtime acceptance existují |
-| H1 | RESOLVED | Autonomous session preparation provádí allowlisted refresh a staleness gate |
-| H2 | RESOLVED | Capability/readiness/knowledge cutoff jsou persistentní a execution gate je fail-closed |
-| H3 | RESOLVED | Kanonický approved runtime manifest/hash se před worker execution znovu ověřuje |
-| M1 | RESOLVED | Immutable policy decision a promotion revalidation jsou server-side autorita |
-| M2 | RESOLVED WITH P2 GAP | Klíčové control mutations nesou actor/reason/result/correlation; legacy non-operator mutations nejsou všechny reasoned |
-| M3 | RESOLVED | Backend XNYS calendar řeší sessions; existují DST/holiday/early-close testy |
-| M4 | REGRESSED | UI neumí celý požadovaný create/approve/enroll workflow; API jej umí |
-
-## New findings
-
-| ID | Severity | Finding | Evidence | Pilot blocker |
-| --- | --- | --- | --- | --- |
-| RA-P0-01 | P0 | Legacy fixture endpoint obcházel deployment, approval, runtime manifest, monitoring a current-data causal gate | Baseline `api.py` route přímo volala `trading_service.run` nad fixture | Ano na baseline; **opraveno** odstraněním route |
-| RA-P2-01 | P2 | M4 UI není kompletní operátorský workflow | Data/research stránky jsou read-only; chybí create deployment/approval/enrollment UI | Ne při API runbooku a lidském dohledu |
-| RA-P2-02 | P2 | Aktuální runtime/PostgreSQL/container důkaz nebylo možné v tomto prostředí obnovit | Docker/PostgreSQL chybí; uv pin nelze stáhnout kvůli 403 | Ne jako kódový blocker; před pilotem povinná CI podmínka |
-| RA-P3-01 | P3 | Některé legacy ADMIN mutations nemají reasoned audit contract | `/reconciliation/run`, demo backtest/research a obecná automation API | Ne; pro pilot používat operator control plane |
-
-## RBAC matice `/operator/...`
-
-Všechny řádky procházejí globálním middlewarem. `Actor` je `request.state.principal`, nikoli pole
-requestu. GET nevyžaduje reason; každá uvedená control mutation jej vyžaduje v Pydantic body.
-
-| Endpoint | Method | Viewer | Admin | Actor | Reason | Backend authority |
-| --- | --- | --- | --- | --- | --- | --- |
-| `/operator/overview`, `/paper`, `/paper/performance` | GET | ano | ano | server | N/A | read model |
-| `/operator/monitoring/{id}/comparison` | GET | ano | ano | server | N/A | monitoring read model |
-| `/operator/strategies[/​{id}]` | GET | ano | ano | server | N/A | registry read model |
-| `/operator/research/experiments[/​{id}]` | GET | ano | ano | server | N/A | research read model |
-| `/operator/research/experiments/{id}/eligibility` | GET | ano | ano | server | N/A | M1 decision store |
-| `/operator/risk`, `/data-health`, `/automation`, `/audit` | GET | ano | ano | server | N/A | respective read model |
-| `/operator/instruments` | POST | ne | ano | server | ano | registry service |
-| `/operator/universes`, `/universes/{id}/memberships` | POST | ne | ano | server | ano | registry service |
-| `/operator/market-data/ingestions`, `/datasets` | POST | ne | ano | server | ano | data/snapshot service |
-| `/operator/research/experiments` | POST | ne | ano | server | ano | Phase6 runner |
-| `/operator/research/experiments/{id}/eligibility`, `/promote` | POST | ne | ano | server | ano | M1 service |
-| `/operator/deployments`, `/deployments/{id}/approve` | POST | ne | ano | server | ano | deployment service |
-| `/operator/deployments/{id}/jobs`, `/autonomous/enable`, `/autonomous/disable` | POST | ne | ano | server | ano | automation repository |
-| `/operator/monitoring/policies`, `/monitoring/enrollments` | POST | ne | ano | server | ano | monitoring service |
-| `/operator/risk/halt` | POST | ne | ano (i operator) | server | ano | risk service |
-| `/operator/risk/resume` | POST | ne | ano | server | ano | risk/reconciliation gate |
-
-## E2E evidence
-
-Clean PostgreSQL cesta je implementována v CI jako Alembic `upgrade head`, Phase 3–9 integration
-suites, čistý schema reset pro B1 a M1 a samostatné B1/B2/P0/H2/H3/Stage-C acceptance kroky.
-Assertions v klíčových testech kontrolují vznik experiment/deployment/job/cycle/order/fill,
-idempotentní retry, monitoring lineage a fail-closed scénáře. V tomto auditu však nebyl dostupný
-PostgreSQL server ani Docker daemon: **clean DB E2E = UNVERIFIED**, nikoli PASS.
-
-Před pilotem se musí na výsledném SHA uložit zelený CI run a operátor musí provést staging dry-run
-podle runbooku. Přímé SQL inserty mimo fixture bootstrap nejsou povoleny.
-
-## Failure tests
-
-| Scénář | Expected behavior | Observed evidence |
-| --- | --- | --- |
-| Provider unavailable | retry/dead-letter, bez fillu | CODE INSPECTION PASS; runtime UNVERIFIED |
-| Incomplete/failed/stale ingestion | data accessor odmítne execution | CODE INSPECTION PASS; runtime UNVERIFIED |
-| Missing corporate readiness | fail closed před signal/fill | CODE INSPECTION PASS; H2 runtime UNVERIFIED |
-| Corrupted snapshot | hash/manifest validation error | CODE INSPECTION PASS; tamper runtime UNVERIFIED |
-| Eligibility/policy/metrics tamper | promotion conflict | CODE INSPECTION PASS; M1 runtime UNVERIFIED |
-| Promotion bez decision | konflikt, žádný candidate | CODE INSPECTION PASS; runtime UNVERIFIED |
-| Manifest/approval lineage mismatch | approval/execution odmítnuta | CODE INSPECTION PASS; H3 runtime UNVERIFIED |
-| Monitoring inactive | no-action nebo exception, bez fillu | CODE INSPECTION PASS; runtime UNVERIFIED |
-| Scheduler retry / duplicate worker | jedna occurrence, fenced lease | CODE INSPECTION PASS; PostgreSQL runtime UNVERIFIED |
-| Missed open | žádný retroaktivní fill | CODE INSPECTION PASS; P0 acceptance runtime UNVERIFIED |
-| DB interruption/restart | rollback nebo expired-lease takeover | CODE INSPECTION PASS; runtime UNVERIFIED |
-| Legacy direct cycle | route nesmí existovat | Remediation CODE INSPECTION PASS + AST regression připravena |
-
-## Security
-
-Nebyl nalezen broker SDK, exchange order API, funding/withdrawal flow, private key ani hardcoded
-production credential. Stooq je read-only market-data provider. `.env.production` není commitnutý
-a compose používá secret file. Git history secret scan, dependency CVE audit a image scan jsou v
-tomto prostředí `UNVERIFIED`; CI je však má jako blocking kroky bez `continue-on-error`.
-
-Auth negativní očekávání z middleware: bez tokenu `401`, viewer mutation `403`, neplatný Host
-`400`, malformed body `422`. Origin obrana je v server action vrstvě; přímý bearer klient nemá
-ambient cookie credential. Input model eligibility zakazuje extra fields; ostatní významné modely
-mají délkové/enum/numerické meze, ale nejsou všechny `extra=forbid` (P3 hardening).
-
-## CI audit
-
-CI má minimální `contents: read`, nepoužívá `continue-on-error` a samostatně blokuje quality,
-unit/API, PostgreSQL integration, frontend, security, image build/scan a production smoke.
-B1, B2, missed-open P0, production-worker P0, H2, H3 a M1 mají explicitní acceptance commands.
-M4 má pouze obecné frontend test/build pokrytí a potřebuje budoucí workflow-level UI test;
-pro API-řízený omezený pilot to není blocker.
-
-## Operational constraints
-
-**PILOT JE POVOLEN POUZE ZA PODMÍNEK:**
-
-1. výsledný commit má zelené všechny CI jobs včetně clean PostgreSQL acceptance, Trivy a smoke;
-2. PAPER ONLY, XNYS, USD equities, daily timeframe, jeden aktivní deployment a jeden worker;
-3. pouze autoritativní `/operator` workflow; žádné demo/legacy mutations;
-4. ACTIVE monitoring, čerstvá successful ingestion a complete corporate-action readiness před runem;
-5. denní lidská kontrola heartbeat, latest run/attempt, fills a reconciliation;
-6. při stale heartbeat, FAILED/DEAD_LETTER, mismatch nebo nejasném fillu okamžitý HALT;
-7. žádné bezobslužné konfigurační změny a žádné paralelní scheduler deploymenty.
-
-## Residual risks
-
-Hlavní residual risk je chybějící lokálně zopakovaný runtime důkaz, nikoli známý otevřený P0/P1.
-UI nepokrývá celý workflow a operátor musí používat zdokumentované API. Process-local rate limiter
-je přijatelný pouze při single-backend pilot topology. Provider Stooq nemá SLA; failure musí zůstat
-no-fill a být denně kontrolován.
+Před prvním ekonomickým během musí operátor provést staging dry-run podle runbooku, ověřit fresh
+heartbeat/data, complete corporate-action readiness, ACTIVE monitoring a SAFE reconciliation.
+Jakákoli odchylka, P0/P1 nebo nejasný fill znamená okamžitý HALT a verdikt **NOT READY**.
 
 ## Final recommendation
 
-Po odstranění `RA-P0-01` nejsou z code inspection známé otevřené P0/P1. Pilot lze spustit pouze
-po zeleném CI výsledného commitu a úspěšném staging clean-DB dry-runu, v úzkém scope a podle
-`docs/paper-pilot-runbook.md`. Pokud kterýkoli povinný gate není zelený, rozhodnutí se automaticky
-mění na **NOT READY FOR PAPER PILOT**.
-
-# MŮŽEME AUTONOMOUS QUANT LAB PUSTIT DO ŘÍZENÉHO PAPER TESTOVACÍHO PROVOZU?
-
-## ANO, ALE POUZE ZA TĚCHTO PODMÍNEK
-
-- zelený CI a clean PostgreSQL staging E2E na výsledném SHA;
-- jeden XNYS/USD/daily paper deployment a jeden worker pod denním dohledem;
-- ACTIVE monitoring, fresh data, reconciliation SAFE a okamžitý HALT při odchylce.
+Kombinovaný head `6ed177a81d89fe2ac367e236435286dc31c7ad49` včetně M4/PR #62 a
+odstranění legacy route je **CONDITIONAL READY FOR CONTROLLED PAPER PILOT**. Podmíněnost se týká
+výhradně staging/provozních gateů, nikoli chybějícího CI či známého kódového P0/P1. Live trading,
+rozšíření scope ani obejití operator workflow nejsou povoleny.


### PR DESCRIPTION
### Motivation
- Re-run the pre-pilot forensic re-audit against the actual combined PR #63 tree (including merged PR #62/M4) and remove stale claims that M4/PR #62 was unavailable to the audit. 
- Ensure the legacy direct-paper execution path is closed and that documentation and runbook reflect the current, audited implementation and required operational gates. 
- Maintain the PAPER-only invariant and regression protection so the removed legacy route cannot be reintroduced silently.

### Description
- Updated the forensic audit document `docs/pre-pilot-forensic-reaudit.md` to record the re-audit of the combined tree, to acknowledge the operator-control-plane M4 fixes, and to issue a fresh **CONDITIONAL READY FOR CONTROLLED PAPER PILOT** verdict gated on operational/staging checks. 
- Updated the operator runbook `docs/paper-pilot-runbook.md` to reference the authoritative CI evidence, require a new green CI run after any SHA change, require idempotent `MONITOR_PAPER_DEPLOYMENT` scheduling and single-active enrollment semantics, and to mandate audited operator actions for reconciliation/recovery instead of direct DB edits. 
- Preserved and validated removal of the legacy endpoint `/demo/trading/cycles/run-paper` and retained the AST regression test that asserts the route is absent so the legacy mutation cannot be reintroduced.
- Committed the documentation updates to the PR branch and recorded the combined-tree revalidation so CI run #435 is referenced as the authoritative evidence for runtime acceptance gates.

### Testing
- Ran repository sanity and Python lint/format checks with `git diff --check` and `python -m ruff format --check . && python -m ruff check .`, which succeeded. 
- Exercised the frontend verification: `cd frontend && npm ci`, `npm run lint`, `npm run typecheck`, `npm test` (30 tests passed across 5 test files), and `npm run build`, all of which completed successfully. 
- Performed local backend static checks; `python -m mypy` reported missing runtime dependency stubs because the execution environment lacks the pinned backend toolchain and packages, and `uv` version mismatches prevented running `uv lock --check` locally, so backend pytest/PostgreSQL acceptance runs were delegated to authoritative GitHub CI. 
- Authoritative CI evidence: GitHub Actions run #435 on the audited head completed successfully for `quality`, `unit-research`, `api`, `frontend`, `security`, `container-build`, `integration-postgres`, and `production-smoke`, and is cited in the updated audit as the acceptance proof for the combined tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a91c9bf9d40833286ca12548b6e7b90)