### PR TITLE
Fix Issue #100 bootstrap generation checkout

### DIFF
--- a/.github/workflows/bootstrap-issue-100-publisher.yml
+++ b/.github/workflows/bootstrap-issue-100-publisher.yml
@@ -127,6 +127,13 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: test -n "$OPENAI_API_KEY"
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.base_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+      - name: Verify exact generation checkout
+        run: test "$(git rev-parse HEAD)" = "${{ needs.prepare.outputs.base_sha }}"
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: bootstrap-issue-100-context-${{ github.run_id }}


### PR DESCRIPTION
Narrow remediation for the merged Issue #100 bootstrap publisher. The first live bootstrap run failed closed because the Codex generation job had only the downloaded `.codex-input` artifact and no exact-base repository checkout, so Codex could not produce an applicable unified diff.

This PR adds a read-only, credential-free checkout of the exact `prepare`-captured base SHA to the `generate` job and verifies the checkout before the Codex invocation.

No application/runtime, dependency, migration, deployment, broker/execution/risk/trading, branch-protection, or live-trading changes. The generate job remains `contents: read`, uses `persist-credentials: false`, retains read-only Codex permissions, and still has no GitHub write credential.