### PR TITLE
Phase6: Centrální normalizace parametrů strategií (Decimal/int)

### DIFF
--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -8,7 +8,7 @@ import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, time
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from uuid import uuid4
 
 from sqlalchemy import select
@@ -122,6 +122,75 @@ class PaperExecutionTiming:
     execution_time: datetime
 
 
+_STRATEGY_PARAMETER_TYPES: dict[str, dict[str, type[object]]] = {
+    "multi_asset_trend": {"fast": int, "slow": int},
+    "cross_sectional_momentum": {"lookback": int, "top_n": int},
+    "multi_asset_mean_reversion": {"lookback": int, "threshold": Decimal},
+}
+
+
+def _normalize_integer(value: object, parameter: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+        raise DatasetInvalid(f"Parametr {parameter} musí být celé číslo")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise DatasetInvalid(f"Parametr {parameter} musí být konečné celé číslo")
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise DatasetInvalid(f"Parametr {parameter} musí být celé číslo") from exc
+    if not decimal_value.is_finite() or decimal_value != decimal_value.to_integral_value():
+        raise DatasetInvalid(f"Parametr {parameter} musí být konečné celé číslo")
+    return int(decimal_value)
+
+
+def _normalize_decimal(value: object, parameter: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (str, int, float, Decimal)):
+        raise DatasetInvalid(f"Parametr {parameter} musí být desetinné číslo")
+    try:
+        normalized = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise DatasetInvalid(f"Parametr {parameter} musí být desetinné číslo") from exc
+    if not normalized.is_finite():
+        raise DatasetInvalid(f"Parametr {parameter} musí být konečné desetinné číslo")
+    return normalized
+
+
+def normalize_strategy_config(
+    strategy_name: str, strategy_version: str, config: dict[str, object]
+) -> dict[str, object]:
+    """Normalizuje allowlisted Phase 6 konfiguraci na ekonomické Python typy."""
+    strategy_type = STRATEGY_REGISTRY.get(strategy_name)
+    parameter_types = _STRATEGY_PARAMETER_TYPES.get(strategy_name)
+    if strategy_type is None or parameter_types is None or strategy_version != "1.0.0":
+        raise DatasetInvalid("Přesná strategy version není allowlisted")
+    if any(not isinstance(parameter, str) for parameter in config):
+        raise DatasetInvalid("Názvy strategy parametrů musí být řetězce")
+    unknown = set(config) - (set(parameter_types) | {"rebalance_frequency"})
+    if unknown:
+        raise DatasetInvalid(f"Neznámé strategy parametry: {', '.join(sorted(unknown))}")
+    normalized: dict[str, object] = {}
+    for parameter, value in config.items():
+        expected = parameter_types.get(parameter)
+        if expected is int:
+            normalized[parameter] = _normalize_integer(value, parameter)
+        elif expected is Decimal:
+            normalized[parameter] = _normalize_decimal(value, parameter)
+        elif parameter == "rebalance_frequency":
+            if not isinstance(value, str):
+                raise DatasetInvalid("Parametr rebalance_frequency není platný")
+            try:
+                normalized[parameter] = RebalanceFrequency(value)
+            except (TypeError, ValueError) as exc:
+                raise DatasetInvalid("Parametr rebalance_frequency není platný") from exc
+    try:
+        implementation = strategy_type(**normalized)
+    except (TypeError, ValueError, InvalidOperation, OverflowError) as exc:
+        raise DatasetInvalid("Strategy parametry jsou mimo povolené meze") from exc
+    if implementation.name != strategy_name or implementation.version != strategy_version:
+        raise DatasetInvalid("Implementace strategy version neodpovídá allowlistu")
+    return normalized
+
+
 def persisted_execution_open_scope(
     intent_instruments: set[str], held_instruments: set[str]
 ) -> tuple[str, ...]:
@@ -178,6 +247,10 @@ class Phase6ExperimentRunner:
     ) -> ExperimentRecord | Phase6ExperimentReplay:
         if not request.parameter_configs:
             raise ValueError("Parameter space nesmí být prázdný")
+        normalized_configs = tuple(
+            normalize_strategy_config(request.strategy_name, request.strategy_version, config)
+            for config in request.parameter_configs
+        )
         if not Decimal(0) < request.train_fraction < Decimal(1) or not Decimal(
             0
         ) < request.validation_fraction < Decimal(1):
@@ -186,7 +259,7 @@ class Phase6ExperimentRunner:
         identity_payload = {
             "snapshot_id": request.snapshot_id,
             "strategy": [request.strategy_name, request.strategy_version],
-            "parameters": request.parameter_configs,
+            "parameters": normalized_configs,
             "train_fraction": request.train_fraction,
             "validation_fraction": request.validation_fraction,
             "initial_cash": request.initial_cash,
@@ -402,7 +475,7 @@ class Phase6ExperimentRunner:
                 return multi_asset_metrics(result, request.initial_cash), result
 
             scored: list[tuple[Decimal, str, dict[str, object], MultiAssetMetrics]] = []
-            for config in request.parameter_configs:
+            for config in normalized_configs:
                 evaluate(config, times[:train_end])
                 validation, _ = evaluate(config, times[train_end:validation_end])
                 scored.append(
@@ -439,7 +512,7 @@ class Phase6ExperimentRunner:
                 strategy_name=request.strategy_name,
                 strategy_version=request.strategy_version,
                 parameter_space_id=hashlib.sha256(
-                    self._canonical(request.parameter_configs).encode()
+                    self._canonical(normalized_configs).encode()
                 ).hexdigest(),
                 decision="RESEARCH_ONLY",
                 total_return=float(oos.total_return),
@@ -1176,7 +1249,12 @@ class DeploymentService:
                 raise DatasetInvalid("Deployment vyžaduje existující kompatibilní paper účet")
             if row.timeframe != "1d" or snapshot.timeframe != row.timeframe:
                 raise DatasetInvalid("Deployment timeframe není podporován")
-            if self._evidence(row.parameters_json, "deployment parameters") != parameters:
+            persisted_parameters = normalize_strategy_config(
+                row.strategy_name,
+                row.strategy_version,
+                self._evidence(row.parameters_json, "deployment parameters"),
+            )
+            if persisted_parameters != parameters:
                 raise DatasetInvalid("Deployment parameters neodpovídají experiment evidence")
             if already_approved:
                 return
@@ -1267,11 +1345,12 @@ class DeploymentService:
             raise DatasetInvalid("Experiment nemá code SHA")
         cls._valid_sha(experiment.code_sha)
         cls._evidence(experiment.cost_model_json, "cost model")
-        parameters = cls._evidence(experiment.selected_parameters_json, "parameters")
-        try:
-            implementation = strategy_type(**parameters)
-        except (TypeError, ValueError) as exc:
-            raise DatasetInvalid("Experiment parameters nejsou pro strategii platné") from exc
+        parameters = normalize_strategy_config(
+            experiment.strategy_name,
+            experiment.strategy_version,
+            cls._evidence(experiment.selected_parameters_json, "parameters"),
+        )
+        implementation = strategy_type(**parameters)
         if (
             implementation.name != experiment.strategy_name
             or implementation.version != experiment.strategy_version
@@ -1445,7 +1524,13 @@ class Phase6PaperExecutionService:
                 or deployment.universe_id != snapshot.universe_id
                 or deployment.strategy_name != strategy_row.strategy_name
                 or deployment.strategy_version != strategy_row.strategy_version
-                or DeploymentService._evidence(deployment.parameters_json, "deployment parameters")
+                or normalize_strategy_config(
+                    deployment.strategy_name,
+                    deployment.strategy_version,
+                    DeploymentService._evidence(
+                        deployment.parameters_json, "deployment parameters"
+                    ),
+                )
                 != selected
                 or account is None
                 or deployment.currency != "USD"

--- a/backend/src/quantlab/phase6_runtime.py
+++ b/backend/src/quantlab/phase6_runtime.py
@@ -130,10 +130,8 @@ _STRATEGY_PARAMETER_TYPES: dict[str, dict[str, type[object]]] = {
 
 
 def _normalize_integer(value: object, parameter: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
+    if isinstance(value, bool) or isinstance(value, float) or not isinstance(value, (int, Decimal)):
         raise DatasetInvalid(f"Parametr {parameter} musí být celé číslo")
-    if isinstance(value, float) and not math.isfinite(value):
-        raise DatasetInvalid(f"Parametr {parameter} musí být konečné celé číslo")
     try:
         decimal_value = Decimal(str(value))
     except (InvalidOperation, ValueError) as exc:
@@ -153,6 +151,19 @@ def _normalize_decimal(value: object, parameter: str) -> Decimal:
     if not normalized.is_finite():
         raise DatasetInvalid(f"Parametr {parameter} musí být konečné desetinné číslo")
     return normalized
+
+
+def _canonical_decimal(value: Decimal) -> Decimal:
+    if value.is_zero():
+        return Decimal(0)
+    sign, digits, exponent = value.as_tuple()
+    if not isinstance(exponent, int):
+        raise DatasetInvalid("Decimal strategy parametr musí být konečný")
+    canonical_digits = list(digits)
+    while canonical_digits[-1] == 0:
+        canonical_digits.pop()
+        exponent += 1
+    return Decimal((sign, tuple(canonical_digits), exponent))
 
 
 def normalize_strategy_config(
@@ -188,7 +199,14 @@ def normalize_strategy_config(
         raise DatasetInvalid("Strategy parametry jsou mimo povolené meze") from exc
     if implementation.name != strategy_name or implementation.version != strategy_version:
         raise DatasetInvalid("Implementace strategy version neodpovídá allowlistu")
-    return normalized
+    canonical: dict[str, object] = {
+        parameter: getattr(implementation, parameter) for parameter in parameter_types
+    }
+    canonical["rebalance_frequency"] = implementation.rebalance_frequency
+    for parameter, value in canonical.items():
+        if isinstance(value, Decimal):
+            canonical[parameter] = _canonical_decimal(value)
+    return canonical
 
 
 def persisted_execution_open_scope(

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -135,7 +135,7 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
     )
     assert mean_reversion.status_code == 200, mean_reversion.text
     assert mean_reversion.json()["selected_parameters_json"] == (
-        '{"lookback":20,"threshold":"0.95"}'
+        '{"lookback":20,"rebalance_frequency":"WEEKLY","threshold":"0.95"}'
     )
     # Regresní request nesmí spotřebovat mutation budget dlouhého B1 acceptance workflow.
     # Rate-limit samotný má oddělené security testy; zde ověřujeme Phase 6 datový průchod.

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -122,6 +122,21 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
         },
     )
     assert snapshot.status_code == 200, snapshot.text
+    mean_reversion = client.post(
+        "/operator/research/experiments",
+        json={
+            "snapshot_id": snapshot.json()["snapshot_id"],
+            "strategy_name": "multi_asset_mean_reversion",
+            "strategy_version": "1.0.0",
+            "parameter_configs": [{"lookback": 20, "threshold": "0.95"}],
+            "code_sha": "a" * 40,
+            "reason": reason,
+        },
+    )
+    assert mean_reversion.status_code == 200, mean_reversion.text
+    assert mean_reversion.json()["selected_parameters_json"] == (
+        '{"lookback":20,"threshold":"0.95"}'
+    )
     experiment = client.post(
         "/operator/research/experiments",
         json={

--- a/backend/tests/test_b1_control_plane_postgres.py
+++ b/backend/tests/test_b1_control_plane_postgres.py
@@ -137,6 +137,10 @@ def test_supported_b1_control_plane_reaches_active_monitoring(monkeypatch) -> No
     assert mean_reversion.json()["selected_parameters_json"] == (
         '{"lookback":20,"threshold":"0.95"}'
     )
+    # Regresní request nesmí spotřebovat mutation budget dlouhého B1 acceptance workflow.
+    # Rate-limit samotný má oddělené security testy; zde ověřujeme Phase 6 datový průchod.
+    with limiter.lock:
+        limiter.events.clear()
     experiment = client.post(
         "/operator/research/experiments",
         json={

--- a/backend/tests/test_phase6_experiment_audit.py
+++ b/backend/tests/test_phase6_experiment_audit.py
@@ -86,12 +86,44 @@ def test_mean_reversion_decimal_transport_has_one_canonical_identity() -> None:
             code_sha="a" * 40,
         )
 
-    from_string = runner.run(request("0.95"))
+    from_string = runner.run(request("0.950"))
     from_number = runner.run(request(0.95))
+    with_default_omitted = runner.run(
+        Phase6ExperimentRequest(
+            snapshot.snapshot_id,
+            "multi_asset_mean_reversion",
+            "1.0.0",
+            ({"threshold": "0.95"},),
+            code_sha="a" * 40,
+        )
+    )
     replay = runner.replay(request(0.95))
-    assert from_string.id == from_number.id
-    assert from_string.selected_parameters_json == '{"lookback":20,"threshold":"0.95"}'
-    assert replay.selected_parameters == {"lookback": 20, "threshold": Decimal("0.95")}
+    assert from_string.id == from_number.id == with_default_omitted.id
+    assert from_string.selected_parameters_json == (
+        '{"lookback":20,"rebalance_frequency":"WEEKLY","threshold":"0.95"}'
+    )
+    assert replay.selected_parameters == {
+        "lookback": 20,
+        "rebalance_frequency": runtime.RebalanceFrequency.WEEKLY,
+        "threshold": Decimal("0.95"),
+    }
+
+
+def test_strategy_config_materializes_defaults_canonically() -> None:
+    omitted = normalize_strategy_config(
+        "multi_asset_mean_reversion", "1.0.0", {"threshold": "0.9500"}
+    )
+    explicit = normalize_strategy_config(
+        "multi_asset_mean_reversion",
+        "1.0.0",
+        {"lookback": 20, "threshold": Decimal("0.95")},
+    )
+    assert omitted == explicit
+    assert omitted == {
+        "lookback": 20,
+        "rebalance_frequency": runtime.RebalanceFrequency.WEEKLY,
+        "threshold": Decimal("0.95"),
+    }
 
 
 @pytest.mark.parametrize(
@@ -100,6 +132,8 @@ def test_mean_reversion_decimal_transport_has_one_canonical_identity() -> None:
         ({"lookback": 20, "threshold": "abc"}, "desetinné číslo"),
         ({"lookback": True, "threshold": "0.95"}, "celé číslo"),
         ({"lookback": 20.5, "threshold": "0.95"}, "celé číslo"),
+        ({"lookback": 20.0, "threshold": "0.95"}, "celé číslo"),
+        ({"lookback": 9007199254740993.0, "threshold": "0.95"}, "celé číslo"),
         (
             {"lookback": 20, "threshold": "0.95", "threshhold": "0.9"},
             "Neznámé strategy parametry",
@@ -157,11 +191,16 @@ def test_experiment_api_returns_domain_error_for_invalid_config(
 def test_trend_and_momentum_configs_remain_typed() -> None:
     assert normalize_strategy_config("multi_asset_trend", "1.0.0", {"fast": 2, "slow": 3}) == {
         "fast": 2,
+        "rebalance_frequency": runtime.RebalanceFrequency.MONTHLY,
         "slow": 3,
     }
     assert normalize_strategy_config(
         "cross_sectional_momentum", "1.0.0", {"lookback": 20, "top_n": 3}
-    ) == {"lookback": 20, "top_n": 3}
+    ) == {
+        "lookback": 20,
+        "rebalance_frequency": runtime.RebalanceFrequency.MONTHLY,
+        "top_n": 3,
+    }
 
 
 def _canonical_hash(manifest: dict[str, object]) -> str:

--- a/backend/tests/test_phase6_experiment_audit.py
+++ b/backend/tests/test_phase6_experiment_audit.py
@@ -6,14 +6,20 @@ from copy import deepcopy
 from decimal import Decimal
 
 import pytest
+from fastapi.testclient import TestClient
 from phase6_audit_helpers import seed_phase6_snapshot
 from sqlalchemy import create_engine, func, select
 from sqlalchemy.orm import sessionmaker
 
 import quantlab.phase6_runtime as runtime
+from quantlab import api
 from quantlab.market_data import DatasetInvalid
-from quantlab.persistence import DatasetSnapshotRecord, ExperimentRecord
-from quantlab.phase6_runtime import Phase6ExperimentRunner
+from quantlab.persistence import DatasetSnapshotRecord, ExperimentRecord, StrategyRecord
+from quantlab.phase6_runtime import (
+    Phase6ExperimentRequest,
+    Phase6ExperimentRunner,
+    normalize_strategy_config,
+)
 
 
 def factory():
@@ -54,6 +60,108 @@ def test_phase6_runner_oos_isolation() -> None:
     first, second = runner.run(request_one), runner.run(request_two)
     assert first.selected_parameters_json == second.selected_parameters_json
     assert first.result_json != second.result_json
+
+
+def test_mean_reversion_decimal_transport_has_one_canonical_identity() -> None:
+    sessions = factory()
+    _, _, _, snapshot, _ = seed_phase6_snapshot(sessions, suffix="mean-reversion")
+    with sessions() as session, session.begin():
+        session.add(
+            StrategyRecord(
+                strategy_identity="mean-reversion-1",
+                strategy_name="multi_asset_mean_reversion",
+                strategy_version="1.0.0",
+                created_at=runtime.datetime.now(runtime.UTC),
+                metadata_json="{}",
+            )
+        )
+    runner = Phase6ExperimentRunner(sessions)
+
+    def request(threshold: object) -> Phase6ExperimentRequest:
+        return Phase6ExperimentRequest(
+            snapshot.snapshot_id,
+            "multi_asset_mean_reversion",
+            "1.0.0",
+            ({"lookback": 20, "threshold": threshold},),
+            code_sha="a" * 40,
+        )
+
+    from_string = runner.run(request("0.95"))
+    from_number = runner.run(request(0.95))
+    replay = runner.replay(request(0.95))
+    assert from_string.id == from_number.id
+    assert from_string.selected_parameters_json == '{"lookback":20,"threshold":"0.95"}'
+    assert replay.selected_parameters == {"lookback": 20, "threshold": Decimal("0.95")}
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        ({"lookback": 20, "threshold": "abc"}, "desetinné číslo"),
+        ({"lookback": True, "threshold": "0.95"}, "celé číslo"),
+        ({"lookback": 20.5, "threshold": "0.95"}, "celé číslo"),
+        (
+            {"lookback": 20, "threshold": "0.95", "threshhold": "0.9"},
+            "Neznámé strategy parametry",
+        ),
+    ],
+)
+def test_strategy_config_rejects_invalid_operator_values(
+    config: dict[str, object], message: str
+) -> None:
+    with pytest.raises(DatasetInvalid, match=message):
+        normalize_strategy_config("multi_asset_mean_reversion", "1.0.0", config)
+
+
+def test_runner_rejects_bad_config_before_strategy_construction() -> None:
+    sessions = factory()
+    runner = Phase6ExperimentRunner(sessions)
+    request = Phase6ExperimentRequest(
+        "unused",
+        "multi_asset_mean_reversion",
+        "1.0.0",
+        ({"lookback": 20, "threshold": "abc"},),
+        code_sha="a" * 40,
+    )
+    with pytest.raises(DatasetInvalid, match="desetinné číslo"):
+        runner.run(request)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"lookback": 20, "threshold": "abc"},
+        {"lookback": True, "threshold": "0.95"},
+        {"lookback": 20.5, "threshold": "0.95"},
+        {"lookback": 20, "threshold": "0.95", "threshhold": "0.9"},
+    ],
+)
+def test_experiment_api_returns_domain_error_for_invalid_config(
+    config: dict[str, object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(api.control_plane_registry, "ensure_strategy", lambda *args: None)
+    response = TestClient(api.app).post(
+        "/operator/research/experiments",
+        json={
+            "snapshot_id": "unused",
+            "strategy_name": "multi_asset_mean_reversion",
+            "strategy_version": "1.0.0",
+            "parameter_configs": [config],
+            "code_sha": "a" * 40,
+            "reason": "regression test",
+        },
+    )
+    assert response.status_code == 409, response.text
+
+
+def test_trend_and_momentum_configs_remain_typed() -> None:
+    assert normalize_strategy_config("multi_asset_trend", "1.0.0", {"fast": 2, "slow": 3}) == {
+        "fast": 2,
+        "slow": 3,
+    }
+    assert normalize_strategy_config(
+        "cross_sectional_momentum", "1.0.0", {"lookback": 20, "top_n": 3}
+    ) == {"lookback": 20, "top_n": 3}
 
 
 def _canonical_hash(manifest: dict[str, object]) -> str:

--- a/docs/strategy-research.md
+++ b/docs/strategy-research.md
@@ -4,6 +4,14 @@ Strategie implementuje `generate_targets(StrategyContext) -> TargetPortfolio`, d
 
 Baseline registry obsahuje multi-asset MA trend (`fast`, `slow`), cross-sectional momentum (`lookback`, `top_n`, deterministický tie-break canonical ID) a distance-from-mean reversion (`lookback`, `threshold`). Chybějící lookback asset explicitně vyřadí. Monthly/weekly hranice používá dostupné společné XNYS sessions.
 
+Phase 6 normalizuje každou konfiguraci centrálně ještě před výpočtem identity, výběrem,
+konstrukcí strategie a persistencí. Celočíselné parametry odmítají boolean, zlomky i
+nekonečné hodnoty. Ekonomické Decimal parametry (například `threshold`) jsou interně vždy
+kanonické `Decimal`; JSON transport může použít přesný string (`"0.95"`) nebo number (`0.95`),
+který se převádí přes jeho deterministickou desetinnou reprezentaci. Oba transportní tvary tak
+mají stejnou experiment identity a replay konfiguraci. Neznámé parametry a nepovolené dvojice
+strategie/verze jsou odmítnuty fail closed.
+
 Engine vede společnou USD hotovost, více pozic, cost basis, fills a portfolio equity. Nejde o součet single-symbol backtestů. Sells proběhnou deterministicky před buys, množství jsou whole-share a buy je ořezán dostupnou hotovostí včetně fee. Nově obchodovat lze jen asset s čerstvým raw open; existing stale valuation starší než policy limit selže. Multi-currency universe bez FX selže uzavřeně.
 
 Universe typu `POINT_IN_TIME_MEMBERSHIP` filtruje `valid_from <= decision < valid_to` i `known_at <= knowledge_as_of`. `STATIC` je vždy označen `BIAS_PRONE_STATIC`: dnešní static seznam není survivorship-bias-free. Budoucí prices, membership a corporate actions nesmí ovlivnit prefix rozhodnutí.

--- a/docs/strategy-research.md
+++ b/docs/strategy-research.md
@@ -10,7 +10,11 @@ nekonečné hodnoty. Ekonomické Decimal parametry (například `threshold`) jso
 kanonické `Decimal`; JSON transport může použít přesný string (`"0.95"`) nebo number (`0.95`),
 který se převádí přes jeho deterministickou desetinnou reprezentaci. Oba transportní tvary tak
 mají stejnou experiment identity a replay konfiguraci. Neznámé parametry a nepovolené dvojice
-strategie/verze jsou odmítnuty fail closed.
+strategie/verze jsou odmítnuty fail closed. Canonical konfigurace materializuje také všechny
+dataclass defaulty a Decimal hodnotám odstraní nevýznamné koncové nuly, takže vynechaný default
+versus jeho explicitní hodnota ani `"0.95"` versus `"0.950"` nemění experiment identity.
+Integer parametry musí JSON transport poslat jako integer, nikoli jako float, protože float již
+mohl před validací nevratně ztratit přesnost.
 
 Engine vede společnou USD hotovost, více pozic, cost basis, fills a portfolio equity. Nejde o součet single-symbol backtestů. Sells proběhnou deterministicky před buys, množství jsou whole-share a buy je ořezán dostupnou hotovostí včetně fee. Nově obchodovat lze jen asset s čerstvým raw open; existing stale valuation starší než policy limit selže. Multi-currency universe bez FX selže uzavřeně.
 


### PR DESCRIPTION
### Motivation
- Opravit příčinu HTTP 500 při použití JSON transportu (např. `"threshold": "0.95"`) kde surové JSON typy pronikaly do dataclass strategií a způsobovaly `TypeError` při porovnání `Decimal` vs `str`.
- Zajistit deterministickou canonical identitu experimentu nezávislou na tom, zda klient poslal Decimal jako JSON string nebo number, a zabránit look‑ahead/implicitním konverzím v Phase6 pipeline.
- Fail‑closed chování pro neznámé nebo špatně typované parametry tak, aby invalidní operator config nikdy neskončil neošetřeným HTTP 500.

### Description
- Přidán centrální normalizátor `normalize_strategy_config()` s pomocnými funkcemi `_normalize_integer()` a `_normalize_decimal()` v `phase6_runtime.py`, který mapuje a validuje allowlisted parametry pro `multi_asset_trend`, `cross_sectional_momentum` a `multi_asset_mean_reversion` (vč. `threshold: Decimal`).
- Runner nyní normalizuje celý `parameter_configs` před výpočtem identity, výběrem, konstrukcí strategie a persistencí; stejný normalizátor je použit také při validaci experimentní evidence, deployment validaci a paper execution pro replay idempotency.
- Integrační změny: nahrazeny zástupy surových JSON hodnot normalizovanými hodnotami při tvorbě identity payloadu, při výběru konfigurací i při persistenci `parameter_space_id`/`selected_parameters_json`.
- Přidány regresní testy a API scenáře (backend/tests/*) pokrývající: canonical identity pro `"0.95"` vs `0.95`, odmítnutí neplatných decimal/integers/booleans/unknown field a ověření, že API vrací deterministický doménový error (HTTP 409) místo 500; doplněna dokumentace v `docs/strategy-research.md` popisující canonical Decimal semantics.

### Testing
- `ruff format` / `ruff check` on modified files — SUCCESS.
- `mypy --ignore-missing-imports backend/src/quantlab/phase6_runtime.py` — SUCCESS for the changed module (full mypy blocked by unsynchronized env deps).
- `python -m compileall -q backend/src backend/tests` — SUCCESS (compiled changed sources).
- `UV_NO_CONFIG=1 uv lock --check` — SUCCESS in this environment; full `uv sync --locked --all-groups` was blocked by network/proxy so dependency sync could not complete here.
- `pytest` runs were attempted for the added tests but collection/execution was blocked by missing runtime dependencies (e.g. `fastapi`/other packages) in this environment, so the new regression tests were added but not fully executed here.

Poznámky před sloučením
- Commit SHA: `f2ec52430a0f568ac2814a8dc6d9a392a5b0fe9d`.
- Změněné soubory: `backend/src/quantlab/phase6_runtime.py`, `backend/tests/test_phase6_experiment_audit.py`, `backend/tests/test_b1_control_plane_postgres.py`, `docs/strategy-research.md`.
- Co zbývá: v CI s přístupem k registru/přesným verzím (`uv 0.12.3`) spustit `uv sync --locked --all-groups`, spustit plné unit/API/PostgreSQL integration testy a production smoke; poté dokončit PR merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9481c43e8c8332bcd27b63b6207aa8)