### PR TITLE
Persistuj immutable pre‑open execution intenty a zavést open‑time verifikaci

### DIFF
--- a/alembic/versions/20260830_02_preopen_execution_intents.py
+++ b/alembic/versions/20260830_02_preopen_execution_intents.py
@@ -1,0 +1,94 @@
+"""Přidá immutable pre-open execution intent evidence.
+
+Revision ID: 20260830_02
+Revises: 20260830_01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260830_02"
+down_revision = "20260830_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "preopen_execution_intents",
+        sa.Column("intent_id", sa.String(64), primary_key=True),
+        sa.Column(
+            "deployment_id",
+            sa.String(64),
+            sa.ForeignKey("strategy_deployments.deployment_id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "account_id",
+            sa.String(64),
+            sa.ForeignKey("paper_accounts.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("strategy_id", sa.String(100), nullable=False),
+        sa.Column("instrument_id", sa.String(40), nullable=False),
+        sa.Column("side", sa.String(10), nullable=False),
+        sa.Column("quantity", sa.Numeric(24, 8), nullable=False),
+        sa.Column("order_type", sa.String(10), nullable=False),
+        sa.Column("execution_session", sa.Date(), nullable=False),
+        sa.Column(
+            "intended_execution_open", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.Column("decision_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sizing_reference_price", sa.Numeric(24, 8), nullable=False),
+        sa.Column(
+            "sizing_reference_known_at", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.Column("snapshot_id", sa.String(64), nullable=False),
+        sa.Column("universe_id", sa.String(64), nullable=False),
+        sa.Column("signal_observation_ids_json", sa.Text(), nullable=False),
+        sa.Column("evidence_json", sa.Text(), nullable=False),
+        sa.Column("integrity_hash", sa.String(64), nullable=False),
+        sa.UniqueConstraint(
+            "deployment_id",
+            "execution_session",
+            "instrument_id",
+            name="uq_preopen_intent_logical_identity",
+        ),
+        sa.CheckConstraint("quantity > 0", name="ck_preopen_intent_quantity_positive"),
+        sa.CheckConstraint("side IN ('BUY', 'SELL')", name="ck_preopen_intent_side"),
+        sa.CheckConstraint(
+            "order_type = 'MARKET'", name="ck_preopen_intent_order_type"
+        ),
+        sa.CheckConstraint(
+            "sizing_reference_price > 0", name="ck_preopen_intent_reference_positive"
+        ),
+        sa.CheckConstraint(
+            "created_at < intended_execution_open",
+            name="ck_preopen_intent_created_preopen",
+        ),
+        sa.CheckConstraint(
+            "decision_time < intended_execution_open",
+            name="ck_preopen_intent_decision_preopen",
+        ),
+        sa.CheckConstraint(
+            "sizing_reference_known_at <= decision_time",
+            name="ck_preopen_intent_reference_causal",
+        ),
+    )
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            """CREATE FUNCTION reject_preopen_intent_mutation() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pre-open execution intents are immutable'; END; $$"""
+        )
+        op.execute(
+            "CREATE TRIGGER preopen_execution_intents_immutable BEFORE UPDATE OR DELETE ON preopen_execution_intents FOR EACH ROW EXECUTE FUNCTION reject_preopen_intent_mutation()"
+        )
+
+
+def downgrade() -> None:
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            "DROP TRIGGER IF EXISTS preopen_execution_intents_immutable ON preopen_execution_intents"
+        )
+        op.execute("DROP FUNCTION IF EXISTS reject_preopen_intent_mutation()")
+    op.drop_table("preopen_execution_intents")

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -7,6 +7,7 @@ import signal
 import socket
 from collections.abc import Callable
 from datetime import UTC, date, datetime, time, timedelta
+from decimal import ROUND_DOWN, Decimal
 from enum import StrEnum
 from threading import Event, Thread
 from typing import Any
@@ -15,10 +16,12 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import (
     CheckConstraint,
+    Date,
     DateTime,
     ForeignKey,
     Index,
     Integer,
+    Numeric,
     String,
     Text,
     UniqueConstraint,
@@ -81,10 +84,11 @@ MANAGED_JOB_TYPES = frozenset(
         JobType.MONITOR_PAPER_DEPLOYMENT,
     }
 )
-AUTONOMOUS_DAILY_TIME = "09:30"
+AUTONOMOUS_DAILY_TIME = "09:00"
 AUTONOMOUS_TIMEZONE = "America/New_York"
 MONITOR_INTERVAL_SECONDS = 3600
 PREOPEN_EXECUTION_INTENT_BLOCK = "PREOPEN_EXECUTION_INTENT_NOT_PERSISTED"
+PREOPEN_EXECUTION_INTENT_INVALID = "PREOPEN_EXECUTION_INTENT_INVALID"
 
 TERMINAL = {RunStatus.SUCCEEDED, RunStatus.FAILED, RunStatus.DEAD_LETTER, RunStatus.CANCELLED}
 
@@ -192,6 +196,60 @@ class WorkerHeartbeat(Base):
         ForeignKey("job_runs.id", ondelete="SET NULL")
     )
     stopped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class PreOpenExecutionIntentRecord(Base):
+    """Immutable ekonomická instrukce vytvořená před zamýšleným XNYS open."""
+
+    __tablename__ = "preopen_execution_intents"
+    __table_args__ = (
+        UniqueConstraint(
+            "deployment_id",
+            "execution_session",
+            "instrument_id",
+            name="uq_preopen_intent_logical_identity",
+        ),
+        CheckConstraint("quantity > 0", name="ck_preopen_intent_quantity_positive"),
+        CheckConstraint("side IN ('BUY', 'SELL')", name="ck_preopen_intent_side"),
+        CheckConstraint("order_type = 'MARKET'", name="ck_preopen_intent_order_type"),
+        CheckConstraint("sizing_reference_price > 0", name="ck_preopen_intent_reference_positive"),
+        CheckConstraint(
+            "created_at < intended_execution_open", name="ck_preopen_intent_created_preopen"
+        ),
+        CheckConstraint(
+            "decision_time < intended_execution_open", name="ck_preopen_intent_decision_preopen"
+        ),
+        CheckConstraint(
+            "sizing_reference_known_at <= decision_time", name="ck_preopen_intent_reference_causal"
+        ),
+    )
+    intent_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    deployment_id: Mapped[str] = mapped_column(
+        ForeignKey("strategy_deployments.deployment_id", ondelete="RESTRICT"), nullable=False
+    )
+    account_id: Mapped[str] = mapped_column(
+        ForeignKey("paper_accounts.id", ondelete="RESTRICT"), nullable=False
+    )
+    strategy_id: Mapped[str] = mapped_column(String(100), nullable=False)
+    instrument_id: Mapped[str] = mapped_column(String(40), nullable=False)
+    side: Mapped[str] = mapped_column(String(10), nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    order_type: Mapped[str] = mapped_column(String(10), nullable=False)
+    execution_session: Mapped[date] = mapped_column(Date, nullable=False)
+    intended_execution_open: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    decision_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    sizing_reference_price: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    sizing_reference_known_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    snapshot_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    universe_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    signal_observation_ids_json: Mapped[str] = mapped_column(Text, nullable=False)
+    evidence_json: Mapped[str] = mapped_column(Text, nullable=False)
+    integrity_hash: Mapped[str] = mapped_column(String(64), nullable=False)
 
 
 def utc(value: datetime) -> datetime:
@@ -849,6 +907,184 @@ class JobExecutor:
         self.provider_factory = provider_factory
         self.clock = clock or (lambda: datetime.now(UTC))
 
+    @staticmethod
+    def _intent_content(row: PreOpenExecutionIntentRecord) -> dict[str, str | list[str]]:
+        def decimal_value(value: Decimal) -> str:
+            return format(Decimal(value).quantize(Decimal("0.00000001")), "f")
+
+        return {
+            "deployment_id": row.deployment_id,
+            "account_id": row.account_id,
+            "strategy_id": row.strategy_id,
+            "instrument_id": row.instrument_id,
+            "side": row.side,
+            "quantity": decimal_value(row.quantity),
+            "order_type": row.order_type,
+            "execution_session": row.execution_session.isoformat(),
+            "intended_execution_open": utc(row.intended_execution_open).isoformat(),
+            "decision_time": utc(row.decision_time).isoformat(),
+            "sizing_reference_price": decimal_value(row.sizing_reference_price),
+            "sizing_reference_known_at": utc(row.sizing_reference_known_at).isoformat(),
+            "snapshot_id": row.snapshot_id,
+            "universe_id": row.universe_id,
+            "signal_observation_ids": json.loads(row.signal_observation_ids_json),
+            "evidence": row.evidence_json,
+        }
+
+    @classmethod
+    def _intent_hash(cls, row: PreOpenExecutionIntentRecord) -> str:
+        canonical = json.dumps(cls._intent_content(row), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
+    def _persist_preopen_intents(
+        self,
+        *,
+        deployment: Any,
+        snapshot: Any,
+        eligible_ids: set[str],
+        execution_instrument_ids: tuple[str, ...],
+        signal_session: date,
+        signal_close: datetime,
+        execution_session: date,
+        execution_open: datetime,
+        created_at: datetime,
+    ) -> tuple[str, ...]:
+        """Vytvoří side/quantity výhradně z causal adjusted signal close."""
+        from quantlab.market_data import CorporateAction, CorporateActionKind, causal_adjusted_close
+        from quantlab.market_data_service import _database_utc
+        from quantlab.multi_asset import STRATEGY_REGISTRY, StrategyContext
+        from quantlab.persistence import CorporateActionRecord, ExperimentRecord
+        from quantlab.phase4 import PaperAccountRecord, PositionRecord
+        from quantlab.phase6_runtime import DeploymentService, ValidatedCurrentDataAccessor
+
+        if created_at >= execution_open:
+            raise PermanentJobError("PREOPEN_EXECUTION_INTENT_CREATED_TOO_LATE")
+        with Session(self.trading.repository.engine) as session:
+            experiment = session.get(ExperimentRecord, deployment.experiment_id)
+            if experiment is None:
+                raise PermanentJobError("Deployment experiment neexistuje")
+            _, _, selected = DeploymentService.validate_experiment(session, experiment)
+            strategy_type = STRATEGY_REGISTRY.get(deployment.strategy_name)
+            if strategy_type is None:
+                raise PermanentJobError("Deployment strategy není allowlisted")
+            strategy = strategy_type(**selected)
+            account = session.get(PaperAccountRecord, deployment.paper_account_id)
+            if account is None:
+                raise PermanentJobError("Paper account neexistuje")
+            positions = {
+                row.instrument_id: row.quantity
+                for row in session.scalars(
+                    select(PositionRecord).where(PositionRecord.account_id == account.id)
+                )
+            }
+            pending: dict[str, Decimal] = {}
+            for order in self.trading.broker.get_open_orders(account.id):
+                signed = (
+                    order.remaining_quantity if order.side == "BUY" else -order.remaining_quantity
+                )
+                pending[order.instrument_id] = pending.get(order.instrument_id, Decimal(0)) + signed
+            actions = tuple(
+                session.scalars(
+                    select(CorporateActionRecord).where(
+                        CorporateActionRecord.instrument_id.in_(eligible_ids),
+                        CorporateActionRecord.known_at <= signal_close,
+                    )
+                )
+            )
+        accessor = ValidatedCurrentDataAccessor(lambda: Session(self.trading.repository.engine))
+        history = accessor.history(
+            execution_instrument_ids,
+            signal_close,
+            strategy.required_lookback,
+            before_session=execution_session,
+            known_at=signal_close,
+        )
+        domain_actions = tuple(
+            CorporateAction(
+                item.action_id,
+                item.instrument_id,
+                CorporateActionKind(item.kind),
+                _database_utc(item.effective_at),
+                _database_utc(item.known_at),
+                Decimal(item.value) if item.value is not None else None,
+                item.new_symbol,
+            )
+            for item in actions
+        )
+        prices = {
+            instrument: tuple(
+                causal_adjusted_close(values, domain_actions, signal_close)[item.session_date]
+                for item in values
+            )
+            for instrument, values in history.items()
+        }
+        target = strategy.generate_targets(
+            StrategyContext(
+                signal_close,
+                {key: value for key, value in history.items() if key in eligible_ids},
+                tuple(sorted(eligible_ids)),
+                {key: value for key, value in prices.items() if key in eligible_ids},
+            )
+        )
+        weights = {instrument: Decimal("0") for instrument in positions}
+        weights.update(dict(target.weights))
+        rows: list[PreOpenExecutionIntentRecord] = []
+        strategy_id = f"phase6:{deployment.deployment_id}"
+        for instrument, weight in sorted(weights.items()):
+            reference = prices.get(instrument, ())[-1]
+            desired = (account.equity * weight / reference).to_integral_value(rounding=ROUND_DOWN)
+            delta = (
+                desired
+                - positions.get(instrument, Decimal(0))
+                - pending.get(instrument, Decimal(0))
+            )
+            if delta == 0:
+                continue
+            observation_ids = [item.observation_id for item in history[instrument]]
+            logical = f"{deployment.deployment_id}|{execution_session.isoformat()}|{instrument}"
+            intent_id = hashlib.sha256(logical.encode()).hexdigest()
+            row = PreOpenExecutionIntentRecord(
+                intent_id=intent_id,
+                deployment_id=deployment.deployment_id,
+                account_id=account.id,
+                strategy_id=strategy_id,
+                instrument_id=instrument,
+                side="BUY" if delta > 0 else "SELL",
+                quantity=abs(delta),
+                order_type="MARKET",
+                execution_session=execution_session,
+                intended_execution_open=execution_open,
+                decision_time=signal_close,
+                created_at=created_at,
+                sizing_reference_price=reference,
+                sizing_reference_known_at=signal_close,
+                snapshot_id=snapshot.snapshot_id,
+                universe_id=deployment.universe_id,
+                signal_observation_ids_json=json.dumps(observation_ids, sort_keys=True),
+                evidence_json=json.dumps(
+                    {
+                        "method": "equity_weight_over_causal_adjusted_close",
+                        "target_weight": str(weight),
+                    },
+                    sort_keys=True,
+                ),
+                integrity_hash="",
+            )
+            row.integrity_hash = self._intent_hash(row)
+            rows.append(row)
+        with Session(self.trading.repository.engine) as session, session.begin():
+            for row in rows:
+                existing = session.get(PreOpenExecutionIntentRecord, row.intent_id)
+                if existing is not None:
+                    if (
+                        existing.integrity_hash != row.integrity_hash
+                        or self._intent_hash(existing) != existing.integrity_hash
+                    ):
+                        raise PermanentJobError("PREOPEN_EXECUTION_INTENT_CONFLICT")
+                    continue
+                session.add(row)
+        return tuple(row.intent_id for row in rows)
+
     def __call__(self, job: ScheduledJob, run: JobRun) -> dict[str, str | None]:
         snapshot = json.loads(run.config_snapshot_json)
         if not isinstance(snapshot, dict) or snapshot.get("snapshot_version") != 1:
@@ -1018,10 +1254,7 @@ class JobExecutor:
             )
         if not rows or len(rows) != len(instrument_ids):
             raise PermanentJobError("PIT universe scope je prázdný nebo nekonzistentní")
-        # Současný runtime nepersistuje před 09:30 plně specifikovaný immutable order
-        # intent (side + quantity). Po open proto nesmí číst opening print a teprve
-        # následně z něj odvozovat ekonomický příkaz. Do zavedení pre-open intentu
-        # je autonomous economic path záměrně fail-closed.
+        # Intent smí vzniknout pouze před open; pozdní PREPARE jej nesmí backdatovat.
         if now >= execution_open:
             return {
                 "deployment_id": deployment_id,
@@ -1142,14 +1375,39 @@ class JobExecutor:
             if not open_ready:
                 raise TransientJobError("DATA_NOT_READY: provider nevrátil raw executable open")
         if now < execution_open:
+            intent_ids = self._persist_preopen_intents(
+                deployment=deployment,
+                snapshot=snapshot,
+                eligible_ids=eligible_ids,
+                execution_instrument_ids=instrument_ids,
+                signal_session=signal_session,
+                signal_close=signal_close,
+                execution_session=execution_session,
+                execution_open=execution_open,
+                created_at=now,
+            )
+            run_id = (
+                self.repository.materialize_execution_session(
+                    deployment_id=deployment_id,
+                    account_id=account_id,
+                    execution_session=execution_session,
+                    execution_time=execution_open,
+                    created_at=now,
+                )
+                if intent_ids
+                else None
+            )
             return {
                 "deployment_id": deployment_id,
                 "monitoring_id": monitoring.monitoring_id,
                 "trading_cycle_id": None,
                 "reconciliation_id": None,
-                "outcome": "WAITING_FOR_EXECUTION_OPEN",
-                "no_action_reason": "EXECUTION_SESSION_NOT_OPEN",
+                "outcome": "INTENT_READY" if intent_ids else "NO_ACTION",
+                "no_action_reason": None if intent_ids else "NO_TRADE_DELTA",
+                "execution_run_id": run_id,
+                "intent_ids": ",".join(intent_ids),
                 "ingestion_ids": ",".join(ingestions),
+                "corporate_action_evidence_ids": ",".join(action_evidence),
             }
         execution_now = utc(self.clock())
         if execution_now >= execution_cutoff:
@@ -1197,18 +1455,6 @@ class JobExecutor:
         deployment_id = payload["deployment_id"]
         execution_now = utc(self.clock())
 
-        if run.occurrence_key.startswith("xnys:"):
-            # Legacy/materialized XNYS occurrence nesmí po upgradu obejít chybějící
-            # immutable pre-open order intent. Žádný raw-open economic effect.
-            return {
-                "deployment_id": deployment_id,
-                "monitoring_id": None,
-                "trading_cycle_id": None,
-                "reconciliation_id": None,
-                "outcome": "NO_ACTION",
-                "no_action_reason": PREOPEN_EXECUTION_INTENT_BLOCK,
-            }
-
         def sessions() -> Session:
             return Session(self.trading.repository.engine)
 
@@ -1251,6 +1497,112 @@ class JobExecutor:
                     "outcome": "BLOCKED_BY_LIFECYCLE",
                     "no_action_reason": f"MONITORING_{monitoring.state}",
                 }
+        persisted_intents = None
+        if run.occurrence_key.startswith("xnys:"):
+            from quantlab.domain import OrderIntent, OrderType, Side
+            from quantlab.market_data import AssetType, Instrument, XNYSCalendar
+            from quantlab.market_data_service import PersistentMarketDataService
+            from quantlab.persistence import InstrumentRecord
+
+            try:
+                execution_session = date.fromisoformat(run.occurrence_key.removeprefix("xnys:"))
+            except ValueError as exc:
+                raise PermanentJobError(PREOPEN_EXECUTION_INTENT_INVALID) from exc
+            execution_open = XNYSCalendar().session_open(execution_session)
+            with sessions() as session:
+                rows = tuple(
+                    session.scalars(
+                        select(PreOpenExecutionIntentRecord).where(
+                            PreOpenExecutionIntentRecord.deployment_id == deployment_id,
+                            PreOpenExecutionIntentRecord.execution_session == execution_session,
+                        )
+                    )
+                )
+            if not rows:
+                return {
+                    "deployment_id": deployment_id,
+                    "monitoring_id": monitoring.monitoring_id,
+                    "trading_cycle_id": None,
+                    "reconciliation_id": None,
+                    "outcome": "NO_ACTION",
+                    "no_action_reason": PREOPEN_EXECUTION_INTENT_BLOCK,
+                }
+            invalid = any(
+                row.account_id != account_id
+                or row.strategy_id != f"phase6:{deployment_id}"
+                or utc(row.intended_execution_open) != execution_open
+                or utc(row.created_at) >= execution_open
+                or utc(row.decision_time) >= execution_open
+                or utc(row.sizing_reference_known_at) > utc(row.decision_time)
+                or row.quantity <= 0
+                or row.side not in {"BUY", "SELL"}
+                or self._intent_hash(row) != row.integrity_hash
+                for row in rows
+            )
+            if invalid:
+                return {
+                    "deployment_id": deployment_id,
+                    "monitoring_id": monitoring.monitoring_id,
+                    "trading_cycle_id": None,
+                    "reconciliation_id": None,
+                    "outcome": "NO_ACTION",
+                    "no_action_reason": PREOPEN_EXECUTION_INTENT_INVALID,
+                }
+            calendar = XNYSCalendar()
+            if not calendar.is_executable_open_time(execution_session, execution_now):
+                reason = (
+                    "EXECUTION_SESSION_NOT_OPEN"
+                    if execution_now < execution_open
+                    else "MISSED_EXECUTION_OPEN"
+                )
+                return {
+                    "deployment_id": deployment_id,
+                    "monitoring_id": monitoring.monitoring_id,
+                    "trading_cycle_id": None,
+                    "reconciliation_id": None,
+                    "outcome": "NO_ACTION",
+                    "no_action_reason": reason,
+                }
+            provider = self.provider_factory() if self.provider_factory else StooqProvider()
+            with sessions() as session:
+                instrument_rows = tuple(
+                    session.scalars(
+                        select(InstrumentRecord).where(
+                            InstrumentRecord.instrument_id.in_([row.instrument_id for row in rows])
+                        )
+                    )
+                )
+            if len(instrument_rows) != len(rows):
+                raise PermanentJobError(PREOPEN_EXECUTION_INTENT_INVALID)
+            for item in instrument_rows:
+                instrument = Instrument(
+                    item.instrument_id,
+                    item.symbol,
+                    item.exchange,
+                    item.calendar,
+                    item.currency,
+                    AssetType(item.asset_type),
+                    item.active_from.date(),
+                    item.active_to.date() if item.active_to else None,
+                    utc(item.created_at),
+                )
+                result = PersistentMarketDataService(
+                    sessions, calendar, clock=lambda: execution_now
+                ).ingest_open(provider, instrument, execution_session, execution_now)
+                if result.status != "SUCCEEDED":
+                    raise TransientJobError(result.error or "Raw executable open refresh selhal")
+            persisted_intents = tuple(
+                OrderIntent(
+                    row.instrument_id,
+                    Side(row.side),
+                    row.quantity,
+                    utc(row.decision_time),
+                    "persisted-preopen-target-delta",
+                    row.intent_id,
+                    OrderType(row.order_type),
+                )
+                for row in sorted(rows, key=lambda item: item.instrument_id)
+            )
         provider = self.provider_factory() if self.provider_factory else StooqProvider()
         service = Phase6PaperExecutionService(
             sessions,
@@ -1269,6 +1621,7 @@ class JobExecutor:
                 execution_intent_time=run.scheduled_for
                 if run.occurrence_key.startswith("xnys:")
                 else None,
+                persisted_intents=persisted_intents,
             )
         except DatasetInvalid as exc:
             message = str(exc)

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -26,6 +26,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     and_,
+    case,
     create_engine,
     func,
     or_,
@@ -254,6 +255,42 @@ class PreOpenExecutionIntentRecord(Base):
 
 def utc(value: datetime) -> datetime:
     return value.astimezone(UTC) if value.tzinfo else value.replace(tzinfo=UTC)
+
+
+def mark_preopen_equity(
+    cash: Decimal,
+    positions: dict[str, Decimal],
+    signal_references: dict[str, Decimal],
+) -> Decimal:
+    """Ocení účet pouze causal signal cenami dostupnými při PREPARE."""
+    if set(positions) - set(signal_references):
+        raise ValueError("Pre-open mark postrádá causal signal reference")
+    values = (cash, *positions.values(), *signal_references.values())
+    if any(not value.is_finite() for value in values) or any(
+        value <= 0 for value in signal_references.values()
+    ):
+        raise ValueError("Pre-open mark obsahuje neplatnou hodnotu")
+    return cash + sum(
+        (quantity * signal_references[instrument] for instrument, quantity in positions.items()),
+        Decimal(0),
+    )
+
+
+def preopen_execution_delta(
+    *,
+    marked_equity: Decimal,
+    weight: Decimal,
+    signal_reference: Decimal,
+    split_ratio: Decimal,
+    position: Decimal,
+    pending: Decimal,
+) -> tuple[Decimal, Decimal]:
+    """Vrátí execution-unit reference a delta bez použití opening printu."""
+    if signal_reference <= 0 or split_ratio <= 0:
+        raise ValueError("Pre-open sizing reference a split ratio musí být kladné")
+    execution_reference = signal_reference / split_ratio
+    desired = (marked_equity * weight / execution_reference).to_integral_value(rounding=ROUND_DOWN)
+    return execution_reference, desired - position * split_ratio - pending
 
 
 def validate_payload(payload: dict[str, Any]) -> None:
@@ -986,18 +1023,19 @@ class JobExecutor:
             actions = tuple(
                 session.scalars(
                     select(CorporateActionRecord).where(
-                        CorporateActionRecord.instrument_id.in_(eligible_ids),
-                        CorporateActionRecord.known_at <= signal_close,
+                        CorporateActionRecord.instrument_id.in_(execution_instrument_ids),
+                        CorporateActionRecord.known_at <= created_at,
+                        CorporateActionRecord.effective_at <= execution_open,
                     )
                 )
             )
         accessor = ValidatedCurrentDataAccessor(lambda: Session(self.trading.repository.engine))
         history = accessor.history(
             execution_instrument_ids,
-            signal_close,
+            created_at,
             strategy.required_lookback,
             before_session=execution_session,
-            known_at=signal_close,
+            known_at=created_at,
         )
         domain_actions = tuple(
             CorporateAction(
@@ -1013,14 +1051,14 @@ class JobExecutor:
         )
         prices = {
             instrument: tuple(
-                causal_adjusted_close(values, domain_actions, signal_close)[item.session_date]
+                causal_adjusted_close(values, domain_actions, created_at)[item.session_date]
                 for item in values
             )
             for instrument, values in history.items()
         }
         target = strategy.generate_targets(
             StrategyContext(
-                signal_close,
+                created_at,
                 {key: value for key, value in history.items() if key in eligible_ids},
                 tuple(sorted(eligible_ids)),
                 {key: value for key, value in prices.items() if key in eligible_ids},
@@ -1028,19 +1066,48 @@ class JobExecutor:
         )
         weights = {instrument: Decimal("0") for instrument in positions}
         weights.update(dict(target.weights))
+        strategy_observation_ids = sorted(
+            item.observation_id for values in history.values() for item in values
+        )
+        reference_known_at = max(
+            utc(item.observed_at) for values in history.values() for item in values
+        )
+        if reference_known_at > created_at:
+            raise PermanentJobError("PREOPEN_EXECUTION_INTENT_NON_CAUSAL_REFERENCE")
+        marked_equity = mark_preopen_equity(
+            account.cash,
+            positions,
+            {instrument: values[-1] for instrument, values in prices.items()},
+        )
+        split_ratios: dict[str, Decimal] = {}
+        for action in domain_actions:
+            if (
+                action.kind is CorporateActionKind.SPLIT
+                and signal_close < action.effective_at <= execution_open
+            ):
+                ratio = action.value or Decimal(0)
+                if ratio <= 0:
+                    raise PermanentJobError("PREOPEN_EXECUTION_INTENT_INVALID_SPLIT_RATIO")
+                split_ratios[action.instrument_id] = (
+                    split_ratios.get(action.instrument_id, Decimal(1)) * ratio
+                )
         rows: list[PreOpenExecutionIntentRecord] = []
         strategy_id = f"phase6:{deployment.deployment_id}"
         for instrument, weight in sorted(weights.items()):
-            reference = prices.get(instrument, ())[-1]
-            desired = (account.equity * weight / reference).to_integral_value(rounding=ROUND_DOWN)
-            delta = (
-                desired
-                - positions.get(instrument, Decimal(0))
-                - pending.get(instrument, Decimal(0))
+            signal_reference = prices.get(instrument, ())[-1]
+            split_ratio = split_ratios.get(instrument, Decimal(1))
+            if split_ratio != 1 and pending.get(instrument, Decimal(0)) != 0:
+                raise PermanentJobError("PREOPEN_EXECUTION_INTENT_SPLIT_WITH_PENDING_ORDER")
+            execution_unit_reference, delta = preopen_execution_delta(
+                marked_equity=marked_equity,
+                weight=weight,
+                signal_reference=signal_reference,
+                split_ratio=split_ratio,
+                position=positions.get(instrument, Decimal(0)),
+                pending=pending.get(instrument, Decimal(0)),
             )
             if delta == 0:
                 continue
-            observation_ids = [item.observation_id for item in history[instrument]]
             logical = f"{deployment.deployment_id}|{execution_session.isoformat()}|{instrument}"
             intent_id = hashlib.sha256(logical.encode()).hexdigest()
             row = PreOpenExecutionIntentRecord(
@@ -1054,17 +1121,21 @@ class JobExecutor:
                 order_type="MARKET",
                 execution_session=execution_session,
                 intended_execution_open=execution_open,
-                decision_time=signal_close,
+                decision_time=created_at,
                 created_at=created_at,
-                sizing_reference_price=reference,
-                sizing_reference_known_at=signal_close,
+                sizing_reference_price=execution_unit_reference,
+                sizing_reference_known_at=reference_known_at,
                 snapshot_id=snapshot.snapshot_id,
                 universe_id=deployment.universe_id,
-                signal_observation_ids_json=json.dumps(observation_ids, sort_keys=True),
+                signal_observation_ids_json=json.dumps(strategy_observation_ids),
                 evidence_json=json.dumps(
                     {
                         "method": "equity_weight_over_causal_adjusted_close",
                         "target_weight": str(weight),
+                        "marked_equity": str(marked_equity),
+                        "signal_time": signal_close.isoformat(),
+                        "signal_reference_price": str(signal_reference),
+                        "execution_unit_split_ratio": str(split_ratio),
                     },
                     sort_keys=True,
                 ),
@@ -1586,11 +1657,43 @@ class JobExecutor:
                     item.active_to.date() if item.active_to else None,
                     utc(item.created_at),
                 )
-                result = PersistentMarketDataService(
-                    sessions, calendar, clock=lambda: execution_now
-                ).ingest_open(provider, instrument, execution_session, execution_now)
+                request_time = utc(self.clock())
+                if not calendar.is_executable_open_time(execution_session, request_time):
+                    return {
+                        "deployment_id": deployment_id,
+                        "monitoring_id": monitoring.monitoring_id,
+                        "trading_cycle_id": None,
+                        "reconciliation_id": None,
+                        "outcome": "NO_ACTION",
+                        "no_action_reason": "MISSED_EXECUTION_OPEN",
+                    }
+                try:
+                    result = PersistentMarketDataService(
+                        sessions, calendar, clock=lambda: utc(self.clock())
+                    ).ingest_open(provider, instrument, execution_session, request_time)
+                except DatasetInvalid as exc:
+                    if "MISSED_EXECUTION_OPEN" not in str(exc):
+                        raise
+                    return {
+                        "deployment_id": deployment_id,
+                        "monitoring_id": monitoring.monitoring_id,
+                        "trading_cycle_id": None,
+                        "reconciliation_id": None,
+                        "outcome": "NO_ACTION",
+                        "no_action_reason": "MISSED_EXECUTION_OPEN",
+                    }
                 if result.status != "SUCCEEDED":
                     raise TransientJobError(result.error or "Raw executable open refresh selhal")
+            execution_now = utc(self.clock())
+            if not calendar.is_executable_open_time(execution_session, execution_now):
+                return {
+                    "deployment_id": deployment_id,
+                    "monitoring_id": monitoring.monitoring_id,
+                    "trading_cycle_id": None,
+                    "reconciliation_id": None,
+                    "outcome": "NO_ACTION",
+                    "no_action_reason": "MISSED_EXECUTION_OPEN",
+                }
             persisted_intents = tuple(
                 OrderIntent(
                     row.instrument_id,
@@ -1733,7 +1836,12 @@ class WorkerService:
                         ),
                     ),
                 )
-                .order_by(JobRun.scheduled_for, JobRun.created_at, JobRun.id)
+                .order_by(
+                    case((JobRun.occurrence_key.like("xnys:%"), 0), else_=1),
+                    JobRun.scheduled_for,
+                    JobRun.created_at,
+                    JobRun.id,
+                )
                 .limit(1)
             )
             if session.bind and session.bind.dialect.name == "postgresql":
@@ -1775,6 +1883,20 @@ class WorkerService:
             )
             session.commit()
             return run.id, run.fencing_token
+
+    def next_xnys_dispatch_delay(self, now: datetime | None = None) -> float | None:
+        """Vrátí přesné čekání k nejbližší připravené XNYS occurrence."""
+        current = utc(now or datetime.now(UTC))
+        with Session(self.repository.engine) as session:
+            due = session.scalar(
+                select(func.min(JobRun.scheduled_for)).where(
+                    JobRun.occurrence_key.like("xnys:%"),
+                    JobRun.status.in_([RunStatus.PENDING, RunStatus.RETRY_SCHEDULED]),
+                )
+            )
+        if due is None:
+            return None
+        return max(0.0, (utc(due) - current).total_seconds())
 
     def finish(
         self, run_id: str, token: int, result: dict[str, str | None], now: datetime | None = None

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -1359,8 +1359,8 @@ class JobExecutor:
                             provider,
                             instrument,
                             snapshot.start_at.date(),
-                            signal_session,
-                            signal_close,
+                            execution_session,
+                            now,
                         )
                     )
                 except DatasetInvalid as exc:

--- a/backend/src/quantlab/automation.py
+++ b/backend/src/quantlab/automation.py
@@ -1515,9 +1515,11 @@ class JobExecutor:
     ) -> dict[str, str | None]:
         from quantlab.market_data import DatasetInvalid, StooqProvider
         from quantlab.persistence import StrategyDeploymentRecord
+        from quantlab.phase4 import PositionRecord
         from quantlab.phase6_runtime import (
             Phase6PaperExecutionService,
             ValidatedCurrentDataAccessor,
+            persisted_execution_open_scope,
         )
         from quantlab.phase7 import PaperMonitoringRunRecord
 
@@ -1636,14 +1638,27 @@ class JobExecutor:
                 }
             provider = self.provider_factory() if self.provider_factory else StooqProvider()
             with sessions() as session:
-                instrument_rows = tuple(
+                held_instruments = set(
                     session.scalars(
-                        select(InstrumentRecord).where(
-                            InstrumentRecord.instrument_id.in_([row.instrument_id for row in rows])
+                        select(PositionRecord.instrument_id).where(
+                            PositionRecord.account_id == account_id,
+                            PositionRecord.quantity > 0,
                         )
                     )
                 )
-            if len(instrument_rows) != len(rows):
+                required_open_instruments = set(
+                    persisted_execution_open_scope(
+                        {row.instrument_id for row in rows}, held_instruments
+                    )
+                )
+                instrument_rows = tuple(
+                    session.scalars(
+                        select(InstrumentRecord).where(
+                            InstrumentRecord.instrument_id.in_(required_open_instruments)
+                        )
+                    )
+                )
+            if {item.instrument_id for item in instrument_rows} != required_open_instruments:
                 raise PermanentJobError(PREOPEN_EXECUTION_INTENT_INVALID)
             for item in instrument_rows:
                 instrument = Instrument(

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -1142,6 +1142,8 @@ class TradingCycleService:
         session_date: date,
         decision_time: datetime,
         persisted_intents: tuple[OrderIntent, ...] | None = None,
+        *,
+        risk_evaluation_time: datetime | None = None,
     ) -> str:
         if not bars:
             raise ValueError("Chybí market data")
@@ -1393,8 +1395,21 @@ class TradingCycleService:
                 daily_notional,
                 account.trading_state,
             )
+            evaluation_time = risk_evaluation_time or decision_time
+            if persisted_intent is not None and (
+                evaluation_time < intent.decision_time or evaluation_time < bar.timestamp
+            ):
+                raise ValueError(
+                    "Risk evaluation nesmí předcházet persisted intent ani executable open"
+                )
             decision = self.risk.evaluate(
-                intent, bar.open, snapshot, cycle_id, correlation_id, decision_time, bar.timestamp
+                intent,
+                bar.open,
+                snapshot,
+                cycle_id,
+                correlation_id,
+                evaluation_time,
+                bar.timestamp,
             )
             if persisted_intent is not None and decision.status is RiskDecisionStatus.MODIFIED:
                 decision = RiskDecision(

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -1141,6 +1141,7 @@ class TradingCycleService:
         target_weights: dict[str, Decimal],
         session_date: date,
         decision_time: datetime,
+        persisted_intents: tuple[OrderIntent, ...] | None = None,
     ) -> str:
         if not bars:
             raise ValueError("Chybí market data")
@@ -1156,7 +1157,13 @@ class TradingCycleService:
             for executable_bar in bars:
                 validate_bars([executable_bar])
         cycle_key = deterministic_cycle_key(account_id, strategy_id, session_date)
-        input_fingerprint = cycle_input_fingerprint(bars, decision_time, target_weights)
+        fingerprint_targets = target_weights
+        if persisted_intents is not None:
+            fingerprint_targets = {
+                f"{item.symbol}:{item.side.value}:{item.id}": item.quantity
+                for item in persisted_intents
+            }
+        input_fingerprint = cycle_input_fingerprint(bars, decision_time, fingerprint_targets)
         cycle_id = cycle_key
         correlation_id = cycle_key
         lease_owner = str(uuid4())
@@ -1321,27 +1328,54 @@ class TradingCycleService:
                 )
                 or 0
             )
-        for symbol, weight in sorted(target_weights.items()):
+        economic_inputs: list[tuple[str, Decimal, OrderIntent | None]] = []
+        if persisted_intents is not None:
+            economic_inputs = [(item.symbol, Decimal("0"), item) for item in persisted_intents]
+        else:
+            economic_inputs = [
+                (symbol, weight, None) for symbol, weight in sorted(target_weights.items())
+            ]
+        for symbol, weight, persisted_intent in economic_inputs:
             bar = bars_by_symbol.get(symbol)
             if bar is None:
                 raise ValueError("Cycle vyžaduje executable bar každého target instrumentu")
-            desired = (account.equity * weight / bar.open).to_integral_value(rounding=ROUND_DOWN)
-            delta = desired - positions.get(symbol, Decimal(0)) - pending.get(symbol, Decimal(0))
-            if delta == 0:
-                continue
-            intent_id = hashlib.sha256(f"{cycle_id}|{symbol}|{desired}".encode()).hexdigest()
-            intent = OrderIntent(
-                symbol,
-                Side.BUY if delta > 0 else Side.SELL,
-                abs(delta),
-                decision_time,
-                "target-vs-actual",
-                intent_id,
-                OrderType.MARKET,
-                None,
-                cycle_id,
-                correlation_id,
-            )
+            if persisted_intent is None:
+                desired = (account.equity * weight / bar.open).to_integral_value(
+                    rounding=ROUND_DOWN
+                )
+                delta = (
+                    desired - positions.get(symbol, Decimal(0)) - pending.get(symbol, Decimal(0))
+                )
+                if delta == 0:
+                    continue
+                intent_id = hashlib.sha256(f"{cycle_id}|{symbol}|{desired}".encode()).hexdigest()
+                intent = OrderIntent(
+                    symbol,
+                    Side.BUY if delta > 0 else Side.SELL,
+                    abs(delta),
+                    decision_time,
+                    "target-vs-actual",
+                    intent_id,
+                    OrderType.MARKET,
+                    None,
+                    cycle_id,
+                    correlation_id,
+                )
+            else:
+                # Autonomous kontrakt přebírá ekonomická pole beze změny;
+                # open je pouze risk/fill reference.
+                intent = OrderIntent(
+                    persisted_intent.symbol,
+                    persisted_intent.side,
+                    persisted_intent.quantity,
+                    persisted_intent.decision_time,
+                    persisted_intent.reason,
+                    persisted_intent.id,
+                    persisted_intent.order_type,
+                    persisted_intent.limit_price,
+                    cycle_id,
+                    correlation_id,
+                )
             with Session(self.repository.engine) as session:
                 account_row = session.get(PaperAccountRecord, account_id)
                 if account_row is None:
@@ -1362,6 +1396,20 @@ class TradingCycleService:
             decision = self.risk.evaluate(
                 intent, bar.open, snapshot, cycle_id, correlation_id, decision_time, bar.timestamp
             )
+            if persisted_intent is not None and decision.status is RiskDecisionStatus.MODIFIED:
+                decision = RiskDecision(
+                    decision.decision_id,
+                    decision.timestamp,
+                    decision.order_intent_id,
+                    RiskDecisionStatus.REJECTED,
+                    decision.original_quantity,
+                    Decimal(0),
+                    decision.reasons,
+                    decision.evaluated_limits,
+                    decision.portfolio_snapshot,
+                    decision.correlation_id,
+                    decision.trading_cycle_id,
+                )
             with Session(self.repository.engine) as session:
                 if session.get(RiskDecisionRecord, decision.decision_id) is None:
                     self.repository.audit(

--- a/backend/src/quantlab/phase4.py
+++ b/backend/src/quantlab/phase4.py
@@ -421,6 +421,27 @@ class PortfolioRiskSnapshot:
     trading_state: SystemTradingState
 
 
+def execution_marked_equity(
+    cash: Decimal, positions: dict[str, Decimal], prices: dict[str, Decimal]
+) -> Decimal:
+    """Ocení held portfolio raw executable cenami pro execution-time risk."""
+    if set(positions) - set(prices):
+        raise ValueError("Execution risk postrádá raw-open cenu drženého instrumentu")
+    relevant_prices = {instrument: prices[instrument] for instrument in positions}
+    values = (cash, *positions.values(), *relevant_prices.values())
+    if any(not value.is_finite() for value in values) or any(
+        price <= 0 for price in relevant_prices.values()
+    ):
+        raise ValueError("Execution portfolio mark obsahuje neplatnou hodnotu")
+    marked = cash + sum(
+        (quantity * relevant_prices[instrument] for instrument, quantity in positions.items()),
+        Decimal(0),
+    )
+    if not marked.is_finite() or marked <= 0:
+        raise ValueError("Execution portfolio mark musí být konečný a kladný")
+    return marked
+
+
 class ProductionRiskEngine:
     def __init__(self, config: ProductionRiskConfig):
         self.config = config
@@ -1279,16 +1300,12 @@ class TradingCycleService:
                 )
             session.commit()
         bars_by_symbol = {item.symbol: item for item in bars}
-        with Session(self.repository.engine) as session:
-            account_row = session.get(PaperAccountRecord, account_id)
-            if account_row is None:
-                raise KeyError(account_id)
-            if account_row.session_date != session_date:
-                account_row.session_date = session_date
-                account_row.session_start_equity = account_row.equity
-                session.commit()
         account = self.repository.account(account_id)
-        positions = {p.instrument_id: p.quantity for p in self.repository.positions(account_id)}
+        positions = {
+            p.instrument_id: p.quantity
+            for p in self.repository.positions(account_id)
+            if p.quantity != 0
+        }
         pending: dict[str, Decimal] = {}
         for open_order in self.broker.get_open_orders(account_id):
             signed_remaining = (
@@ -1301,6 +1318,19 @@ class TradingCycleService:
             )
         # Všechny risk marky musí být dostupné ve stejném okamžiku jako next-open fill.
         prices = {symbol: item.open for symbol, item in bars_by_symbol.items()}
+        marked_equity = (
+            execution_marked_equity(account.cash, positions, prices)
+            if persisted_intents is not None
+            else account.equity
+        )
+        with Session(self.repository.engine) as session:
+            account_row = session.get(PaperAccountRecord, account_id)
+            if account_row is None:
+                raise KeyError(account_id)
+            if account_row.session_date != session_date:
+                account_row.session_date = session_date
+                account_row.session_start_equity = marked_equity
+                session.commit()
         with Session(self.repository.engine) as session:
             daily_orders = int(
                 session.scalar(
@@ -1383,10 +1413,15 @@ class TradingCycleService:
                 if account_row is None:
                     raise RuntimeError("Paper účet během trading cycle zmizel")
                 session_start_equity = account_row.session_start_equity or account.equity
+            if persisted_intent is not None:
+                marked_equity = execution_marked_equity(account.cash, positions, prices)
+                session_start_equity = account_row.session_start_equity or marked_equity
             snapshot = PortfolioRiskSnapshot(
                 account.cash,
-                account.equity,
-                account.high_water_mark,
+                marked_equity if persisted_intent is not None else account.equity,
+                max(account.high_water_mark, marked_equity)
+                if persisted_intent is not None
+                else account.high_water_mark,
                 session_start_equity,
                 positions,
                 prices,
@@ -1489,6 +1524,7 @@ class TradingCycleService:
             positions = {
                 position.instrument_id: position.quantity
                 for position in self.repository.positions(account_id)
+                if position.quantity != 0
             }
             daily_orders += 1
             daily_notional += order.submitted_notional

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -121,6 +121,15 @@ class PaperExecutionTiming:
     execution_time: datetime
 
 
+def persisted_execution_open_scope(
+    intent_instruments: set[str], held_instruments: set[str]
+) -> tuple[str, ...]:
+    """Vrátí minimální raw-open scope pro persisted-intent risk a execution."""
+    if not intent_instruments:
+        raise DatasetInvalid("Persisted execution vyžaduje alespoň jeden economic intent")
+    return tuple(sorted(intent_instruments | held_instruments))
+
+
 class Phase6ExperimentRunner:
     """Snapshot-only Phase 6 runner s persistentní, exactly-once OOS identitou."""
 
@@ -1448,7 +1457,17 @@ class Phase6PaperExecutionService:
                     )
                 )
             }
-            execution_instruments = tuple(sorted(set(eligible) | held))
+            if persisted_intents is None:
+                execution_instruments = tuple(sorted(set(eligible) | held))
+            else:
+                intent_instruments = {intent.symbol for intent in persisted_intents}
+                if not intent_instruments or not intent_instruments <= (set(eligible) | held):
+                    raise DatasetInvalid(
+                        "Persisted intent instrument neodpovídá PIT universe ani held scope"
+                    )
+                # Open-time risk potřebuje pouze instrumenty s ekonomickým intentem
+                # a držené instrumenty pro úplné portfolio marking.
+                execution_instruments = persisted_execution_open_scope(intent_instruments, held)
             if any(len(instrument_id) > 40 for instrument_id in execution_instruments):
                 raise DatasetInvalid("Paper execution instrument ID překračuje Phase 4 limit")
             instruments = {
@@ -1632,6 +1651,7 @@ class Phase6PaperExecutionService:
             executable_session,
             decision_time,
             persisted_intents,
+            risk_evaluation_time=as_of if persisted_intents is not None else None,
         )
         self._ensure_cycle_lineage(
             monitoring.monitoring_id,

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from quantlab.domain import AuditEventType, Bar, require_utc
+from quantlab.domain import AuditEventType, Bar, OrderIntent, require_utc
 from quantlab.market_data import (
     CorporateAction,
     CorporateActionKind,
@@ -1334,6 +1334,7 @@ class Phase6PaperExecutionService:
         now: datetime,
         *,
         execution_intent_time: datetime | None = None,
+        persisted_intents: tuple[OrderIntent, ...] | None = None,
     ) -> str:
         as_of = require_utc(now)
         if execution_intent_time is None:
@@ -1630,6 +1631,7 @@ class Phase6PaperExecutionService:
             target_weights,
             executable_session,
             decision_time,
+            persisted_intents,
         )
         self._ensure_cycle_lineage(
             monitoring.monitoring_id,

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -1525,13 +1525,17 @@ class Phase6PaperExecutionService:
                 ready_instruments = {item.instrument_id for item in readiness}
                 if ready_instruments != set(execution_instruments):
                     raise DatasetInvalid("CORPORATE_ACTIONS_NOT_READY")
-            action_rows = tuple(
-                session.scalars(
-                    select(CorporateActionRecord).where(
-                        CorporateActionRecord.instrument_id.in_(eligible),
-                        CorporateActionRecord.known_at <= decision_time,
+            action_rows = (
+                tuple(
+                    session.scalars(
+                        select(CorporateActionRecord).where(
+                            CorporateActionRecord.instrument_id.in_(eligible),
+                            CorporateActionRecord.known_at <= decision_time,
+                        )
                     )
                 )
+                if persisted_intents is None
+                else ()
             )
         strategy_type = STRATEGY_REGISTRY.get(deployment.strategy_name)
         if strategy_type is None:
@@ -1548,48 +1552,6 @@ class Phase6PaperExecutionService:
         latest = self.current_data.for_execution_session(
             execution_instruments, executable_session, as_of
         )
-        expected_sessions: list[date] = []
-        history_session = executable_session
-        for _ in range(strategy.required_lookback):
-            history_session = self.current_data.calendar.previous_session(history_session)
-            expected_sessions.append(history_session)
-        expected_sessions.reverse()
-        signal_time = self.current_data.calendar.session_close(expected_sessions[-1])
-        history = self.current_data.history(
-            eligible,
-            decision_time,
-            strategy.required_lookback,
-            before_session=executable_session,
-            known_at=signal_time,
-        )
-        if any(
-            len(values) != strategy.required_lookback
-            or [item.session_date for item in values] != expected_sessions
-            for values in history.values()
-        ):
-            raise DatasetInvalid("Current strategy history je neúplná")
-        actions = tuple(
-            CorporateAction(
-                item.action_id,
-                item.instrument_id,
-                CorporateActionKind(item.kind),
-                _database_utc(item.effective_at),
-                _database_utc(item.known_at),
-                Decimal(item.value) if item.value is not None else None,
-                item.new_symbol,
-            )
-            for item in action_rows
-            if _database_utc(item.known_at) <= signal_time
-        )
-        signal_prices = {
-            instrument: tuple(
-                causal_adjusted_close(values, actions, decision_time)[item.session_date]
-                for item in values
-            )
-            for instrument, values in history.items()
-        }
-        from quantlab.multi_asset import StrategyContext
-
         strategy_id = f"phase6:{deployment.deployment_id}"
         with self._sessions() as session:
             previous_cycle = session.scalar(
@@ -1611,17 +1573,66 @@ class Phase6PaperExecutionService:
                 as_of,
             )
             return previous_cycle.id
-        if previous_cycle is not None and not self._rebalance_due(
-            executable_session,
-            previous_cycle.session_date,
-            strategy.rebalance_frequency,
-        ):
-            raise DatasetInvalid("Deployment dnes nemá povolený rebalance")
-        target = strategy.generate_targets(
-            StrategyContext(signal_time, history, eligible, signal_prices)
-        )
-        if any(instrument not in eligible for instrument, _ in target.weights):
-            raise DatasetInvalid("Strategy vytvořila target mimo deployment PIT universe")
+        history: dict[str, tuple[Observation, ...]] = {}
+        signal_prices: dict[str, tuple[Decimal, ...]] = {}
+        expected_sessions = [timing.signal_session]
+        target_weights: dict[str, Decimal] = {}
+        if persisted_intents is None:
+            expected_sessions = []
+            history_session = executable_session
+            for _ in range(strategy.required_lookback):
+                history_session = self.current_data.calendar.previous_session(history_session)
+                expected_sessions.append(history_session)
+            expected_sessions.reverse()
+            signal_time = self.current_data.calendar.session_close(expected_sessions[-1])
+            history = self.current_data.history(
+                eligible,
+                decision_time,
+                strategy.required_lookback,
+                before_session=executable_session,
+                known_at=signal_time,
+            )
+            if any(
+                len(values) != strategy.required_lookback
+                or [item.session_date for item in values] != expected_sessions
+                for values in history.values()
+            ):
+                raise DatasetInvalid("Current strategy history je neúplná")
+            actions = tuple(
+                CorporateAction(
+                    item.action_id,
+                    item.instrument_id,
+                    CorporateActionKind(item.kind),
+                    _database_utc(item.effective_at),
+                    _database_utc(item.known_at),
+                    Decimal(item.value) if item.value is not None else None,
+                    item.new_symbol,
+                )
+                for item in action_rows
+                if _database_utc(item.known_at) <= signal_time
+            )
+            signal_prices = {
+                instrument: tuple(
+                    causal_adjusted_close(values, actions, decision_time)[item.session_date]
+                    for item in values
+                )
+                for instrument, values in history.items()
+            }
+            from quantlab.multi_asset import StrategyContext
+
+            if previous_cycle is not None and not self._rebalance_due(
+                executable_session,
+                previous_cycle.session_date,
+                strategy.rebalance_frequency,
+            ):
+                raise DatasetInvalid("Deployment dnes nemá povolený rebalance")
+            target = strategy.generate_targets(
+                StrategyContext(signal_time, history, eligible, signal_prices)
+            )
+            if any(instrument not in eligible for instrument, _ in target.weights):
+                raise DatasetInvalid("Strategy vytvořila target mimo deployment PIT universe")
+            target_weights = {instrument: Decimal("0") for instrument in held}
+            target_weights.update(dict(target.weights))
         bars = [
             Bar(
                 item.instrument_id,
@@ -1639,8 +1650,6 @@ class Phase6PaperExecutionService:
             )
             for item in latest
         ]
-        target_weights = {instrument: Decimal("0") for instrument in held}
-        target_weights.update(dict(target.weights))
         from quantlab.phase7 import PaperCorporateActionService
 
         PaperCorporateActionService(self._sessions).apply(account.id, as_of)
@@ -1695,6 +1704,9 @@ class Phase6PaperExecutionService:
                     "signal_observation_ids": [
                         item.observation_id for values in history.values() for item in values
                     ],
+                    "persisted_intent_ids": sorted(
+                        intent.id for intent in (persisted_intents or ())
+                    ),
                     "decision_time": decision_time.isoformat(),
                     "signal_through_session": expected_sessions[-1].isoformat(),
                     "executable_session": executable_session.isoformat(),

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -1492,6 +1492,20 @@ class Phase6PaperExecutionService:
                 if self.corporate_action_provider_identity is None:
                     raise DatasetInvalid("CORPORATE_ACTION_PROVIDER_IDENTITY_MISSING")
                 provider_name, provider_version = self.corporate_action_provider_identity
+                readiness_end = timing.signal_session
+                readiness_cutoff = decision_time
+                if persisted_intents is not None:
+                    intent_cutoffs = {intent.decision_time for intent in persisted_intents}
+                    if len(intent_cutoffs) != 1:
+                        raise DatasetInvalid(
+                            "Persisted intents mají nekonzistentní pre-open decision cutoff"
+                        )
+                    readiness_cutoff = next(iter(intent_cutoffs))
+                    if not decision_time < readiness_cutoff < execution_time:
+                        raise DatasetInvalid(
+                            "Persisted intent decision cutoff není mezi signal close a open"
+                        )
+                    readiness_end = executable_session
                 readiness = tuple(
                     session.scalars(
                         select(CorporateActionReadinessRecord).where(
@@ -1500,8 +1514,8 @@ class Phase6PaperExecutionService:
                             CorporateActionReadinessRecord.provider_version == provider_version,
                             CorporateActionReadinessRecord.requested_start <= snapshot.start_at,
                             CorporateActionReadinessRecord.requested_end
-                            >= datetime.combine(timing.signal_session, time(), UTC),
-                            CorporateActionReadinessRecord.knowledge_cutoff == decision_time,
+                            >= datetime.combine(readiness_end, time(), UTC),
+                            CorporateActionReadinessRecord.knowledge_cutoff == readiness_cutoff,
                             CorporateActionReadinessRecord.checked_at <= as_of,
                             CorporateActionReadinessRecord.supports_actions == 1,
                             CorporateActionReadinessRecord.status == "COMPLETE",

--- a/backend/src/quantlab/worker.py
+++ b/backend/src/quantlab/worker.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import UTC, datetime
 
 from quantlab.automation import AutomationRepository, JobExecutor, SchedulerService, WorkerService
 from quantlab.config import get_settings
@@ -36,8 +37,18 @@ def main() -> None:
             worker.heartbeat()
             scheduler.tick()
             worker.heartbeat(scheduler_ticked=True)
+            dispatch_delay = worker.next_xnys_dispatch_delay(datetime.now(UTC))
+            if dispatch_delay is not None and 0 < dispatch_delay <= settings.worker_poll_interval:
+                # Těsně před open nespouštíme starší práci, která by zabrala celé
+                # executable okno; worker se probudí přímo na připravenou occurrence.
+                worker.stop_event.wait(dispatch_delay)
+                continue
             worker.execute_one()
-            worker.stop_event.wait(settings.worker_poll_interval)
+            dispatch_delay = worker.next_xnys_dispatch_delay(datetime.now(UTC))
+            wait_for = settings.worker_poll_interval
+            if dispatch_delay is not None:
+                wait_for = min(wait_for, dispatch_delay)
+            worker.stop_event.wait(wait_for)
     finally:
         worker.mark_stopped()
         logger.info("Worker byl korektně zastaven: worker_id=%s", worker.worker_id)

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -233,7 +233,7 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
     assert autonomous.status_code == 200, autonomous.text
     assert autonomous.json()["enabled"] is True
     assert autonomous.json()["schedule_type"] == "DAILY"
-    assert autonomous.json()["daily_time"] == "09:30"
+    assert autonomous.json()["daily_time"] == "09:00"
     assert autonomous.json()["timezone"] == "America/New_York"
 
     recovery_run_id = api_module.automation_scheduler.run_now(

--- a/backend/tests/test_h2_corporate_action_readiness_postgres.py
+++ b/backend/tests/test_h2_corporate_action_readiness_postgres.py
@@ -125,6 +125,40 @@ def test_unsupported_provider_is_not_empty_complete_even_with_hidden_event(scope
         assert evidence.action_count == 0
 
 
+def test_split_known_after_signal_close_is_ready_at_preopen_cutoff(scope) -> None:
+    factory, instrument = scope
+    signal_close = datetime(2026, 8, 24, 20, tzinfo=UTC)
+    received_at = datetime(2026, 8, 25, 11, tzinfo=UTC)
+    preopen_decision = datetime(2026, 8, 25, 13, tzinfo=UTC)
+    execution_open = datetime(2026, 8, 25, 13, 30, tzinfo=UTC)
+    split = CorporateAction(
+        uuid4().hex,
+        instrument.instrument_id,
+        CorporateActionKind.SPLIT,
+        execution_open,
+        received_at,
+        Decimal("2"),
+    )
+    evidence_id = PersistentMarketDataService(
+        factory, clock=lambda: preopen_decision
+    ).verify_corporate_action_readiness(
+        ActionProvider(True, [split]),
+        instrument,
+        date(2026, 8, 1),
+        execution_open.date(),
+        preopen_decision,
+    )
+    with factory() as session:
+        evidence = session.get(CorporateActionReadinessRecord, evidence_id)
+        persisted = session.get(CorporateActionRecord, split.action_id)
+        assert evidence is not None and evidence.status == "COMPLETE"
+        assert evidence.knowledge_cutoff == preopen_decision
+        assert evidence.requested_end.date() == execution_open.date()
+        assert persisted is not None and persisted.known_at == received_at
+        assert persisted.effective_at == execution_open
+    assert signal_close < received_at <= preopen_decision < execution_open
+
+
 @pytest.mark.parametrize("actions", [[], ["split"]])
 def test_capable_provider_can_prove_empty_or_pit_valid_actions(scope, actions) -> None:
     factory, instrument = scope

--- a/backend/tests/test_phase4.py
+++ b/backend/tests/test_phase4.py
@@ -250,10 +250,15 @@ def test_persisted_intent_quantity_is_invariant_to_opening_print(
         assert order.order_intent_id == "preopen-intent"
         decision = session.scalar(select(RiskDecisionRecord))
         assert decision is not None
-        assert decision.timestamp == executable.timestamp + timedelta(milliseconds=100)
+        risk_timestamp = (
+            decision.timestamp.replace(tzinfo=UTC)
+            if decision.timestamp.tzinfo is None
+            else decision.timestamp.astimezone(UTC)
+        )
+        assert risk_timestamp == executable.timestamp + timedelta(milliseconds=100)
         assert NOW < persisted.decision_time < executable.timestamp
-        assert decision.timestamp >= executable.timestamp
-        assert decision.timestamp >= persisted.decision_time
+        assert risk_timestamp >= executable.timestamp
+        assert risk_timestamp >= persisted.decision_time
         assert RiskReason.STALE_DATA.value not in json.loads(decision.reasons_json)
 
 

--- a/backend/tests/test_phase4.py
+++ b/backend/tests/test_phase4.py
@@ -23,11 +23,13 @@ from quantlab.domain import (
 )
 from quantlab.phase4 import (
     AuditEventRecord,
+    PaperAccountRecord,
     PaperFillRecord,
     PaperOrderRecord,
     PersistentPaperBroker,
     Phase4Repository,
     PortfolioRiskSnapshot,
+    PositionRecord,
     ProductionRiskConfig,
     ProductionRiskEngine,
     ReconciliationService,
@@ -260,6 +262,90 @@ def test_persisted_intent_quantity_is_invariant_to_opening_print(
         assert risk_timestamp >= executable.timestamp
         assert risk_timestamp >= persisted.decision_time
         assert RiskReason.STALE_DATA.value not in json.loads(decision.reasons_json)
+
+
+@pytest.mark.parametrize(
+    ("held_open", "expected_equity", "expected_status"),
+    [
+        (Decimal("100"), Decimal("10000"), RiskDecisionStatus.APPROVED),
+        (Decimal("150"), Decimal("12500"), RiskDecisionStatus.REJECTED),
+    ],
+)
+def test_persisted_intent_risk_uses_execution_marked_equity(
+    held_open: Decimal,
+    expected_equity: Decimal,
+    expected_status: RiskDecisionStatus,
+) -> None:
+    repository = Phase4Repository()
+    repository.seed_account(cash=Decimal("10000"))
+    with Session(repository.engine) as session, session.begin():
+        account = session.get(PaperAccountRecord, "paper-main")
+        assert account is not None
+        account.cash = Decimal("5000")
+        account.equity = Decimal("10000")
+        session.add(
+            PositionRecord(
+                account_id="paper-main",
+                instrument_id="B",
+                quantity=Decimal("50"),
+                average_cost=Decimal("100"),
+                realized_pnl=Decimal(0),
+                lots_json="[]",
+                updated_at=NOW,
+            )
+        )
+    opened = NOW + timedelta(days=1)
+    bars = [
+        Bar(
+            "A",
+            opened,
+            Decimal("100"),
+            Decimal("101"),
+            Decimal("99"),
+            Decimal("100"),
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+        Bar(
+            "B",
+            opened,
+            held_open,
+            held_open + 1,
+            held_open - 1,
+            held_open,
+            Decimal("10000"),
+            Decimal("100"),
+        ),
+    ]
+    persisted = OrderIntent(
+        "A", Side.BUY, Decimal("10"), NOW + timedelta(hours=1), "persisted-preopen", "marked-risk"
+    )
+    TradingCycleService(
+        repository,
+        ProductionRiskConfig(
+            max_position_pct=Decimal("1"),
+            max_single_order_pct=Decimal("1"),
+            max_gross_exposure=Decimal("0.65"),
+            instrument_allowlist=frozenset({"A", "B"}),
+        ),
+    ).run(
+        "paper-main",
+        "phase6:marked",
+        bars,
+        {"A": Decimal(0)},
+        date(2026, 8, 12),
+        NOW,
+        (persisted,),
+        risk_evaluation_time=opened + timedelta(milliseconds=100),
+    )
+    with Session(repository.engine) as session:
+        decision = session.scalar(select(RiskDecisionRecord))
+        assert decision is not None
+        assert decision.status == expected_status
+        assert Decimal(json.loads(decision.portfolio_json)["equity"]) == expected_equity
+        account = session.get(PaperAccountRecord, "paper-main")
+        assert account is not None
+        assert account.session_start_equity == expected_equity
 
 
 def test_partial_fill_cancel_and_invalid_transition() -> None:

--- a/backend/tests/test_phase4.py
+++ b/backend/tests/test_phase4.py
@@ -215,7 +215,12 @@ def test_persisted_intent_quantity_is_invariant_to_opening_print(
     repository = Phase4Repository()
     repository.seed_account()
     persisted = OrderIntent(
-        "SPY", Side.BUY, Decimal("37"), NOW, "persisted-preopen", "preopen-intent"
+        "SPY",
+        Side.BUY,
+        Decimal("37"),
+        NOW + timedelta(hours=1),
+        "persisted-preopen",
+        "preopen-intent",
     )
     executable = Bar(
         "SPY",
@@ -235,6 +240,7 @@ def test_persisted_intent_quantity_is_invariant_to_opening_print(
         date(2026, 8, 12),
         NOW,
         (persisted,),
+        risk_evaluation_time=executable.timestamp + timedelta(milliseconds=100),
     )
     with Session(repository.engine) as session:
         order = session.scalar(select(PaperOrderRecord))
@@ -242,6 +248,13 @@ def test_persisted_intent_quantity_is_invariant_to_opening_print(
         assert order.side == Side.BUY
         assert order.quantity == Decimal("37")
         assert order.order_intent_id == "preopen-intent"
+        decision = session.scalar(select(RiskDecisionRecord))
+        assert decision is not None
+        assert decision.timestamp == executable.timestamp + timedelta(milliseconds=100)
+        assert NOW < persisted.decision_time < executable.timestamp
+        assert decision.timestamp >= executable.timestamp
+        assert decision.timestamp >= persisted.decision_time
+        assert RiskReason.STALE_DATA.value not in json.loads(decision.reasons_json)
 
 
 def test_partial_fill_cancel_and_invalid_transition() -> None:

--- a/backend/tests/test_phase4.py
+++ b/backend/tests/test_phase4.py
@@ -208,6 +208,42 @@ def test_end_to_end_cycle_is_idempotent_and_reconciles() -> None:
     assert account.equity == account.cash + position.quantity * Decimal("101")
 
 
+@pytest.mark.parametrize("opening_price", [Decimal("100"), Decimal("150")])
+def test_persisted_intent_quantity_is_invariant_to_opening_print(
+    opening_price: Decimal,
+) -> None:
+    repository = Phase4Repository()
+    repository.seed_account()
+    persisted = OrderIntent(
+        "SPY", Side.BUY, Decimal("37"), NOW, "persisted-preopen", "preopen-intent"
+    )
+    executable = Bar(
+        "SPY",
+        NOW + timedelta(days=1),
+        opening_price,
+        opening_price + 1,
+        opening_price - 1,
+        opening_price,
+        Decimal("10000"),
+        Decimal("100"),
+    )
+    TradingCycleService(repository, ProductionRiskConfig(max_single_order_pct=Decimal("1"))).run(
+        "paper-main",
+        "phase6:deployment",
+        [executable],
+        {"SPY": Decimal("0.99")},
+        date(2026, 8, 12),
+        NOW,
+        (persisted,),
+    )
+    with Session(repository.engine) as session:
+        order = session.scalar(select(PaperOrderRecord))
+        assert order is not None
+        assert order.side == Side.BUY
+        assert order.quantity == Decimal("37")
+        assert order.order_intent_id == "preopen-intent"
+
+
 def test_partial_fill_cancel_and_invalid_transition() -> None:
     repository = Phase4Repository()
     repository.seed_account()

--- a/backend/tests/test_phase6_e2e_postgres.py
+++ b/backend/tests/test_phase6_e2e_postgres.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session, sessionmaker
 
 from quantlab.automation import PreOpenExecutionIntentRecord
-from quantlab.domain import ReconciliationStatus, SystemTradingState
+from quantlab.domain import OrderIntent, ReconciliationStatus, Side, SystemTradingState
 from quantlab.market_data import AssetType, CorporateAction, CorporateActionKind, Instrument
 from quantlab.market_data_service import DatasetSnapshotService, PersistentMarketDataService
 from quantlab.multi_asset import MultiAssetPortfolio
@@ -44,6 +44,7 @@ from quantlab.phase4 import (
     ProductionRiskConfig,
     ReconciliationRecord,
     RiskDecisionRecord,
+    TradingCycleRecord,
     TradingCycleService,
 )
 from quantlab.phase6_runtime import (
@@ -54,7 +55,12 @@ from quantlab.phase6_runtime import (
     Phase6PaperExecutionService,
     ValidatedCurrentDataAccessor,
 )
-from quantlab.phase7 import DEFAULT_POLICY, MonitoringState, PaperMonitoringService
+from quantlab.phase7 import (
+    DEFAULT_POLICY,
+    MonitoringState,
+    PaperDeploymentCycleRecord,
+    PaperMonitoringService,
+)
 
 pytestmark = pytest.mark.skipif(
     os.getenv("RUN_POSTGRES_TESTS") != "1", reason="vyžaduje PostgreSQL CI"
@@ -441,7 +447,7 @@ def _seed_opening_observation(
         )
 
 
-def _research_to_paper(factory, engine, *, halted: bool):
+def _research_to_paper(factory, engine, *, halted: bool, persisted: bool = False):
     suffix = uuid4().hex
     instrument, provider, sessions, snapshot, request = seed_phase6_snapshot(factory, suffix=suffix)
     runner = Phase6ExperimentRunner(factory)
@@ -501,9 +507,59 @@ def _research_to_paper(factory, engine, *, halted: bool):
     # Procesní default záměrně neumožňuje instrument. Deployment musí použít approved manifest.
     drifted_runtime_risk = ProductionRiskConfig(instrument_allowlist=frozenset())
     cycle = TradingCycleService(repository, drifted_runtime_risk)
-    service = Phase6PaperExecutionService(factory, ValidatedCurrentDataAccessor(factory), cycle)
-    cycle_id = service.run(deployment.deployment_id, CALENDAR.session_open(next_session))
+    current_data = ValidatedCurrentDataAccessor(factory)
+    service = Phase6PaperExecutionService(factory, current_data, cycle)
+    execution_open = CALENDAR.session_open(next_session)
+    if persisted:
+        intent = OrderIntent(
+            instrument.instrument_id,
+            Side.BUY,
+            Decimal("10"),
+            execution_open - timedelta(minutes=30),
+            "persisted-preopen",
+            f"intent-{suffix}",
+        )
+
+        def forbidden_history(*args, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError("Persisted execution nesmí znovu načíst strategy history")
+
+        current_data.history = forbidden_history  # type: ignore[method-assign]
+        cycle_id = service.run(
+            deployment.deployment_id,
+            execution_open,
+            execution_intent_time=execution_open,
+            persisted_intents=(intent,),
+        )
+    else:
+        cycle_id = service.run(deployment.deployment_id, execution_open)
     return account_id, deployment, experiment, snapshot, cycle_id, instrument, halted
+
+
+def test_postgres_persisted_execution_does_not_regenerate_strategy(factory, engine) -> None:
+    account_id, deployment, _, _, cycle_id, _, _ = _research_to_paper(
+        factory, engine, halted=False, persisted=True
+    )
+    with Session(engine) as session:
+        cycle = session.get(TradingCycleRecord, cycle_id)
+        order = session.scalar(
+            select(PaperOrderRecord).where(PaperOrderRecord.trading_cycle_id == cycle_id)
+        )
+        fill = session.scalar(
+            select(PaperFillRecord)
+            .join(PaperOrderRecord)
+            .where(PaperOrderRecord.trading_cycle_id == cycle_id)
+        )
+        lineage = session.scalar(
+            select(PaperDeploymentCycleRecord).where(
+                PaperDeploymentCycleRecord.trading_cycle_id == cycle_id,
+                PaperDeploymentCycleRecord.deployment_id == deployment.deployment_id,
+            )
+        )
+        assert cycle is not None and cycle.status == "COMPLETED"
+        assert order is not None and order.order_intent_id.startswith("intent-")
+        assert fill is not None
+        assert lineage is not None
+        assert session.get(PaperAccountRecord, account_id) is not None
 
 
 def test_postgres_research_to_paper_authoritative_e2e(factory, engine) -> None:

--- a/backend/tests/test_phase6_e2e_postgres.py
+++ b/backend/tests/test_phase6_e2e_postgres.py
@@ -596,20 +596,22 @@ def test_postgres_research_to_paper_authoritative_e2e(factory, engine) -> None:
                 integrity_hash="0" * 64,
             )
         )
-    with pytest.raises(DBAPIError, match="pre-open execution intents are immutable"):
+    with pytest.raises(DBAPIError) as update_error:
         with Session(engine) as session, session.begin():
             session.execute(
                 update(PreOpenExecutionIntentRecord)
                 .where(PreOpenExecutionIntentRecord.intent_id == immutable_id)
                 .values(quantity=Decimal("2"))
             )
-    with pytest.raises(DBAPIError, match="pre-open execution intents are immutable"):
+    assert "pre-open execution intents are immutable" in str(update_error.value.orig)
+    with pytest.raises(DBAPIError) as delete_error:
         with Session(engine) as session, session.begin():
             session.execute(
                 delete(PreOpenExecutionIntentRecord).where(
                     PreOpenExecutionIntentRecord.intent_id == immutable_id
                 )
             )
+    assert "pre-open execution intents are immutable" in str(delete_error.value.orig)
     matching = next(
         item
         for item in lineage

--- a/backend/tests/test_phase6_e2e_postgres.py
+++ b/backend/tests/test_phase6_e2e_postgres.py
@@ -15,9 +15,11 @@ from phase6_audit_helpers import (
     daily_bar,
     seed_phase6_snapshot,
 )
-from sqlalchemy import create_engine, func, select
+from sqlalchemy import create_engine, delete, func, select, update
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session, sessionmaker
 
+from quantlab.automation import PreOpenExecutionIntentRecord
 from quantlab.domain import ReconciliationStatus, SystemTradingState
 from quantlab.market_data import AssetType, CorporateAction, CorporateActionKind, Instrument
 from quantlab.market_data_service import DatasetSnapshotService, PersistentMarketDataService
@@ -567,6 +569,47 @@ def test_postgres_research_to_paper_authoritative_e2e(factory, engine) -> None:
                 session.get(DatasetSnapshotRecord, snapshot.snapshot_id).manifest_json
             )["observations"]
         }
+
+    execution_open = CALENDAR.session_open(fill.timestamp.date())
+    immutable_id = uuid4().hex.ljust(64, "0")
+    with Session(engine) as session, session.begin():
+        session.add(
+            PreOpenExecutionIntentRecord(
+                intent_id=immutable_id,
+                deployment_id=deployment.deployment_id,
+                account_id=account_id,
+                strategy_id=f"phase6:{deployment.deployment_id}",
+                instrument_id=instrument.instrument_id,
+                side="BUY",
+                quantity=Decimal("1"),
+                order_type="MARKET",
+                execution_session=execution_open.date(),
+                intended_execution_open=execution_open,
+                decision_time=execution_open - timedelta(hours=1),
+                created_at=execution_open - timedelta(hours=1),
+                sizing_reference_price=Decimal("100"),
+                sizing_reference_known_at=execution_open - timedelta(hours=1),
+                snapshot_id=snapshot.snapshot_id,
+                universe_id=snapshot.universe_id,
+                signal_observation_ids_json="[]",
+                evidence_json="{}",
+                integrity_hash="0" * 64,
+            )
+        )
+    with pytest.raises(DBAPIError, match="pre-open execution intents are immutable"):
+        with Session(engine) as session, session.begin():
+            session.execute(
+                update(PreOpenExecutionIntentRecord)
+                .where(PreOpenExecutionIntentRecord.intent_id == immutable_id)
+                .values(quantity=Decimal("2"))
+            )
+    with pytest.raises(DBAPIError, match="pre-open execution intents are immutable"):
+        with Session(engine) as session, session.begin():
+            session.execute(
+                delete(PreOpenExecutionIntentRecord).where(
+                    PreOpenExecutionIntentRecord.intent_id == immutable_id
+                )
+            )
     matching = next(
         item
         for item in lineage

--- a/backend/tests/test_phase6_runtime.py
+++ b/backend/tests/test_phase6_runtime.py
@@ -3,7 +3,15 @@ from decimal import Decimal
 
 from quantlab.domain import Side
 from quantlab.multi_asset import MultiAssetFill, MultiAssetResult
-from quantlab.phase6_runtime import multi_asset_metrics
+from quantlab.phase6_runtime import multi_asset_metrics, persisted_execution_open_scope
+
+
+def test_persisted_execution_open_scope_excludes_zero_delta_unheld_assets() -> None:
+    assert persisted_execution_open_scope({"A"}, set()) == ("A",)
+
+
+def test_persisted_execution_open_scope_includes_held_assets_without_intent() -> None:
+    assert persisted_execution_open_scope({"A"}, {"B"}) == ("A", "B")
 
 
 def test_multi_asset_metrics_use_time_weighted_exposure_and_hand_calculated_costs() -> None:

--- a/backend/tests/test_pre_pilot_review_remediation.py
+++ b/backend/tests/test_pre_pilot_review_remediation.py
@@ -1,4 +1,5 @@
 from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
 
 from sqlalchemy.orm import Session
 
@@ -14,8 +15,12 @@ from quantlab.automation import (
     RunStatus,
     ScheduledJob,
     ScheduleType,
+    WorkerService,
     daily_occurrence_at_or_after,
+    mark_preopen_equity,
+    preopen_execution_delta,
 )
+from quantlab.config import Settings
 from quantlab.market_data import XNYSCalendar
 from quantlab.phase4 import AuditEventRecord, Phase4Repository
 
@@ -69,6 +74,42 @@ def test_executable_open_window_remains_fail_closed() -> None:
     assert calendar.is_executable_open_time(session, opened)
     assert calendar.is_executable_open_time(session, opened + timedelta(milliseconds=999))
     assert not calendar.is_executable_open_time(session, opened + timedelta(seconds=1))
+
+
+def test_worker_waits_precisely_for_materialized_xnys_open(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    database_url = f"sqlite:///{tmp_path / 'xnys-dispatch.db'}"
+    Phase4Repository(database_url, bootstrap_test_schema=True).seed_account()
+    repository = AutomationRepository(database_url)
+    now = datetime(2026, 7, 6, 13, 29, 59, 750000, tzinfo=UTC)
+    opened = datetime(2026, 7, 6, 13, 30, tzinfo=UTC)
+    repository.materialize_execution_session(
+        deployment_id="deployment-test",
+        account_id="paper-main",
+        execution_session=date(2026, 7, 6),
+        execution_time=opened,
+        created_at=now,
+    )
+    worker = WorkerService(
+        repository,
+        Settings(database_url=database_url, automation_enabled=True),
+        worker_id="dispatch-test",
+    )
+    assert worker.next_xnys_dispatch_delay(now) == 0.25
+
+
+def test_preopen_sizing_marks_equity_and_normalizes_next_open_split() -> None:
+    marked = mark_preopen_equity(Decimal("1000"), {"SPY": Decimal("50")}, {"SPY": Decimal("100")})
+    reference, delta = preopen_execution_delta(
+        marked_equity=marked,
+        weight=Decimal("1"),
+        signal_reference=Decimal("100"),
+        split_ratio=Decimal("2"),
+        position=Decimal("50"),
+        pending=Decimal(0),
+    )
+    assert marked == Decimal("6000")
+    assert reference == Decimal("50")
+    assert delta == Decimal("20")
 
 
 def test_legacy_autonomous_schedule_is_disabled_before_polling(tmp_path) -> None:  # type: ignore[no-untyped-def]

--- a/backend/tests/test_pre_pilot_review_remediation.py
+++ b/backend/tests/test_pre_pilot_review_remediation.py
@@ -58,8 +58,8 @@ def test_autonomous_daily_occurrence_tracks_new_york_dst() -> None:
         AUTONOMOUS_DAILY_TIME,
         AUTONOMOUS_TIMEZONE,
     )
-    assert summer == datetime(2026, 7, 6, 13, 30, tzinfo=UTC)
-    assert winter == datetime(2026, 1, 5, 14, 30, tzinfo=UTC)
+    assert summer == datetime(2026, 7, 6, 13, tzinfo=UTC)
+    assert winter == datetime(2026, 1, 5, 14, tzinfo=UTC)
 
 
 def test_executable_open_window_remains_fail_closed() -> None:

--- a/docs/paper-pilot-runbook.md
+++ b/docs/paper-pilot-runbook.md
@@ -82,6 +82,8 @@ Autonomous PREPARE schedule je ukotvený na `09:00 America/New_York` a je DST-sa
 
 Strict executable-open cutoff zůstává `[open, open + 1 second)`. `PREPARE_PAPER_SESSION` před open persistuje target delta vypočtený z causal adjusted signal close a teprve poté materializuje execution occurrence. Proto platí:
 
+Production worker rezervuje nejbližší materializované XNYS occurrence před běžnou frontou a čeká přímo do jejího `scheduled_for`; pětisekundový obecný polling tedy není dispatch mechanismem executable-open běhu. Provider response time se měří živými UTC hodinami a odpověď získaná po cutoff failuje jako `MISSED_EXECUTION_OPEN` bez fillu.
+
 - execution bez pre-open intentu vrátí `NO_ACTION / PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`;
 - pozdní nebo porušený intent vrátí `NO_ACTION / PREOPEN_EXECUTION_INTENT_INVALID`;
 - raw opening print se nesmí použít k vytvoření nového ekonomického intentu;

--- a/docs/paper-pilot-runbook.md
+++ b/docs/paper-pilot-runbook.md
@@ -90,6 +90,8 @@ Production worker rezervuje nejbližší materializované XNYS occurrence před 
 - validní `xnys:` run smí raw open použít jen pro risk, kapacitu a fill, nikoli pro side/quantity;
 - persisted-intent execution načítá raw open pro všechny intent instrumenty a všechny držené instrumenty potřebné pro portfolio/risk marking; zero-delta neheld člen universe raw open nevyžaduje;
 - execution-time risk decision používá skutečný open-time knowledge čas, nikdy previous-session signal close;
+- risk equity a nový `session_start_equity` se markují z cash a raw-open cen všech held instrumentů; stale ledger equity není risk denominator;
+- corporate-action readiness pre-open intentu končí execution session a používá skutečný PREPARE decision cutoff, zatímco strategy signal history zůstává omezena prior-session causal cutoffem;
 - žádný backdating `scheduled_for` nevytváří pre-open objednávku;
 - po cutoff se nikdy nedělá retroaktivní fill ani ruční backfill.
 

--- a/docs/paper-pilot-runbook.md
+++ b/docs/paper-pilot-runbook.md
@@ -92,6 +92,7 @@ Production worker rezervuje nejbližší materializované XNYS occurrence před 
 - execution-time risk decision používá skutečný open-time knowledge čas, nikdy previous-session signal close;
 - risk equity a nový `session_start_equity` se markují z cash a raw-open cen všech held instrumentů; stale ledger equity není risk denominator;
 - corporate-action readiness pre-open intentu končí execution session a používá skutečný PREPARE decision cutoff, zatímco strategy signal history zůstává omezena prior-session causal cutoffem;
+- persisted-intent open cesta znovu nenačítá signal history ani negeneruje target portfolio; ekonomické strategy rozhodnutí proběhlo výhradně v PREPARE a open runtime pouze validuje a vykonává immutable intent;
 - žádný backdating `scheduled_for` nevytváří pre-open objednávku;
 - po cutoff se nikdy nedělá retroaktivní fill ani ruční backfill.
 

--- a/docs/paper-pilot-runbook.md
+++ b/docs/paper-pilot-runbook.md
@@ -88,6 +88,8 @@ Production worker rezervuje nejbližší materializované XNYS occurrence před 
 - pozdní nebo porušený intent vrátí `NO_ACTION / PREOPEN_EXECUTION_INTENT_INVALID`;
 - raw opening print se nesmí použít k vytvoření nového ekonomického intentu;
 - validní `xnys:` run smí raw open použít jen pro risk, kapacitu a fill, nikoli pro side/quantity;
+- persisted-intent execution načítá raw open pro všechny intent instrumenty a všechny držené instrumenty potřebné pro portfolio/risk marking; zero-delta neheld člen universe raw open nevyžaduje;
+- execution-time risk decision používá skutečný open-time knowledge čas, nikdy previous-session signal close;
 - žádný backdating `scheduled_for` nevytváří pre-open objednávku;
 - po cutoff se nikdy nedělá retroaktivní fill ani ruční backfill.
 

--- a/docs/paper-pilot-runbook.md
+++ b/docs/paper-pilot-runbook.md
@@ -2,10 +2,7 @@
 
 Tento runbook je pouze pro interní PAPER provoz. **Aktuální stav repository je NOT READY FOR PAPER PILOT.** Nezakládá ani nepovoluje live režim.
 
-Aktuálně existují dva hard blockery:
-
-1. production `StooqProvider` nemá corporate-action capability (`supports_actions=False`);
-2. autonomous execution ještě nemá před XNYS open persistovaný plně specifikovaný immutable economic/order intent (`side` + `quantity`). Proto autonomous open-time path záměrně končí no-action `PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`.
+Obě dříve chybějící capability (production Alpaca v5 corporate-action evidence a immutable pre-open economic intent) jsou implementované. Hard blockerem spuštění je nyní chybějící zelený required CI a production-like PostgreSQL/staging acceptance výsledného head SHA.
 
 ## 1. Hard gates před pilotem
 
@@ -18,12 +15,12 @@ Pilot se nesmí spustit, dokud není současně splněno vše:
 5. production provider pro equity scope skutečně podporuje corporate actions a capability je E2E ověřena;
 6. corporate-action readiness je `READY` pro celý požadovaný interval;
 7. monitoring enrollment má právě jeden validní enabled canonical `MONITOR_PAPER_DEPLOYMENT` schedule;
-8. autonomous schedule je DST-safe ukotvený na XNYS 09:30 a žádný legacy/drifted schedule není enabled;
+8. autonomous PREPARE schedule je DST-safe ukotvený na 09:00 `America/New_York` a žádný legacy/drifted schedule není enabled;
 9. před 09:30 existuje immutable auditovatelný economic/order intent, jehož side/quantity nemůže záviset na current-session opening printu;
 10. FAILED/DEAD_LETTER recovery pro managed jobs je auditovaná a atomická;
 11. proběhl celý production-like staging dry-run.
 
-Dokud body 5 a 9 nejsou splněny, **nepokračujte k autonomous equity pilotu**.
+Dokud všechny body včetně CI a production-like acceptance nejsou doloženy pro nasazovaný SHA, **nepokračujte k autonomous equity pilotu**.
 
 ## 2. Production-like topology
 
@@ -66,7 +63,7 @@ Před autonomous enable musí být ověřeno:
 - canonical autonomous schedule;
 - pre-open immutable economic/order intent capability.
 
-Současný production provider a současná autonomous intent architektura poslední dva ekonomické gates nesplňují; funkční autonomous pilot je proto zakázán.
+Tyto gates musí být ověřeny nad konkrétním nasazovaným SHA; samotná existence implementace není provozní důkaz.
 
 ## 5. Monitoring invariant
 
@@ -81,17 +78,18 @@ Enrollment a scheduler job nemusí vznikat v jedné DB transakci. Bezpečnost je
 
 ## 6. XNYS scheduling a execution causalita
 
-Autonomous schedule je ukotvený na `09:30 America/New_York` a je DST-safe. To pouze řeší orchestration phase; samo o sobě to nedává právo obchodovat.
+Autonomous PREPARE schedule je ukotvený na `09:00 America/New_York` a je DST-safe; připravený execution occurrence zůstává ukotvený na skutečný XNYS open.
 
-Strict executable-open cutoff zůstává `[open, open + 1 second)`. Současný autonomous path ale nesmí ani uvnitř tohoto okna nejprve načíst opening print a až potom vytvořit side/quantity. Proto bez pre-open immutable intentu platí:
+Strict executable-open cutoff zůstává `[open, open + 1 second)`. `PREPARE_PAPER_SESSION` před open persistuje target delta vypočtený z causal adjusted signal close a teprve poté materializuje execution occurrence. Proto platí:
 
-- `PREPARE_PAPER_SESSION` při/po execution open vrátí `NO_ACTION / PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`;
+- execution bez pre-open intentu vrátí `NO_ACTION / PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`;
+- pozdní nebo porušený intent vrátí `NO_ACTION / PREOPEN_EXECUTION_INTENT_INVALID`;
 - raw opening print se nesmí použít k vytvoření nového ekonomického intentu;
-- legacy materializovaný `xnys:` execution run je rovněž no-action;
+- validní `xnys:` run smí raw open použít jen pro risk, kapacitu a fill, nikoli pro side/quantity;
 - žádný backdating `scheduled_for` nevytváří pre-open objednávku;
 - po cutoff se nikdy nedělá retroaktivní fill ani ruční backfill.
 
-Budoucí funkční implementace musí před open persistovat immutable intent s plně určenou side/quantity a lineage. Po open smí pouze připojit validovaný raw opening print a provést fill podle již existujícího intentu.
+Intent record je append-only a nese deployment/account/strategy/session identitu, decision a persistence čas, sizing reference, snapshot/universe/signal-observation lineage a integritní hash. Execution jeho ekonomická pole nemění.
 
 ## 7. Auditovaný FAILED/DEAD_LETTER recovery
 

--- a/docs/pre-pilot-forensic-reaudit.md
+++ b/docs/pre-pilot-forensic-reaudit.md
@@ -4,10 +4,7 @@
 
 **NOT READY FOR PAPER PILOT**
 
-Verdikt je záměrně fail-closed. PR #67 opravuje nalezené control-plane, scheduling, recovery a network mezery, ale současný production path stále nesplňuje dvě nutné ekonomické capability:
-
-1. `StooqProvider` deklaruje `supports_actions=False`, takže neexistuje production corporate-action-capable feed pro XNYS/USD equity pilot.
-2. Současná autonomous orchestrace nepersistuje před XNYS open plně specifikovaný immutable economic/order intent (`side` + `quantity`). Runtime proto po open záměrně odmítá vytvořit ekonomický efekt a vrací `PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`.
+Verdikt zůstává fail-closed do zeleného required CI a production-like acceptance výsledného SHA. Production Alpaca v5 corporate-action contract je provider-capable a autonomous orchestrace nyní před open persistuje plně specifikovaný immutable economic intent (`side` + `quantity`). Bez validního intentu zůstává `PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`.
 
 Dokumentace nesmí být silnější než implementace. Zelený syntetický test není production evidence a timestamp připnutý na 09:30 sám o sobě nedokazuje, že objednávka vznikla před znalostí opening printu.
 
@@ -16,13 +13,13 @@ Dokumentace nesmí být silnější než implementace. Zelený syntetický test 
 | Oblast | Stav | Bezpečnostní vlastnost |
 | --- | --- | --- |
 | Monitoring enrollment/schedule | REMEDIATED, čeká na výsledné CI | Deterministický `MONITOR_PAPER_DEPLOYMENT` job je idempotentně ensure/re-enable/normalizován. Autonomous enable kontroluje celý kanonický schedule a failuje při driftu. |
-| Corporate-action provider | **OPEN PILOT BLOCKER** | `StooqProvider.supports_actions=False` zůstává pravdivé; equity autonomous enable nesmí tento gate obejít. |
+| Corporate-action provider | REMEDIATED, čeká na výsledné CI | Production Alpaca v5 používá SSE receipt evidence a exact REST ↔ SSE revision match; Stooq zůstává nezpůsobilý. |
 | FAILED/DEAD_LETTER recovery | REMEDIATED, čeká na výsledné CI | Managed retry a control audit event vznikají v jedné DB transakci. Actor pochází ze server-side principalu, reason je povinný a correlation ID je persistovaný. |
 | Managed retry UI | REMEDIATED, čeká na výsledné CI | ADMIN recovery se zobrazuje pouze FAILED/DEAD_LETTER runům, jejichž `scheduled_job_id` patří managed jobu. |
 | Market-data egress | REMEDIATED, staging evidence stále povinná | DB `data` síť zůstává interní; backend/worker mají explicitní market-data egress; frontend ingress je oddělený. Aplikační Stooq transport dál allowlistuje HTTPS `stooq.com`. |
 | Legacy 300s schedules | REMEDIATED, čeká na výsledné CI | Worker před prvním scheduler tickem fail-closed vypne enabled legacy/drifted `PREPARE_PAPER_SESSION` rows. |
 | Monitoring retirement | REMEDIATED, čeká na výsledné CI | `RETIRED` v téže lifecycle transakci vypne deterministický monitoring schedule i autonomous deployment schedule. |
-| XNYS causal execution | **OPEN PILOT BLOCKER** | Schedule je DST-safe ukotvený na 09:30 `America/New_York`, ale bez immutable pre-open order intentu nesmí open-time path vytvořit order/fill. Autonomous XNYS occurrence proto končí no-action. |
+| XNYS causal execution | REMEDIATED, čeká na výsledné CI | PREPARE schedule je DST-safe ukotvený na 09:00 `America/New_York`; pre-open target delta používá causal adjusted signal close, immutable intent má deterministickou identitu/hash/lineage a open-time cesta smí jen validovat intent a použít raw open pro risk/fill. |
 
 Žádný řádek označený `REMEDIATED, čeká na výsledné CI` není `PASS`, dokud required CI výsledného SHA skutečně neprojde.
 
@@ -67,18 +64,17 @@ Samotná Docker egress síť není hostname firewall. Provider transport proto d
 
 ## XNYS scheduling a causalita
 
-Arbitrary 300sekundový interval od času enablementu není autoritativní scheduling. Nový managed schedule je daily `09:30 America/New_York`, tedy DST-safe. Při startu workeru jsou staré enabled 300s nebo jinak drifted managed schedules před prvním scheduler tickem vypnuty.
+Arbitrary 300sekundový interval od času enablementu není autoritativní scheduling. Managed PREPARE schedule je daily `09:00 America/New_York`, tedy DST-safe a před open. Při startu workeru jsou staré enabled 300s nebo jinak drifted managed schedules před prvním scheduler tickem vypnuty.
 
-To však samo o sobě nestačí k ekonomické kauzalitě. Současný systém nemá před 09:30 persistovaný plně specifikovaný immutable order intent. Kdyby po 09:30 nejprve načetl opening print a teprve potom odvodil side/quantity, šlo by o retroaktivní rozhodnutí i při `scheduled_for=09:30`.
+`PREPARE_PAPER_SESSION` nyní po readiness a strategy evaluation vypočítá target delta z account equity, pozice a causal adjusted signal close. Persistuje side, quantity, decision/reference časy, snapshot/universe/observation lineage a integritní hash. Teprve potom materializuje `xnys:` occurrence. PostgreSQL trigger zakazuje UPDATE i DELETE.
 
-Proto PR #67 zavádí fail-closed hranici:
+Open-time cesta:
 
-- autonomous PREPARE při/po execution open nevytváří raw-open economic run a vrací `PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`;
-- již materializovaný legacy `xnys:` execution run je rovněž no-action;
+- chybějící intent vrací `PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`;
+- pozdní, konfliktní nebo integritně neplatný intent vrací `PREOPEN_EXECUTION_INTENT_INVALID`;
+- validní intent vstupuje beze změny side/quantity do stávající `TradingCycleService` → risk → execution → `PaperBroker` cesty;
 - strict executable-open cutoff zůstává `[open, open + 1 second)` jako obrana ostatních explicitně auditovaných cest;
 - žádný timestamp backdating nesmí nahrazovat skutečný pre-open intent.
-
-Budoucí funkční autonomous pilot vyžaduje nový persistentní, immutable a auditovatelný pre-open intent, jehož side/quantity vzniknou bez znalosti current-session opening printu. Po open smí být pouze připojena validovaná execution price evidence a proveden fill podle tohoto již existujícího intentu.
 
 ## Testovací izolace rate limitu
 
@@ -97,10 +93,10 @@ Před změnou z `NOT READY FOR PAPER PILOT` musí být současně doloženo:
 7. skutečný corporate-action-capable production provider s E2E readiness evidence;
 8. persistentní fully-specified immutable pre-open economic/order intent a E2E důkaz, že opening print nemůže ovlivnit side/quantity.
 
-Body 7 a 8 jsou aktuální pilot blockery. Dokud nejsou oba splněny, autonomous equity PAPER pilot se nesmí spustit.
+Capability body 7 a 8 jsou implementované. Zbývajícím blockerem verdictu je zelené required CI a production-like PostgreSQL/staging acceptance výsledného head SHA; bez těchto důkazů se pilot nesmí spustit.
 
 ## Final recommendation
 
-Předchozí `CONDITIONAL READY` verdict se ruší. Bezpečný stav je **NOT READY FOR PAPER PILOT**. PR #67 může uzavřít control-plane a fail-closed runtime mezery, ale nesmí změnit verdict na READY, dokud production provider nemá pravdivou corporate-action capability a autonomous execution nemá auditovatelný immutable pre-open economic intent.
+Bezpečný stav zůstává **NOT READY FOR PAPER PILOT**, dokud neprojde required CI a production-like acceptance finálního SHA. Nejde již o známou chybějící ekonomickou capability, ale o chybějící provozní důkaz této konkrétní revize.
 
 Acceptance tohoto PR se vyhodnocuje výhradně nad finálním head SHA po všech remediation commitech. Jakákoli další změna kódu nebo testů vyžaduje nové required CI nad novým head SHA.


### PR DESCRIPTION
### Motivation
- Root cause: autonomní PREPARE před XNYS open nevytvářel persistovaný immutable ekonomický intent, takže `TradingCycleService` dříve odvozoval `side`/`quantity` z opening printu a porušoval kauzalitu next‑open execution.\
- Cíl změny: zajistit, že před execution open existují auditovatelné, immutable pre‑open intenty (side, quantity, sizing evidence, lineage) a že open‑time cesta je pouze verifikační a prováděcí (risk → execution → PaperBroker).\

### Description
- Přidán persistentní model `PreOpenExecutionIntentRecord` s DB‑level constrainty a integritním hashem a přidána Alembic migrace `20260830_02_preopen_execution_intents.py` pro append‑only tabulku s triggerem (Postgres) znemožňujícím UPDATE/DELETE.\
- `JobExecutor._persist_preopen_intents(...)` implementuje deterministický sizing z kauzálních signalů (causal adjusted signal close), vytváří intenty před otevřením a ukládá obseration/snapshot/universe evidence + integrity hash; PREPARE materializuje execution occurrence až po úspěšném persistování intentů.\
- Open‑time orchestrace (`RUN_PAPER_DEPLOYMENT` / Phase6) nyní ověřuje existenci/integitu intentů a pokud chybí nebo je neplatný vrací explicitní reasony (`PREOPEN_EXECUTION_INTENT_NOT_PERSISTED`, `PREOPEN_EXECUTION_INTENT_INVALID`, nebo `MISSED_EXECUTION_OPEN`); při validním intentu se intent předává beze změny do existující cesty `TradingCycleService → RiskEngine → ExecutionEngine → PersistentPaperBroker`.\
- `TradingCycleService.run()` rozšířen o podporu zpracování předem persistovaných `OrderIntent` objektů tak, aby open price již nemohl ovlivnit side/quantity; pokud risk engine navrhne `MODIFIED` pro persisted intent, cesta preferuje fail‑closed (reject).\
- Testy & dokumentace: přidán integrační/regresní test ověřující invariant „persisted intent invariant vůči různému opening printu“, aktualizován `docs/pre-pilot-forensic-reaudit.md` a `docs/paper-pilot-runbook.md` (PREPARE posunut na DST‑safe 09:00, popis invariantu, reason codes).\
- Zachováno paper‑only chování a žádná live execution path nebyla přidána; změny kompatibilně využívají stávající risk/execution/broker stack bez paralelních brokerů.\

### Testing
- Statická/formátovací kontrola: `ruff format` / `ruff check` nad upravenými soubory — prošlo lokálně v prostředí.\
- Syntax check: `python -m py_compile` nad upravenými moduly — prošlo.\
- Type‑check / dependency checks: `mypy` narazil na chybějící nainstalované závislosti (SQLAlchemy, pydantic, pyarrow, exchange_calendars), takže kompletní typová kontrola byla v tomto prostředí blokována.\
- Unit / integration test run: spuštění `pytest` bylo blokováno chybějící runtime dependency (`fastapi`) a nelze spustit kompletní backend suite v tomto izolovaném prostředí.\
- CI / dependency tooling: `uv lock --check` nebylo možné dokončit kvůli verzi `uv` v prostředí a nemožnosti instalace požadované verze z externího registru (síť/proxy omezení).\
- Migrace a E2E DB acceptance: Alembic migrace byla přidána do repozitáře a syntakticky zkontrolována, ale plná DB migration/upgrade a PostgreSQL E2E akceptační test nebyly v tomto prostředí spustitelné a čekají na CI nebo lokální Postgres.\

Poznámka: všechny změny zachovávají Phase 3–6 invarianty, neinicializují live trading a zavádějí explicitní fail‑closed chování při chybě nebo konfliktech intentů.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a941bd988c483329bf7e74de9dd2ebb)