### PR TITLE
Draft: Add Saturday calendar regression test for v2 dogfood

### DIFF
--- a/backend/tests/test_research.py
+++ b/backend/tests/test_research.py
@@ -75,6 +75,11 @@ def test_provider_identity_and_quality_events() -> None:
     assert not USExchangeCalendar(frozenset({date(2025, 1, 1)})).is_session(date(2025, 1, 1))
 
 
+def test_us_exchange_calendar_rejects_saturday() -> None:
+    calendar=USExchangeCalendar(frozenset())
+    assert calendar.is_session(date(2025,1,4)) is False
+
+
 def test_split_and_walk_forward_boundaries() -> None:
     source = bars(20)
     split = chronological_split(source, 0.5, 0.25)

--- a/backend/tests/test_research.py
+++ b/backend/tests/test_research.py
@@ -76,8 +76,8 @@ def test_provider_identity_and_quality_events() -> None:
 
 
 def test_us_exchange_calendar_rejects_saturday() -> None:
-    calendar=USExchangeCalendar(frozenset())
-    assert calendar.is_session(date(2025,1,4)) is False
+    calendar = USExchangeCalendar(frozenset())
+    assert calendar.is_session(date(2025, 1, 4)) is False
 
 
 def test_split_and_walk_forward_boundaries() -> None:


### PR DESCRIPTION
### Motivation
- Add a small regression test that proves `USExchangeCalendar` rejects the weekend date `date(2025, 1, 4)` and preserve a deliberate Ruff-format failure for the v2 dogfood rehearsal.

### Description
- Added `test_us_exchange_calendar_rejects_saturday` to `backend/tests/test_research.py` and modified no other files.
- The new test intentionally uses non-canonical Ruff formatting so the initial CI run fails only the `ruff format --check` quality check.
- Agent-Issue: #92

### Testing
- Locally ran `ruff check .` and `python -m py_compile tests/test_research.py`, both of which passed.
- Ran `ruff format --check .` which reported only `tests/test_research.py` and exited non-zero as intended, while full `pytest`/`uv`/`mypy` runs were blocked by the local environment (`uv` version mismatch and missing `fastapi`) and attempts to update `uv` failed due to network restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a99344780888332a40fdf26c7865007)