### PR TITLE
Grant fixer jobs limited `pull-requests: write` for PR metadata mutations (Issue #94)

### DIFF
--- a/.github/scripts/agent-pipeline.test.cjs
+++ b/.github/scripts/agent-pipeline.test.cjs
@@ -454,8 +454,35 @@ test("v2 third-audit workflow wiring is fail-closed and injection safe", () => {
   assert.match(reviewer,/trusted-governance\.json/);
   assert.match(reviewer,/base_sha:pr\.base\.sha/);
   assert.match(reviewer,/git diff --quiet "\$BASE_SHA" "\$HEAD_SHA" -- AGENTS\.md/);
-  assert.doesNotMatch(fixer,/pull-requests: write/);
+  assert.equal((fixer.match(/pull-requests: write/g)||[]).length,4);
   assert.equal((reviewer.match(/pull-requests: write/g)||[]).length,1);
+});
+
+test("Issue #94 grants PR metadata writes only to trusted fixer writers", () => {
+  const fixer=fs.readFileSync(".github/workflows/agent-ci-fixer.yml","utf8");
+  const jobNames=[...fixer.matchAll(/^  ([a-z][a-z0-9-]+):\n(?=    )/gm)].map(match=>({name:match[1],index:match.index}));
+  const jobs=Object.fromEntries(jobNames.map((job,index)=>[
+    job.name,
+    fixer.slice(job.index,jobNames[index+1]?.index ?? fixer.length),
+  ]));
+  const metadataCalls=/github\.rest\.issues\.(?:createComment|addLabels|removeLabel)\(/;
+  const metadataWriters=Object.entries(jobs).filter(([,body])=>metadataCalls.test(body)).map(([name])=>name).sort();
+  assert.deepEqual(metadataWriters,["escalate","fail-closed-finalizer","record-classification","trusted-publish"]);
+  for(const name of metadataWriters) assert.match(jobs[name],/permissions: \{[^\n]*pull-requests: write[^\n]*\}/,`${name} must be able to mutate PR metadata`);
+
+  assert.equal(fixer.match(/^permissions:\n  contents: read$/gm)?.length,1,"workflow permissions remain read-only");
+  assert.match(jobs["record-classification"],/classificationMarker[\s\S]*record\.sha[\s\S]*record\.ciRunId[\s\S]*record\.ciRunAttempt[\s\S]*issues\.createComment/);
+  for(const name of ["escalate","fail-closed-finalizer"]) {
+    assert.match(jobs[name],/for\(const number of \[prNumber,issueNumber\]\)/);
+    assert.match(jobs[name],/escalationMutationPlan\(item\.labels\)[\s\S]*plan\.add[\s\S]*plan\.remove/);
+    assert.doesNotMatch(jobs[name],/contents: write/);
+  }
+  assert.match(jobs["trusted-publish"],/agent-fix:v2[\s\S]*issues\.createComment|issues\.createComment[\s\S]*agent-fix:v2/);
+  for(const name of ["classify","prepare-generation-context","generate-patch","validate-patch","seal-patch"]) {
+    assert.doesNotMatch(jobs[name],/issues: write|pull-requests: write|contents: write/,`${name} trust boundary broadened`);
+  }
+  assert.doesNotMatch(jobs["generate-patch"],/permissions:[^\n]*(?:issues|pull-requests): write/);
+  assert.doesNotMatch(jobs["validate-patch"],/permissions:[^\n]*(?:issues|pull-requests): write/);
 });
 
 test("v2 index mode policy rejects symlinks, gitlinks, and mode transitions", () => {

--- a/.github/workflows/agent-ci-fixer.yml
+++ b/.github/workflows/agent-ci-fixer.yml
@@ -125,7 +125,7 @@ jobs:
     needs: classify
     if: always() && needs.classify.outputs.ci_run_id != ''
     runs-on: ubuntu-latest
-    permissions: {contents: read, issues: write, pull-requests: read}
+    permissions: {contents: read, issues: write, pull-requests: write}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: {ref: '${{ github.event.repository.default_branch }}', path: .trusted-policy, persist-credentials: false}
@@ -144,7 +144,7 @@ jobs:
     needs: [classify, record-classification]
     if: needs.classify.outputs.escalation == 'true'
     runs-on: ubuntu-latest
-    permissions: {contents: read, issues: write, pull-requests: read}
+    permissions: {contents: read, issues: write, pull-requests: write}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: {ref: '${{ github.event.repository.default_branch }}', path: .trusted-policy, persist-credentials: false}
@@ -365,7 +365,7 @@ jobs:
   trusted-publish:
     needs: [classify, seal-patch]
     runs-on: ubuntu-latest
-    permissions: {contents: write, issues: write, pull-requests: read}
+    permissions: {contents: write, issues: write, pull-requests: write}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: {ref: '${{ github.event.repository.default_branch }}', path: .trusted-policy, persist-credentials: false}
@@ -447,7 +447,7 @@ jobs:
     needs: [classify, generate-patch, validate-patch, seal-patch, trusted-publish]
     if: always() && needs.classify.outputs.eligible == 'true' && needs.trusted-publish.result != 'success'
     runs-on: ubuntu-latest
-    permissions: {contents: read, issues: write, pull-requests: read}
+    permissions: {contents: read, issues: write, pull-requests: write}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: {ref: '${{ github.event.repository.default_branch }}', path: .trusted-policy, persist-credentials: false}


### PR DESCRIPTION
### Motivation

- Fix the v2 fixer failure where trusted metadata-writing jobs could not create comments/labels on PRs due to `pull-requests: read` while using `github.rest.issues.*` endpoints. 
- Preserve existing trust boundaries: do not broaden workflow-level permissions, do not add `contents: write` to classifier/record/escalation/finalizer jobs, and keep generation/validation/seal trust separations intact. 

### Description

- Updated `.github/workflows/agent-ci-fixer.yml` to grant `pull-requests: write` at job scope only for the trusted fixer jobs that mutate PR metadata: `record-classification`, `escalate`, `trusted-publish`, and `fail-closed-finalizer`, while keeping other jobs and the workflow default permissions unchanged. 
- Kept `contents: write` limited to the isolated `trusted-publish` publication step and did not add `contents: write` to classifier/record/escalation/finalizer jobs. 
- Added a deterministic regression/wiring test to `.github/scripts/agent-pipeline.test.cjs` titled "Issue #94 grants PR metadata writes only to trusted fixer writers" and adjusted the existing assertion that counts `pull-requests: write` occurrences. 
- This change is prepared as a draft remediation PR targeting `main`; the branch is intentionally not merged and lifecycle/labels are not modified by this change.

- Agent-Issue: #94

### Testing

- Ran `node --test .github/scripts/agent-pipeline.test.cjs` and all tests passed (57/57). 
- Parsed all workflow YAML files using Ruby/Psych successfully with `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].sort.each { |f| YAML.parse_file(f); puts f }'`. 
- Validated `.github/agent-pipeline.json` using `python -m json.tool .github/agent-pipeline.json >/dev/null` successfully. 
- Ran `git diff --check` and repository checks passed with no whitespace or diff errors. 
- Environment notes: an attempt to call the local MCP `make_pr` helper failed due to the runtime `mcp.server.fastmcp` import being unavailable, and a Python `yaml` import attempt failed in this environment; these are environment limitations and did not affect the automated test suite run described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a993f164f1883328b027650e72779dd)