### PR TITLE
Fix production Compose runtime deployment settings

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -13,7 +13,9 @@ services:
       interval: 5s
       timeout: 3s
       retries: 12
+    restart: unless-stopped
     cap_drop: [ALL]
+    cap_add: [CHOWN, DAC_OVERRIDE, FOWNER, SETGID, SETUID]
     security_opt: [no-new-privileges:true]
   backend:
     image: quantlab-backend
@@ -23,6 +25,7 @@ services:
       AUTOMATION_ENABLED: "true"
     depends_on: {postgres: {condition: service_healthy}}
     networks: [data, application]
+    restart: unless-stopped
     read_only: true
     tmpfs: [/tmp]
     cap_drop: [ALL]
@@ -49,13 +52,14 @@ services:
     depends_on: [backend]
     networks: [application]
     ports: ["127.0.0.1:3000:3000"]
+    restart: unless-stopped
     read_only: true
     tmpfs: [/tmp]
     cap_drop: [ALL]
     security_opt: [no-new-privileges:true]
 networks:
   data: {internal: true}
-  application: {internal: true}
+  application: {internal: false}
 volumes:
   quantlab-production-db:
 secrets:


### PR DESCRIPTION
## Co opravuje

Tento PR zapracovává problémy odhalené při reálném nasazení stagingu na Hetzneru:

- PostgreSQL dostává zpět pouze minimální capabilities potřebné pro inicializaci a přepnutí na uživatele `postgres`: `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`.
- `application` síť už není `internal: true`, aby fungovalo publikování frontendu na `127.0.0.1:3000` a aplikační vrstva měla potřebnou konektivitu.
- `postgres`, `backend` a `frontend` dostávají `restart: unless-stopped`, aby se stack po restartu hostitele sám obnovil.

## Proč

Při čistém startu PostgreSQL s `cap_drop: [ALL]` selhal na změně práv a přepnutí uživatele. Současně se publikovaný frontend přes host loopback nerozběhl, dokud byla `application` síť interní. Restart policy byla navíc pouze u workeru.

Cílem je dostat ověřené staging nastavení zpět do produkční Compose konfigurace a odstranit potřebu lokálního staging override pro tyto tři body.