### PR TITLE
Add least-privilege Reviewer BLOCK escalation workflow and route BLOCK to it

### DIFF
--- a/.github/scripts/agent-pipeline.cjs
+++ b/.github/scripts/agent-pipeline.cjs
@@ -347,6 +347,21 @@ function escalationMutationPlan(labels) {
   };
 }
 
+function reviewerBlockPairPlan(prLabels, issueLabels) {
+  const exactEscalationState = (labels) => {
+    const states = labelNames(labels).filter((label) => STATES.includes(label));
+    return states.length === 1 && (states[0] === "agent:pr" || states[0] === "agent:needs-human");
+  };
+  if (!exactEscalationState(prLabels) || !exactEscalationState(issueLabels)) {
+    return { ok: false, reason: "INVALID_REVIEW_BLOCK_PAIR" };
+  }
+  return {
+    ok: true,
+    pr: escalationMutationPlan(prLabels),
+    issue: escalationMutationPlan(issueLabels),
+  };
+}
+
 function invalidationLifecycleDecision({ prLabels, issueLabels = [], issueLoaded, durableLink, markerIssueNumber }) {
   const prStates = labelNames(prLabels).filter((label) => STATES.includes(label));
   const issueStates = labelNames(issueLabels).filter((label) => STATES.includes(label));
@@ -433,11 +448,13 @@ function verificationDecision(input) {
 module.exports = {
   STATES,
   FAILURE_CLASSES,
+  labelNames,
   currentState,
   authoritativeCiRunCandidates,
   durablePrLinkDecision,
   durableIssueLinkDecision,
   escalationMutationPlan,
+  reviewerBlockPairPlan,
   hasDurableLink,
   isImplementation,
   invalidationLifecycleDecision,

--- a/.github/scripts/agent-pipeline.test.cjs
+++ b/.github/scripts/agent-pipeline.test.cjs
@@ -585,8 +585,8 @@ test("v2 reusable caller permissions and governance linkage are fail closed", ()
   assert.doesNotMatch(block,/contents: write|secrets: inherit|AGENT_PUBLISH_TOKEN/);
   assert.match(block,/pr\.head\.sha!==expectedSha[\s\S]*pr\.state!=="open"[\s\S]*pr\.base\.ref!==context\.payload\.repository\.default_branch/);
   assert.match(block,/issue\.pull_request\|\|issue\.state!=="open"\|\|!p\.isImplementation/);
-  assert.match(block,/lifecycleAtAgentPr[\s\S]*fullLinkageDecision[\s\S]*REVIEW_BLOCK_NO_WRITE/);
-  assert.match(block,/const plans=[\s\S]*for\(const \[number,plan\] of plans\)/);
+  assert.match(block,/reviewerBlockPairPlan[\s\S]*fullLinkageDecision[\s\S]*REVIEW_BLOCK_NO_WRITE/);
+  assert.match(block,/setLabels[\s\S]*readValidatedPair\(pair\.issueNumber\)[\s\S]*setLabels/);
   const escalation=reviewer.slice(reviewer.indexOf("governance-escalation:"),reviewer.indexOf("independent-review:"));
   assert.match(escalation,/listComments[\s\S]*fullLinkageDecision[\s\S]*STALE_GOVERNANCE_NO_WRITE/);
 });
@@ -607,6 +607,28 @@ test("Issue #90 Reviewer BLOCK escalation transitions only an exact valid linked
   assert.equal(pipeline.fullLinkageDecision({...valid,issueComments:[]}).ok,false);
   // The workflow additionally compares the requested SHA and base immediately before this decision.
   assert.equal(sha.length,40);
+});
+
+test("Issue #90 Reviewer BLOCK retry reconciles either partial write and preserves foreign labels", () => {
+  for (const [prLabels, issueLabels] of [
+    [["agent:needs-human", "priority:high"], ["type:implementation", "agent:pr", "team:quant"]],
+    [["agent:pr", "priority:high"], ["type:implementation", "agent:needs-human", "team:quant"]],
+  ]) {
+    const plan = pipeline.reviewerBlockPairPlan(prLabels, issueLabels);
+    assert.equal(plan.ok, true);
+    const apply = (labels) => [
+      ...pipeline.labelNames(labels).filter((name) => !pipeline.STATES.includes(name)),
+      "agent:needs-human",
+    ];
+    assert.deepEqual(apply(prLabels), ["priority:high", "agent:needs-human"]);
+    assert.deepEqual(apply(issueLabels), ["type:implementation", "team:quant", "agent:needs-human"]);
+  }
+  for (const conflict of [
+    [["agent:ready"], ["type:implementation", "agent:pr"]],
+    [["agent:pr", "agent:needs-human"], ["type:implementation", "agent:pr"]],
+    [["agent:pr"], ["type:implementation", "agent:verified"]],
+  ]) assert.deepEqual(pipeline.reviewerBlockPairPlan(...conflict),
+    {ok:false,reason:"INVALID_REVIEW_BLOCK_PAIR"});
 });
 
 test("v2 classify job guard admits reusable review-block despite inherited caller events", () => {

--- a/.github/scripts/agent-pipeline.test.cjs
+++ b/.github/scripts/agent-pipeline.test.cjs
@@ -380,6 +380,7 @@ test("v2 independent PASS je exact-SHA a nenahrazuje human review", () => {
 test("v2 workflow wiring odděluje secret, validation a write trust domains", () => {
   const fixer = fs.readFileSync(".github/workflows/agent-ci-fixer.yml", "utf8");
   const reviewer = fs.readFileSync(".github/workflows/agent-codex-review.yml", "utf8");
+  const blockEscalation = fs.readFileSync(".github/workflows/agent-review-block-escalation.yml", "utf8");
   assert.match(fixer, /openai\/codex-action@[0-9a-f]{40}/);
   assert.match(reviewer, /openai\/codex-action@[0-9a-f]{40}/);
   for (const workflow of [fixer, reviewer]) {
@@ -395,7 +396,9 @@ test("v2 workflow wiring odděluje secret, validation a write trust domains", ()
   assert.match(reviewer, /allow-bot-users: "github-actions\[bot\]"/);
   assert.doesNotMatch(fixer + reviewer, /allow-bots:/);
   assert.match(fixer, /workflow_call:/);
-  assert.match(reviewer, /route-block:[\s\S]*uses: \.\/\.github\/workflows\/agent-ci-fixer\.yml[\s\S]*pr_number:[\s\S]*head_sha:/);
+  assert.match(reviewer, /route-block:[\s\S]*uses: \.\/\.github\/workflows\/agent-review-block-escalation\.yml[\s\S]*pr_number:[\s\S]*head_sha:/);
+  assert.doesNotMatch(reviewer, /uses: \.\/\.github\/workflows\/agent-ci-fixer\.yml/);
+  assert.doesNotMatch(reviewer + blockEscalation, /contents: write/);
   assert.match(fixer, /sourceRunId:run\.id,runAttempt:run\.run_attempt,logExcerpt/);
   assert.match(fixer, /prompt-file: \.codex-input\/prompt\.md/);
   assert.match(reviewer, /prompt-file: \.codex-input\/review-prompt\.md/);
@@ -570,15 +573,40 @@ test("v2 fifth-audit wiring pins validation toolchain, seals last, and finalizes
   assert.match(fixer,/BEGIN TRUSTED GOVERNANCE[\s\S]*trusted-AGENTS\.md/);
   assert.match(reviewer,/exact authoritative green CI missing or ambiguous/);
   assert.match(reviewer,/Fail closed when reviewer credential is absent/);
-  assert.match(reviewer,/fail-closed-finalizer:[\s\S]*STALE_REVIEW_FAILURE_NO_WRITE/);
+  assert.match(reviewer,/fail-closed-finalizer:[\s\S]*uses: \.\/\.github\/workflows\/agent-review-block-escalation\.yml[\s\S]*no PASS was synthesized/);
 });
 
 test("v2 reusable caller permissions and governance linkage are fail closed", () => {
   const reviewer=fs.readFileSync(".github/workflows/agent-codex-review.yml","utf8");
+  const block=fs.readFileSync(".github/workflows/agent-review-block-escalation.yml","utf8");
   assert.match(reviewer,/verify-after-pass:[\s\S]*permissions: \{actions: read, contents: read, issues: write, pull-requests: write\}/);
-  assert.match(reviewer,/route-block:[\s\S]*permissions: \{actions: read, contents: read, issues: write, pull-requests: read\}/);
+  assert.match(reviewer,/route-block:[\s\S]*permissions: \{contents: read, issues: write, pull-requests: read\}/);
+  assert.match(block,/permissions: \{contents: read, issues: write, pull-requests: read\}/);
+  assert.doesNotMatch(block,/contents: write|secrets: inherit|AGENT_PUBLISH_TOKEN/);
+  assert.match(block,/pr\.head\.sha!==expectedSha[\s\S]*pr\.state!=="open"[\s\S]*pr\.base\.ref!==context\.payload\.repository\.default_branch/);
+  assert.match(block,/issue\.pull_request\|\|issue\.state!=="open"\|\|!p\.isImplementation/);
+  assert.match(block,/lifecycleAtAgentPr[\s\S]*fullLinkageDecision[\s\S]*REVIEW_BLOCK_NO_WRITE/);
+  assert.match(block,/const plans=[\s\S]*for\(const \[number,plan\] of plans\)/);
   const escalation=reviewer.slice(reviewer.indexOf("governance-escalation:"),reviewer.indexOf("independent-review:"));
   assert.match(escalation,/listComments[\s\S]*fullLinkageDecision[\s\S]*STALE_GOVERNANCE_NO_WRITE/);
+});
+
+test("Issue #90 Reviewer BLOCK escalation transitions only an exact valid linked pair", () => {
+  const issueNumber=90, prNumber=123, sha="a".repeat(40);
+  const marker={user:{login:"github-actions[bot]"},body:`<!-- agent-link:v1 repo=o/r issue=${issueNumber} pr=${prNumber} -->`};
+  const valid={prBody:`- Agent-Issue: #${issueNumber}`,prComments:[marker],issueComments:[marker],owner:"o",repo:"r",issueNumber,prNumber};
+  assert.deepEqual(pipeline.lifecycleAtAgentPr(["agent:pr"],["type:implementation","agent:pr"]),{ok:true});
+  assert.deepEqual(pipeline.fullLinkageDecision(valid),{ok:true});
+  assert.deepEqual(pipeline.escalationMutationPlan(["agent:pr","priority:high"]),
+    {ok:true,add:["agent:needs-human"],remove:["agent:pr"]});
+  for(const conflict of [
+    {prLabels:["agent:pr"],issueLabels:["type:implementation","agent:needs-human"]},
+    {prLabels:["agent:ready"],issueLabels:["type:implementation","agent:pr"]},
+  ]) assert.equal(pipeline.lifecycleAtAgentPr(conflict.prLabels,conflict.issueLabels).ok,false);
+  assert.equal(pipeline.fullLinkageDecision({...valid,prBody:"- Agent-Issue: #91"}).ok,false);
+  assert.equal(pipeline.fullLinkageDecision({...valid,issueComments:[]}).ok,false);
+  // The workflow additionally compares the requested SHA and base immediately before this decision.
+  assert.equal(sha.length,40);
 });
 
 test("v2 classify job guard admits reusable review-block despite inherited caller events", () => {

--- a/.github/workflows/agent-codex-review.yml
+++ b/.github/workflows/agent-codex-review.yml
@@ -187,36 +187,19 @@ jobs:
   route-block:
     needs: [prepare, trusted-record]
     if: needs.trusted-record.outputs.blocked == 'true'
-    uses: ./.github/workflows/agent-ci-fixer.yml
-    permissions: {actions: read, contents: read, issues: write, pull-requests: read}
+    uses: ./.github/workflows/agent-review-block-escalation.yml
+    permissions: {contents: read, issues: write, pull-requests: read}
     with:
-      invocation_mode: review-block
       pr_number: ${{ fromJSON(needs.prepare.outputs.pr_number) }}
       head_sha: ${{ needs.prepare.outputs.head_sha }}
-      review_block: ${{ needs.trusted-record.outputs.block_reason }}
-    secrets: inherit
+      reason: ${{ needs.trusted-record.outputs.block_reason }}
 
   fail-closed-finalizer:
     needs: [prepare, independent-review, trusted-record]
     if: always() && needs.prepare.outputs.eligible == 'true' && needs.trusted-record.result != 'success'
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/agent-review-block-escalation.yml
     permissions: {contents: read, issues: write, pull-requests: read}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with: {ref: '${{ github.event.repository.default_branch }}', persist-credentials: false}
-      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        env: {PR: '${{ needs.prepare.outputs.pr_number }}', ISSUE: '${{ needs.prepare.outputs.issue_number }}', SHA: '${{ needs.prepare.outputs.head_sha }}'}
-        with:
-          script: |
-            const p=require('./.github/scripts/agent-pipeline.cjs'),prNumber=Number(process.env.PR),issueNumber=Number(process.env.ISSUE);
-            const {data:pr}=await github.rest.pulls.get({...context.repo,pull_number:prNumber});
-            const {data:issue}=await github.rest.issues.get({...context.repo,issue_number:issueNumber});
-            const prComments=await github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:prNumber,per_page:100});
-            const issueComments=await github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:issueNumber,per_page:100});
-            if(pr.head.sha!==process.env.SHA||!p.lifecycleAtAgentPr(pr.labels,issue.labels).ok||!p.fullLinkageDecision({prBody:pr.body,prComments,issueComments,...context.repo,issueNumber,prNumber}).ok) return core.notice('STALE_REVIEW_FAILURE_NO_WRITE');
-            for(const number of [prNumber,issueNumber]) {
-              const {data:item}=await github.rest.issues.get({...context.repo,issue_number:number}); const plan=p.escalationMutationPlan(item.labels);
-              if(!plan.ok) return core.setFailed(plan.reason); if(plan.add.length) await github.rest.issues.addLabels({...context.repo,issue_number:number,labels:plan.add});
-              for(const name of plan.remove) await github.rest.issues.removeLabel({...context.repo,issue_number:number,name});
-            }
-            await github.rest.issues.createComment({...context.repo,issue_number:prNumber,body:`Independent reviewer failed closed for exact SHA ${process.env.SHA}: missing/invalid OPENAI_API_KEY or reviewer action/output failure; no PASS was synthesized.`});
+    with:
+      pr_number: ${{ fromJSON(needs.prepare.outputs.pr_number) }}
+      head_sha: ${{ needs.prepare.outputs.head_sha }}
+      reason: Reviewer execution or output failed closed; no PASS was synthesized.

--- a/.github/workflows/agent-review-block-escalation.yml
+++ b/.github/workflows/agent-review-block-escalation.yml
@@ -1,0 +1,56 @@
+name: Agent Reviewer BLOCK escalation
+
+on:
+  workflow_call:
+    inputs:
+      pr_number: {required: true, type: number}
+      head_sha: {required: true, type: string}
+      reason: {required: true, type: string}
+
+permissions: {contents: read}
+
+jobs:
+  escalate:
+    runs-on: ubuntu-latest
+    permissions: {contents: read, issues: write, pull-requests: read}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with: {ref: '${{ github.event.repository.default_branch }}', persist-credentials: false}
+      - name: Revalidate and escalate the exact linked pair
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR: '${{ inputs.pr_number }}'
+          SHA: '${{ inputs.head_sha }}'
+          BLOCK_REASON: '${{ inputs.reason }}'
+        with:
+          script: |
+            const p=require('./.github/scripts/agent-pipeline.cjs');
+            const prNumber=Number(process.env.PR), expectedSha=process.env.SHA;
+            if(!Number.isSafeInteger(prNumber)||prNumber<1||!/^[0-9a-f]{40}$/.test(expectedSha))
+              return core.notice('REVIEW_BLOCK_NO_WRITE: invalid exact binding');
+            // Final trusted read before any write. Candidate content supplies no executable code.
+            const {data:pr}=await github.rest.pulls.get({...context.repo,pull_number:prNumber});
+            const issueNumber=p.parseAgentIssue(pr.body);
+            if(!issueNumber||pr.head.sha!==expectedSha||pr.state!=="open"||
+              pr.base.ref!==context.payload.repository.default_branch)
+              return core.notice('REVIEW_BLOCK_NO_WRITE: stale PR, SHA, base, or Issue marker');
+            const {data:issue}=await github.rest.issues.get({...context.repo,issue_number:issueNumber});
+            const [prComments,issueComments]=await Promise.all([
+              github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:prNumber,per_page:100}),
+              github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:issueNumber,per_page:100}),
+            ]);
+            const lifecycle=p.lifecycleAtAgentPr(pr.labels,issue.labels);
+            const linkage=p.fullLinkageDecision({prBody:pr.body,prComments,issueComments,...context.repo,issueNumber,prNumber});
+            if(issue.pull_request||issue.state!=="open"||!p.isImplementation(issue.labels)||!lifecycle.ok||!linkage.ok)
+              return core.notice(`REVIEW_BLOCK_NO_WRITE: ${lifecycle.reason||linkage.reason||'invalid implementation Issue'}`);
+            // Plan the complete pair before mutation. Foreign labels are retained.
+            const plans=[[prNumber,p.escalationMutationPlan(pr.labels)],[issueNumber,p.escalationMutationPlan(issue.labels)]];
+            if(plans.some(([,plan])=>!plan.ok))
+              return core.notice('REVIEW_BLOCK_NO_WRITE: conflicting paired lifecycle');
+            for(const [number,plan] of plans) {
+              if(plan.add.length) await github.rest.issues.addLabels({...context.repo,issue_number:number,labels:plan.add});
+              for(const name of plan.remove) await github.rest.issues.removeLabel({...context.repo,issue_number:number,name});
+            }
+            const reason=p.redactDiagnostic(process.env.BLOCK_REASON,1024).replaceAll('<!--','&lt;!--').replaceAll('-->','--&gt;');
+            await github.rest.issues.createComment({...context.repo,issue_number:prNumber,
+              body:`Independent Reviewer BLOCK for exact SHA \`${expectedSha}\`: ${reason}\n\nBoth linked objects were transitioned to \`agent:needs-human\`.`});

--- a/.github/workflows/agent-review-block-escalation.yml
+++ b/.github/workflows/agent-review-block-escalation.yml
@@ -28,29 +28,39 @@ jobs:
             const prNumber=Number(process.env.PR), expectedSha=process.env.SHA;
             if(!Number.isSafeInteger(prNumber)||prNumber<1||!/^[0-9a-f]{40}$/.test(expectedSha))
               return core.notice('REVIEW_BLOCK_NO_WRITE: invalid exact binding');
-            // Final trusted read before any write. Candidate content supplies no executable code.
-            const {data:pr}=await github.rest.pulls.get({...context.repo,pull_number:prNumber});
-            const issueNumber=p.parseAgentIssue(pr.body);
-            if(!issueNumber||pr.head.sha!==expectedSha||pr.state!=="open"||
-              pr.base.ref!==context.payload.repository.default_branch)
-              return core.notice('REVIEW_BLOCK_NO_WRITE: stale PR, SHA, base, or Issue marker');
-            const {data:issue}=await github.rest.issues.get({...context.repo,issue_number:issueNumber});
-            const [prComments,issueComments]=await Promise.all([
-              github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:prNumber,per_page:100}),
-              github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:issueNumber,per_page:100}),
-            ]);
-            const lifecycle=p.lifecycleAtAgentPr(pr.labels,issue.labels);
-            const linkage=p.fullLinkageDecision({prBody:pr.body,prComments,issueComments,...context.repo,issueNumber,prNumber});
-            if(issue.pull_request||issue.state!=="open"||!p.isImplementation(issue.labels)||!lifecycle.ok||!linkage.ok)
-              return core.notice(`REVIEW_BLOCK_NO_WRITE: ${lifecycle.reason||linkage.reason||'invalid implementation Issue'}`);
-            // Plan the complete pair before mutation. Foreign labels are retained.
-            const plans=[[prNumber,p.escalationMutationPlan(pr.labels)],[issueNumber,p.escalationMutationPlan(issue.labels)]];
-            if(plans.some(([,plan])=>!plan.ok))
-              return core.notice('REVIEW_BLOCK_NO_WRITE: conflicting paired lifecycle');
-            for(const [number,plan] of plans) {
-              if(plan.add.length) await github.rest.issues.addLabels({...context.repo,issue_number:number,labels:plan.add});
-              for(const name of plan.remove) await github.rest.issues.removeLabel({...context.repo,issue_number:number,name});
-            }
+            const readValidatedPair=async(expectedIssueNumber=null)=>{
+              const {data:pr}=await github.rest.pulls.get({...context.repo,pull_number:prNumber});
+              const issueNumber=p.parseAgentIssue(pr.body);
+              if(!issueNumber||(expectedIssueNumber!==null&&issueNumber!==expectedIssueNumber)||
+                pr.head.sha!==expectedSha||pr.state!=="open"||
+                pr.base.ref!==context.payload.repository.default_branch)
+                return {ok:false,reason:'stale PR, SHA, base, or Issue marker'};
+              const {data:issue}=await github.rest.issues.get({...context.repo,issue_number:issueNumber});
+              const [prComments,issueComments]=await Promise.all([
+                github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:prNumber,per_page:100}),
+                github.paginate(github.rest.issues.listComments,{...context.repo,issue_number:issueNumber,per_page:100}),
+              ]);
+              const lifecycle=p.reviewerBlockPairPlan(pr.labels,issue.labels);
+              const linkage=p.fullLinkageDecision({prBody:pr.body,prComments,issueComments,...context.repo,issueNumber,prNumber});
+              if(issue.pull_request||issue.state!=="open"||!p.isImplementation(issue.labels)||!lifecycle.ok||!linkage.ok)
+                return {ok:false,reason:lifecycle.reason||linkage.reason||'invalid implementation Issue'};
+              return {ok:true,pr,issue,issueNumber,lifecycle};
+            };
+            const targetLabels=(labels)=>[...new Set([
+              ...p.labelNames(labels).filter(name=>!p.STATES.includes(name)),
+              'agent:needs-human',
+            ])];
+            // Each setLabels call is one atomic object-level write. A retry accepts only the
+            // original pair or either partial target and completes the same paired transition.
+            let pair=await readValidatedPair();
+            if(!pair.ok) return core.notice(`REVIEW_BLOCK_NO_WRITE: ${pair.reason}`);
+            if(pair.lifecycle.pr.add.length||pair.lifecycle.pr.remove.length)
+              await github.rest.issues.setLabels({...context.repo,issue_number:prNumber,labels:targetLabels(pair.pr.labels)});
+            // Re-read all mutable binding, linkage, and lifecycle data after the first write.
+            pair=await readValidatedPair(pair.issueNumber);
+            if(!pair.ok) return core.notice(`REVIEW_BLOCK_NO_WRITE: ${pair.reason}`);
+            if(pair.lifecycle.issue.add.length||pair.lifecycle.issue.remove.length)
+              await github.rest.issues.setLabels({...context.repo,issue_number:pair.issueNumber,labels:targetLabels(pair.issue.labels)});
             const reason=p.redactDiagnostic(process.env.BLOCK_REASON,1024).replaceAll('<!--','&lt;!--').replaceAll('-->','--&gt;');
             await github.rest.issues.createComment({...context.repo,issue_number:prNumber,
               body:`Independent Reviewer BLOCK for exact SHA \`${expectedSha}\`: ${reason}\n\nBoth linked objects were transitioned to \`agent:needs-human\`.`});

--- a/docs/autonomous-development-pipeline.md
+++ b/docs/autonomous-development-pipeline.md
@@ -311,10 +311,13 @@ runner-temporary path that the action may not read. The bot allowance is restric
 `github-actions[bot]`. A Reviewer BLOCK calls a dedicated trusted escalation workflow with the
 already validated PR number and exact head SHA. That workflow has no repository-content write
 permission and, immediately before changing labels, independently re-fetches the current open PR,
-default-branch base, exact head SHA, concrete implementation Issue, exact lifecycle on both objects,
-and both durable linkage directions. Stale, ambiguous, partially transitioned, or conflicting state
-performs no write; a valid BLOCK moves both linked objects to `agent:needs-human` and records a
-bounded redacted reason. The failed-CI fixer and its isolated publication credential are not involved.
+default-branch base, exact head SHA, concrete implementation Issue, escalation lifecycle on both
+objects, and both durable linkage directions. The paired transition uses atomic per-object label
+replacement and revalidates the complete binding, lifecycle, and two-sided linkage after the first
+write. A retry accepts either partial ordering (`agent:pr`/`agent:needs-human`) and completes the
+same transition while preserving foreign labels; stale, ambiguous, or conflicting state performs no
+write. A valid BLOCK moves both linked objects to `agent:needs-human` and records a bounded redacted
+reason. The failed-CI fixer and its isolated publication credential are not involved.
 
 ### v2 crash, trust, and pre-link guarantees
 

--- a/docs/autonomous-development-pipeline.md
+++ b/docs/autonomous-development-pipeline.md
@@ -308,9 +308,13 @@ the free-form fixer.
 Both Codex invocations receive deterministic prompt files inside the checked-out workspace. Trusted
 instructions frame bounded Issue or diagnostic JSON as untrusted data, rather than referring to a
 runner-temporary path that the action may not read. The bot allowance is restricted to
-`github-actions[bot]`. A Reviewer BLOCK calls the reusable controller with the already validated PR
-number and exact head SHA; the controller independently re-fetches lifecycle, two-sided linkage, and
-SHA before performing the fail-closed escalation.
+`github-actions[bot]`. A Reviewer BLOCK calls a dedicated trusted escalation workflow with the
+already validated PR number and exact head SHA. That workflow has no repository-content write
+permission and, immediately before changing labels, independently re-fetches the current open PR,
+default-branch base, exact head SHA, concrete implementation Issue, exact lifecycle on both objects,
+and both durable linkage directions. Stale, ambiguous, partially transitioned, or conflicting state
+performs no write; a valid BLOCK moves both linked objects to `agent:needs-human` and records a
+bounded redacted reason. The failed-CI fixer and its isolated publication credential are not involved.
 
 ### v2 crash, trust, and pre-link guarantees
 


### PR DESCRIPTION
### Motivation
- Fix a runtime startup failure where `agent-codex-review.yml` invoked a reusable fixer that required `contents: write`, causing Reviewer BLOCK runs to be rejected at workflow startup; the BLOCK path must never require repository-content write privileges.

### Description
- Add a dedicated workflow `.github/workflows/agent-review-block-escalation.yml` that is `workflow_call`-invokable and runs with least privilege (`permissions: {contents: read}`, job permissions `{contents: read, issues: write, pull-requests: read}`), re-fetches and revalidates the exact PR head SHA, default-branch base, concrete implementation Issue, paired lifecycle, and two-sided durable linkage immediately before any mutation, and transitions both linked objects to `agent:needs-human` with a bounded redacted reason while preserving unrelated labels and failing closed on ambiguous/stale state.
- Update `.github/workflows/agent-codex-review.yml` to route `route-block` and the fail-closed finalizer to the new escalation workflow (pass only the redacted `reason` and exact `pr_number`/`head_sha`), removing the prior call that required `contents: write`/publication capability.
- Add reconciliation-safe Reviewer BLOCK handling that accepts only the intended `agent:pr` / partial `agent:needs-human` combinations, revalidates the full pair between writes, and safely completes either partial-write ordering while rejecting conflicting lifecycle states.
- Add regression/wiring tests in `.github/scripts/agent-pipeline.test.cjs` to assert permission isolation, that Reviewer PASS still invokes the verifier, that Reviewer BLOCK reaches the dedicated escalation without `contents: write`, that exact valid BLOCK transitions both Issue and PR to `agent:needs-human`, and that stale/linkage/lifecycle conflicts produce NO_WRITE/fail-closed behavior.
- Update `docs/autonomous-development-pipeline.md` to document the new least-privilege escalation boundary and its fail-closed contract.
- Agent-related labels were not modified manually in this change.

- Agent-Issue: #90

### Testing
- `node --test .github/scripts/agent-pipeline.test.cjs` — **56/56 PASS**.
- `python -m json.tool .github/agent-pipeline.json >/dev/null` — PASS.
- YAML parse všech `.github/workflows/*.yml` — PASS.
- `git diff --check` — PASS.
- Authoritative CI #774 / run `33732227925` — **9/9 required jobs PASS** on exact head `c945788cb5d2e113882116fbcefef19bbcf632c3`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a99259b833c8332af959cdeffb0ef2b)