### PR TITLE
Opravit úplnost Alpaca corporate-actions inventory (full process-date horizon, provider v5)

### DIFF
--- a/backend/src/quantlab/market_data.py
+++ b/backend/src/quantlab/market_data.py
@@ -428,6 +428,7 @@ class AlpacaProvider:
     """REST adapter; ``known_at`` je lokální receipt time přesně odpovídající SSE revize."""
 
     _base_url = "https://data.alpaca.markets"
+    _corporate_actions_inventory_end = "9999-12-31"
     _supported_collections = frozenset(
         {
             "forward_splits",
@@ -458,7 +459,7 @@ class AlpacaProvider:
         if feed not in {"iex", "sip", "delayed_sip", "otc", "boats", "overnight"}:
             raise ValueError("Alpaca feed není na allowlistu")
         self._feed = feed
-        self.metadata = ProviderMetadata("alpaca", "4", True, True, f"alpaca:{feed}")
+        self.metadata = ProviderMetadata("alpaca", "5", True, True, f"alpaca:{feed}")
 
     def resolve(self, symbol: str) -> dict[str, str]:
         normalized = symbol.strip().upper()
@@ -501,15 +502,12 @@ class AlpacaProvider:
             tokens.add(token)
             query = {**query, "page_token": token}
 
-    def _get_corporate_action_rows(
-        self, symbol: str, requested_end: date
-    ) -> list[tuple[str, dict[str, Any]]]:
+    def _get_corporate_action_rows(self, symbol: str) -> list[tuple[str, dict[str, Any]]]:
         """Načte všechny CA typy; research interval se nepředstírá jako process-date interval."""
-        provider_end = max(requested_end, datetime.now(UTC).date())
         query = {
             "symbols": symbol,
             "start": "1970-01-01",
-            "end": provider_end.isoformat(),
+            "end": self._corporate_actions_inventory_end,
             "limit": "1000",
             "data_quality": "all",
         }
@@ -670,7 +668,7 @@ class AlpacaProvider:
             latest[event.provider_action_id] = event
 
         result: list[CorporateAction] = []
-        rows = self._get_corporate_action_rows(normalized, end)
+        rows = self._get_corporate_action_rows(normalized)
         returned_ids = {
             str(row.get("id"))
             for _, row in rows

--- a/backend/tests/test_alpaca_corporate_actions.py
+++ b/backend/tests/test_alpaca_corporate_actions.py
@@ -254,7 +254,7 @@ def test_alpaca_rest_uses_nested_collections_and_exhausts_pagination() -> None:
 
 def test_alpaca_future_process_date_is_included_by_full_inventory_horizon() -> None:
     row = _dma_cash_dividend()
-    received_at = datetime(2026, 8, 20, 18, tzinfo=UTC)
+    received_at = datetime(2026, 8, 30, 15, 0, 1, tzinfo=UTC)
     event = CorporateActionEvent.from_sse(
         _sse_payload(
             row,

--- a/backend/tests/test_alpaca_corporate_actions.py
+++ b/backend/tests/test_alpaca_corporate_actions.py
@@ -45,6 +45,16 @@ def _cash_dividend(action_id: str = "ca-div") -> dict[str, Any]:
     }
 
 
+def _dma_cash_dividend() -> dict[str, Any]:
+    return {
+        "id": "d0f50368-2964-499c-988c-ebfe01faeb0b",
+        "symbol": "DMA",
+        "rate": 0.1125,
+        "process_date": "2026-08-31",
+        "ex_date": "2026-08-21",
+    }
+
+
 def _sse_payload(
     ca: dict[str, Any],
     *,
@@ -235,9 +245,94 @@ def test_alpaca_rest_uses_nested_collections_and_exhausts_pagination() -> None:
         CorporateActionKind.CASH_DIVIDEND,
     ]
     assert calls[0]["start"] == ["1970-01-01"]
+    assert calls[0]["end"] == ["9999-12-31"]
+    assert calls[0]["limit"] == ["1000"]
     assert calls[0]["data_quality"] == ["all"]
     assert "page_token" not in calls[0]
     assert calls[1]["page_token"] == ["page-2"]
+
+
+def test_alpaca_future_process_date_is_included_by_full_inventory_horizon() -> None:
+    row = _dma_cash_dividend()
+    received_at = datetime(2026, 8, 20, 18, tzinfo=UTC)
+    event = CorporateActionEvent.from_sse(
+        _sse_payload(
+            row,
+            event_type="cash_dividend_corporateaction_event",
+            at="2026-08-30T15:00:00Z",
+        ),
+        received_at=received_at,
+    )
+    calls: list[dict[str, list[str]]] = []
+    provider = AlpacaProvider(
+        "key",
+        "secret",
+        lambda name: (event,) if name == "alpaca" else (),
+        {"DMA": "instrument-dma"},
+        _transport({None: _response({"cash_dividends": [row]})}, calls),
+        timeout=1,
+    )
+
+    actions = provider.corporate_actions("DMA", date(2026, 8, 20), date(2026, 8, 22))
+
+    assert calls[0]["end"] == ["9999-12-31"]
+    assert len(actions) == 1
+    assert actions[0].kind is CorporateActionKind.CASH_DIVIDEND
+    assert actions[0].effective_at == datetime(2026, 8, 21, tzinfo=UTC)
+    assert actions[0].known_at == received_at
+    assert actions[0].known_at != event.at
+    assert actions[0].known_at.date() != date.fromisoformat(row["process_date"])
+
+
+def test_alpaca_future_process_date_without_sse_evidence_fails_closed() -> None:
+    row = _dma_cash_dividend()
+    provider = AlpacaProvider(
+        "key",
+        "secret",
+        lambda _: (),
+        {"DMA": "instrument-dma"},
+        _transport({None: _response({"cash_dividends": [row]})}, []),
+        timeout=1,
+    )
+
+    with pytest.raises(DatasetInvalid, match="^CORPORATE_ACTION_KNOWLEDGE_UNAVAILABLE$"):
+        provider.corporate_actions("DMA", date(2026, 8, 20), date(2026, 8, 22))
+
+
+def test_alpaca_future_process_date_revision_mismatch_fails_closed() -> None:
+    rest_row = _dma_cash_dividend()
+    sse_row = {**rest_row, "rate": 0.1}
+    event = CorporateActionEvent.from_sse(
+        _sse_payload(sse_row, event_type="cash_dividend_corporateaction_event")
+    )
+    provider = AlpacaProvider(
+        "key",
+        "secret",
+        lambda _: (event,),
+        {"DMA": "instrument-dma"},
+        _transport({None: _response({"cash_dividends": [rest_row]})}, []),
+        timeout=1,
+    )
+
+    with pytest.raises(DatasetInvalid, match="^CORPORATE_ACTION_KNOWLEDGE_UNAVAILABLE$"):
+        provider.corporate_actions("DMA", date(2026, 8, 20), date(2026, 8, 22))
+
+
+def test_alpaca_future_process_date_is_filtered_by_economic_effective_date() -> None:
+    row = _dma_cash_dividend()
+    event = CorporateActionEvent.from_sse(
+        _sse_payload(row, event_type="cash_dividend_corporateaction_event")
+    )
+    provider = AlpacaProvider(
+        "key",
+        "secret",
+        lambda _: (event,),
+        {"DMA": "instrument-dma"},
+        _transport({None: _response({"cash_dividends": [row]})}, []),
+        timeout=1,
+    )
+
+    assert provider.corporate_actions("DMA", date(2026, 8, 22), date(2026, 8, 23)) == []
 
 
 def test_alpaca_research_interval_is_not_sent_as_process_date_filter() -> None:

--- a/backend/tests/test_alpaca_production_wiring.py
+++ b/backend/tests/test_alpaca_production_wiring.py
@@ -47,7 +47,7 @@ def test_alpaca_feed_is_part_of_persistent_provider_lineage() -> None:
     sip = AlpacaProvider(*common, feed="sip")
 
     assert iex.metadata.name == sip.metadata.name == "alpaca"
-    assert iex.metadata.version == sip.metadata.version == "4"
+    assert iex.metadata.version == sip.metadata.version == "5"
     assert iex.metadata.persistent_name == "alpaca:iex"
     assert sip.metadata.persistent_name == "alpaca:sip"
 

--- a/docs/market-data.md
+++ b/docs/market-data.md
@@ -21,11 +21,13 @@ Každá ekonomická verze corporate action se ukládá do immutable `corporate_a
 
 REST parametry `start` a `end` Alpaca corporate-actions API filtrují `process_date`, nikoli research `effective_at`/`ex_date`. Adapter proto research interval nepředává jako process-date interval: načítá historii pro symbol s `data_quality=all`, stránkuje všechny vrácené kolekce a teprve lokálně filtruje ekonomické datum. Nepodporovaný ekonomicky relevantní typ v požadovaném období failne closed místo falešného `COMPLETE`.
 
+Corporate-actions inventory používá stabilní process-date horizont `1970-01-01` až `9999-12-31`. Tím zahrne i aktuálně známou akci, jejíž ekonomické `ex_date` již spadá do research intervalu, ale provider ji zpracuje až pozdějším `process_date`; horizont nemění původ `known_at` ze SSE `received_at`.
+
 `AlpacaCorporateActionStream` používá `Last-Event-Id` pro reconnect/replay. Protože replay je inkluzivní, znovu doručený cursor event se přeskočí a persistentní `event_id` zůstává idempotentní. Reconnect je bounded; transientní/provider chyby nevedou k nekonečnému retry. Standardní CI používá pouze fixture transport, nikoli externí síť.
 
 SSE evidence se v provozu ingestuje samostatným procesem `quantlab-alpaca-events` (v developmentu lze ekvivalentně spustit `python -m quantlab.alpaca_event_worker`). Produkční Compose jej spouští jako `alpaca-events` pouze s DB a market-data egress sítí. Proces používá standardní aplikací validovanou konfiguraci a pro `MARKET_DATA_PROVIDER=alpaca` vyžaduje credentials `ALPACA_KEY_ID`/`ALPACA_SECRET_KEY`. Pro jiného providera skončí úspěšně; Compose politika `on-failure` jej proto ve Stooq režimu nerestartuje. V Alpaca režimu načte poslední persistentní event a použije jeho `event_id` jako replay cursor; i čisté vyčerpání bounded SSE reconnectů skončí chybou, aby `on-failure` worker obnovil. Event-worker je oddělen od paper-trading workeru a nevytváří žádnou broker/order cestu. Produkční paper worker získává market-data provider přes společný credential-gated provider factory; live trading path tím nevzniká.
 
-Alpaca provider metadata má po změně tohoto kauzálního kontraktu verzi `4`, takže readiness evidence vytvořená starší implementací se nepovažuje za ekvivalentní.
+Alpaca provider metadata má po změně úplnosti corporate-actions inventory verzi `5`, takže readiness evidence vytvořená starší implementací se nepovažuje za ekvivalentní. Persistentní lineage nadále obsahuje zvolený feed jako `alpaca:<feed>`.
 
 ## Snapshoty
 Snapshot ukládá `as_of`, provider, calendar identity, PIT universe, rozsah, coverage, seřazený manifest observation revisions a SHA-256. Hash nezávisí na pořadí DB řádků. Pozdější correction vytvoří jiný snapshot, nikdy nezmění manifest starého. Snapshot pod minimální coverage (default 80 %) má stav `INVALID` a nesmí spustit experiment.


### PR DESCRIPTION
### Motivation
- Příčina chyby: REST filtr Alpaca podle `process_date` způsobil, že akce s ekonomickým `ex_date` v research intervalu, ale s pozdějším `process_date`, nebyla v inventory viditelná a systém mohl falešně reportovat `COMPLETE` bez akcí.
- Cíl opravy je zajistit, aby REST sloužil jako úplný inventory aktuálně dostupných provider facts a aby se research interval aplikoval až lokálně podle ekonomického data.

### Description
- Použita stabilní process-date horní hranice `9999-12-31` přes novou konstantu `_corporate_actions_inventory_end` a REST dotaz nyní vždy posílá `start=1970-01-01`, `end=9999-12-31`, `limit=1000`, `data_quality=all` a kompletní stránkování přes `next_page_token`.
- Odstraněno používání `requested_end`/`datetime.now()` v `_get_corporate_action_rows` a metoda nyní načítá celý inventory bez předstírání research intervalu; lokální filtr podle `ex_date`/`process_date` zůstává beze změny.
- Zvýšena provider verze z `4` na `5` v metadatech (`ProviderMetadata(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a94131a8cdc8332a5269dfbdf2920dc)