### PR TITLE
Fix verifier metadata authentication provenance (Issue #112)

### DIFF
--- a/.github/scripts/agent-autonomy.test.cjs
+++ b/.github/scripts/agent-autonomy.test.cjs
@@ -128,3 +128,21 @@ test("newest CI failure defeats older success",()=>{const p=require("./agent-pip
 test("npm registry 503 is infra transient",()=>{const p=require("./agent-pipeline.cjs"),sha="e".repeat(40),r=p.classifyCiFailure({jobs:[{id:7,name:"security",conclusion:"failure",steps:[{name:"npm audit",conclusion:"failure"}]}],runHeadSha:sha,expectedHeadSha:sha,sourceRunId:77,runAttempt:1,logExcerpt:"503 Service Unavailable",config:{requiredCiJobs:["security"],failureClassPolicy:{eligible:[],denied:["infra-transient","security"]},protectedDiagnosticPatterns:[]}});assert.equal(r.failureClass,"infra-transient");});
 
 test("ordinary security failure log boilerplate is not transient",()=>{const p=require("./agent-pipeline.cjs"),sha="f".repeat(40),r=p.classifyCiFailure({jobs:[{id:8,name:"security",conclusion:"failure",steps:[{name:"npm audit",conclusion:"failure"}]}],runHeadSha:sha,expectedHeadSha:sha,sourceRunId:78,runAttempt:1,logExcerpt:"Current runner version 2.337.0\nDownloading action\nnpm audit found a critical vulnerability",config:{requiredCiJobs:["security"],failureClassPolicy:{eligible:[],denied:["infra-transient","security"]},protectedDiagnosticPatterns:[]}});assert.equal(r.failureClass,"security");});
+
+test("Issue #112 verifier metadata uses job GITHUB_TOKEN and preserves publish-token boundary", () => {
+  const fs = require("node:fs");
+  const workflow = fs.readFileSync(".github/workflows/agent-verify.yml", "utf8");
+  const verifyJob = workflow.slice(workflow.indexOf("  verify:"), workflow.indexOf("\n  gate:"));
+  const gateJob = workflow.slice(workflow.indexOf("\n  gate:"));
+
+  assert.match(verifyJob, /permissions:\n\s+actions: read\n\s+contents: read\n\s+issues: write\n\s+pull-requests: write/);
+  assert.doesNotMatch(verifyJob, /github-token:\s*\$\{\{\s*secrets\.AGENT_PUBLISH_TOKEN\s*\}\}/);
+  assert.doesNotMatch(verifyJob, /AGENT_PUBLISH_TOKEN/);
+  assert.match(gateJob, /secrets:\n\s+AGENT_PUBLISH_TOKEN:/);
+
+  const headSha = "a".repeat(40);
+  const marker = a.verificationMarker({ repo, issueNumber: 112, prNumber: 113, headSha, specHash: spec, ciRunId: 1234 });
+  const args = { repo, issueNumber: 112, prNumber: 113, headSha, specHash: spec };
+  assert.equal(a.exactVerificationEvidence([{ user: { login: "github-actions[bot]" }, body: marker }], args), true);
+  assert.equal(a.exactVerificationEvidence([{ user: { login: "Bbambaaamm" }, body: marker }], args), false);
+});

--- a/.github/workflows/agent-verify.yml
+++ b/.github/workflows/agent-verify.yml
@@ -34,7 +34,6 @@ jobs:
         name: Verify authorization, current-main, exact CI and independent review
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
-          github-token: ${{ secrets.AGENT_PUBLISH_TOKEN }}
           script: |
             const p=require('./.github/scripts/agent-pipeline.cjs'),a=require('./.github/scripts/agent-autonomy.cjs'),c=require('./.github/agent-pipeline.json');
             const trigger=p.verificationTriggerDecision({workflowRun:context.payload.workflow_run,workflowCallInputs:{prNumber:'${{ inputs.pr_number || '' }}',headSha:'${{ inputs.head_sha || '' }}'}});


### PR DESCRIPTION
Fixes #112

## Summary

Repair verifier metadata authentication so trusted verification evidence is authored by `github-actions[bot]` through the job-scoped `GITHUB_TOKEN` instead of by the human-owned `AGENT_PUBLISH_TOKEN`.

- remove the verifier step's explicit `github-token: ${{ secrets.AGENT_PUBLISH_TOKEN }}` override;
- retain verifier job permissions `issues: write` and `pull-requests: write`;
- preserve `AGENT_PUBLISH_TOKEN` only for the downstream trusted gate/merge domain;
- preserve the strict `github-actions[bot]` provenance requirement for exact verification evidence;
- add focused regression coverage for the token/provenance boundary.

Changed only:
- `.github/workflows/agent-verify.yml`
- `.github/scripts/agent-autonomy.test.cjs`

No ruleset weakening, bypass actors, production/trading code, dependencies, migrations, deploy/infra, or live-trading capability changed.

- Agent-Issue: #112