### PR TITLE
Fix Builder publisher isolated Git authentication path (Issue #110)

### DIFF
--- a/.github/scripts/agent-autonomy.test.cjs
+++ b/.github/scripts/agent-autonomy.test.cjs
@@ -2,6 +2,7 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const a = require("./agent-autonomy.cjs");
 
 const repo = "Bbambaaamm/Autonomous-Quant-Lab";
@@ -128,3 +129,33 @@ test("newest CI failure defeats older success",()=>{const p=require("./agent-pip
 test("npm registry 503 is infra transient",()=>{const p=require("./agent-pipeline.cjs"),sha="e".repeat(40),r=p.classifyCiFailure({jobs:[{id:7,name:"security",conclusion:"failure",steps:[{name:"npm audit",conclusion:"failure"}]}],runHeadSha:sha,expectedHeadSha:sha,sourceRunId:77,runAttempt:1,logExcerpt:"503 Service Unavailable",config:{requiredCiJobs:["security"],failureClassPolicy:{eligible:[],denied:["infra-transient","security"]},protectedDiagnosticPatterns:[]}});assert.equal(r.failureClass,"infra-transient");});
 
 test("ordinary security failure log boilerplate is not transient",()=>{const p=require("./agent-pipeline.cjs"),sha="f".repeat(40),r=p.classifyCiFailure({jobs:[{id:8,name:"security",conclusion:"failure",steps:[{name:"npm audit",conclusion:"failure"}]}],runHeadSha:sha,expectedHeadSha:sha,sourceRunId:78,runAttempt:1,logExcerpt:"Current runner version 2.337.0\nDownloading action\nnpm audit found a critical vulnerability",config:{requiredCiJobs:["security"],failureClassPolicy:{eligible:[],denied:["infra-transient","security"]},protectedDiagnosticPatterns:[]}});assert.equal(r.failureClass,"security");});
+
+test("Issue #110 Builder publisher uses isolated one-command Git auth and exact sealed SHA checks", () => {
+  const publish = fs.readFileSync(".github/workflows/agent-builder-publish.yml", "utf8");
+  const builder = fs.readFileSync(".github/workflows/agent-builder.yml", "utf8");
+
+  assert.doesNotMatch(publish, /gh auth setup-git/);
+  assert.match(publish, /AUTH_HEADER="AUTHORIZATION: basic \$\(printf x-access-token:%s "\$GH_TOKEN" \| base64 -w0\)"/);
+  assert.match(publish, /remote="\$\(git -c http\.extraheader="\$AUTH_HEADER" ls-remote --refs origin "refs\/heads\/\$branch" \| awk '\{print \$1\}'\)"/);
+
+  const absence = publish.indexOf('test -z "$remote"');
+  const push = publish.indexOf('git -c http.extraheader="$AUTH_HEADER" push origin "HEAD:refs/heads/$branch"');
+  const postCheck = publish.indexOf('sha="$(git -c http.extraheader="$AUTH_HEADER" ls-remote --refs origin "refs/heads/$branch"');
+  const exactSha = publish.indexOf('test "$sha" = "$sealed"', postCheck);
+  assert.ok(absence >= 0 && absence < push && push < postCheck && postCheck < exactSha);
+  assert.doesNotMatch(publish, /git[^\n]*push[^\n]*(?:--force-with-lease|--force|\s-f(?:\s|$))/);
+
+  const owned = publish.slice(publish.indexOf("owned(){"), publish.indexOf("prs(){"));
+  assert.match(owned, /test "\$sha" = "\$sealed"/);
+  assert.match(owned, /test "\$p" = "\$BASE"/);
+  assert.match(owned, /test "\$t" = "\$expected_tree"/);
+  assert.match(owned, /Agent-Builder-Seal: v1 issue=\$ISSUE spec=\$SPEC base=\$BASE tree=\$expected_tree/);
+
+  const section = (name, next) => builder.slice(builder.indexOf(`  ${name}:`), next ? builder.indexOf(`  ${next}:`) : builder.length);
+  for (const [name, next] of [["generate", "block"], ["validate", "seal"], ["seal", "publish"]]) {
+    const job = section(name, next);
+    assert.match(job, /permissions: \{contents: read\}/, name);
+    assert.doesNotMatch(job, /AGENT_PUBLISH_TOKEN|GH_TOKEN|contents: write|issues: write|pull-requests: write/, name);
+  }
+  assert.match(section("publish", "fail-closed-finalizer"), /secrets: \{AGENT_PUBLISH_TOKEN:/);
+});

--- a/.github/workflows/agent-builder-publish.yml
+++ b/.github/workflows/agent-builder-publish.yml
@@ -44,6 +44,8 @@ jobs:
           owner="${GH_REPO%%/*}"
           branch="agent/issue-${ISSUE}-${SPEC:0:12}"
           sealed="$(git rev-parse HEAD)"; expected_tree="$(jq -r .tree_sha "$RUNNER_TEMP/s/validated.json")"; test "$(jq -r .base_sha "$RUNNER_TEMP/s/validated.json")" = "$BASE"; test "$(jq -r .spec_hash "$RUNNER_TEMP/s/validated.json")" = "$SPEC"
+          git remote set-url origin "https://github.com/${GH_REPO}.git"
+          AUTH_HEADER="AUTHORIZATION: basic $(printf x-access-token:%s "$GH_TOKEN" | base64 -w0)"
           owned(){
           local sha="$1" m p t
           test "$sha" = "$sealed" || return 1
@@ -62,15 +64,15 @@ jobs:
             sha="$(jq -r '.[0].head.sha'<<<"$q")"
             owned "$sha"
           else
-            remote="$(gh api "repos/$GH_REPO/git/ref/heads/$branch" --jq .object.sha 2>/dev/null||true)"
+            remote="$(git -c http.extraheader="$AUTH_HEADER" ls-remote --refs origin "refs/heads/$branch" | awk '{print $1}')"
             if test -n "$remote"; then
               owned "$remote"
               sha="$remote"
             else
-              git remote set-url origin "https://github.com/${GH_REPO}.git"
-              gh auth setup-git
-              git push origin "HEAD:refs/heads/$branch"
-              sha="$sealed"
+              test -z "$remote"
+              git -c http.extraheader="$AUTH_HEADER" push origin "HEAD:refs/heads/$branch"
+              sha="$(git -c http.extraheader="$AUTH_HEADER" ls-remote --refs origin "refs/heads/$branch" | awk '{print $1}')"
+              test "$sha" = "$sealed"
             fi
             parent="$(gh api "repos/$GH_REPO/commits/$sha" --jq '.parents[0].sha')"
             tree="$(gh api "repos/$GH_REPO/git/commits/$sha" --jq '.tree.sha')"


### PR DESCRIPTION
Fixes #110

## Summary

Repair the autonomous Builder publication path discovered by zero-click dogfood Issue #109 without broadening any trust boundary.

- replace persistent `gh auth setup-git` with a one-command `http.extraheader` derived from `AGENT_PUBLISH_TOKEN` / `GH_TOKEN`;
- prove the deterministic Builder branch is absent before first push;
- push only the exact sealed commit to the deterministic branch;
- re-read the remote ref after push and require it to equal the exact sealed SHA;
- preserve existing-branch adoption checks for exact sealed SHA, parent, tree and seal trailer;
- preserve no-force-push behavior and the generate → validate → seal → trusted publish separation;
- add focused regression coverage proving the publisher auth and write boundary.

## Scope

Changed only:
- `.github/workflows/agent-builder-publish.yml`
- `.github/scripts/agent-autonomy.test.cjs`

No production/trading code, dependency files, migrations, deploy/infra configuration, or live-trading capability changed.

## Validation expected

- `node --test .github/scripts/agent-pipeline.test.cjs .github/scripts/agent-autonomy.test.cjs`
- GitHub Actions YAML parse
- `python -m json.tool .github/agent-pipeline.json >/dev/null`
- `git diff --check`
- all 9 authoritative CI jobs green on the exact PR head

After merge, re-authorize Issue #109 for the final live zero-click dogfood acceptance.

- Agent-Issue: #110